### PR TITLE
Signer identities in options

### DIFF
--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -106,6 +106,10 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&o.PolicyOutput, "policy-out", false, "render the eval results per policy, more detailed than the set view",
 	)
+
+	cmd.PersistentFlags().StringSliceVar(
+		&o.IdentityStrings, "signer", []string{}, "list of signer identities to verify attestations",
+	)
 }
 
 func parseHash(estring string) (algo, value string, err error) {

--- a/pkg/api/v1/policy.go
+++ b/pkg/api/v1/policy.go
@@ -12,6 +12,11 @@ import (
 	intoto "github.com/in-toto/attestation/go/v1"
 )
 
+const (
+	SigstoreModeExact  string = "exact"
+	SigstoreModeRegexp string = "regexp"
+)
+
 func (meta *Meta) testsControl(ctrl *Control) bool {
 	if meta.GetControls() == nil {
 		return false
@@ -59,9 +64,9 @@ func NewIdentityFromSlug(slug string) (*Identity, error) {
 		if !ok {
 			return nil, fmt.Errorf("unable to parse sigstore identity from identity string")
 		}
-		mode := "exact"
+		mode := SigstoreModeExact
 		if itype == "sigstore(regexp)" {
-			mode = "regexp"
+			mode = SigstoreModeRegexp
 		}
 		return &Identity{
 			Sigstore: &IdentitySigstore{
@@ -90,7 +95,7 @@ func (i *Identity) Slug() string {
 	switch {
 	case i.GetSigstore() != nil:
 		mode := ""
-		if i.GetSigstore().GetMode() == "regexp" {
+		if i.GetSigstore().GetMode() == SigstoreModeRegexp {
 			mode = "(regexp)"
 		}
 		return fmt.Sprintf("sigstore%s::%s::%s", mode, i.GetSigstore().GetIssuer(), i.GetSigstore().GetIdentity())

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -42,6 +42,10 @@ type VerificationOptions struct {
 	// GitCommitShaHack enables a hack to duplicate gitCommit subjects of read
 	// attestations as sha1 when reading attestations
 	GitCommitShaHack bool
+
+	// IdentityStrings feeds the signature identities to add to the policy
+	// definitions when verifying signatures.
+	IdentityStrings []string
 }
 
 var DefaultVerificationOptions = VerificationOptions{


### PR DESCRIPTION
This PR adds support for the verifier to read additional identities to verify the attestations from the options. The CLI now has a new `--signer` option to pass a list of identity slugs to the verifier to check the attestation signatures.