### PR TITLE
Message templates

### DIFF
--- a/internal/drivers/attester/driver.go
+++ b/internal/drivers/attester/driver.go
@@ -27,9 +27,9 @@ type Driver struct {
 }
 
 func (d *Driver) RenderResultSet(w io.Writer, rset *api.ResultSet) error {
-	return d.Ampel.AttestResultSet(w, rset)
+	return d.Ampel.AttestResults(w, rset)
 }
 
 func (d *Driver) RenderResult(w io.Writer, status *api.Result) error {
-	return d.Ampel.AttestResult(w, status)
+	return d.Ampel.AttestResults(w, status)
 }

--- a/pkg/api/v1/result.go
+++ b/pkg/api/v1/result.go
@@ -15,6 +15,10 @@ const (
 	StatusSOFTFAIL = "SOFTFAIL"
 )
 
+type Results interface {
+	GetStatus() string
+}
+
 // Assert reads the set's results and computes the finish date
 // and set eval status.
 func (rs *ResultSet) Assert() error {

--- a/pkg/policy/compiler.go
+++ b/pkg/policy/compiler.go
@@ -16,6 +16,14 @@ import (
 	api "github.com/carabiner-dev/ampel/pkg/api/v1"
 )
 
+// PolicyOrSet takes a policy or policyset and returns the one that is not nill
+func PolicyOrSet(set *api.PolicySet, pcy *api.Policy) any {
+	if set != nil {
+		return set
+	}
+	return pcy
+}
+
 type CompilerOptions struct {
 	// TODO: No remote data
 	// TODO: Fail merging on unknown remote tenet ids
@@ -107,12 +115,11 @@ func (compiler *Compiler) Compile(data []byte) (set *api.PolicySet, pcy *api.Pol
 		return nil, nil, err
 	}
 
+	// TODO(puerco): Here, the policy needs to be assembled. Not
+	// supported yet for single policies.
 	if set == nil && pcy != nil {
-		set = &api.PolicySet{
-			Policies: []*api.Policy{
-				pcy,
-			},
-		}
+		fmt.Println("Es Policy")
+		return nil, pcy, nil
 	}
 
 	set, err = compiler.CompileSet(set)

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -294,8 +294,14 @@ func (di *defaultIplementation) CheckIdentities(opts *VerificationOptions, polic
 	allIds := []*api.Identity{}
 	allIds = append(allIds, policyIdentities...)
 
+	if len(policyIdentities) > 0 && len(opts.IdentityStrings) > 0 {
+		logrus.Warnf(
+			"Policy has signer identities defined, %d identities from options will be ignored",
+			len(opts.IdentityStrings))
+	}
+
 	// Add any identities defined in options
-	if len(opts.IdentityStrings) > 0 {
+	if len(opts.IdentityStrings) > 0 && len(policyIdentities) == 0 {
 		logrus.Debugf("Got %d identity strings from options", len(opts.IdentityStrings))
 		for _, idSlug := range opts.IdentityStrings {
 			ident, err := api.NewIdentityFromSlug(idSlug)

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -4,6 +4,7 @@
 package verifier
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"text/template"
 
 	gointoto "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
@@ -46,7 +48,7 @@ type AmpelVerifier interface {
 
 	FilterAttestations(*VerificationOptions, attestation.Subject, []attestation.Envelope) ([]attestation.Predicate, error)
 	AssertResult(*api.Policy, *api.Result) error
-	AttestResult(context.Context, *VerificationOptions, *api.Result) error
+	AttestResults(context.Context, *VerificationOptions, api.Results) error
 
 	// AttestResultToWriter takes an evaluation result and writes an attestation to the supplied io.Writer
 	AttestResultToWriter(io.Writer, *api.Result) error
@@ -669,14 +671,56 @@ func (di *defaultIplementation) VerifySubject(
 		}
 		logrus.WithField("tenet", i).Debugf("Result: %+v", evalres)
 
-		// Carry over the error from the policy if the evaluator didn't add one
-		if evalres.Status != api.StatusPASS && evalres.Error == nil {
-			evalres.Error = tenet.Error
+		// Ideally, we should not reach here with unparseabke templates but oh well..
+
+		// This is the data that gets exposed to error and assessment templates
+		templateData := struct {
+			Context map[string]any
+			Outputs map[string]any
+		}{
+			Context: evalContextValues,
+			Outputs: evalres.GetOutput().AsMap(),
 		}
 
-		// Carry over the assessment from the policy of not set by the engine
+		// Carry over the error from the policy if the runtime didn't add one
+		if evalres.Status != api.StatusPASS && evalres.Error == nil {
+			var b, b2 bytes.Buffer
+
+			tmplMsg, err := template.New("error_message").Parse(tenet.Error.GetMessage())
+			if err != nil {
+				return nil, fmt.Errorf("parsing tenet error template: %w", err)
+			}
+			if err := tmplMsg.Execute(&b, templateData); err != nil {
+				return nil, fmt.Errorf("executing error message template: %w", err)
+			}
+
+			tmpl, err := template.New("error_guidance").Parse(tenet.Error.GetGuidance())
+			if err != nil {
+				return nil, fmt.Errorf("parsing tenet guidance template: %w", err)
+			}
+			if err := tmpl.Execute(&b2, templateData); err != nil {
+				return nil, fmt.Errorf("executing error guidance template: %w", err)
+			}
+
+			evalres.Error = &api.Error{
+				Message:  b.String(),
+				Guidance: b2.String(),
+			}
+		}
+
+		// Carry over the assessment from the policy if not set by the runtime
 		if evalres.Status == api.StatusPASS && evalres.Assessment == nil {
-			evalres.Assessment = tenet.Assessment
+			tmpl, err := template.New("assessment").Parse(tenet.Assessment.GetMessage())
+			if err != nil {
+				return nil, fmt.Errorf("parsing tenet assessment: %w", err)
+			}
+			var b bytes.Buffer
+			if err := tmpl.Execute(&b, templateData); err != nil {
+				return nil, fmt.Errorf("executing assessment template: %w", err)
+			}
+			evalres.Assessment = &api.Assessment{
+				Message: b.String(),
+			}
 		}
 
 		rs.EvalResults = append(rs.EvalResults, evalres)
@@ -690,8 +734,8 @@ func (di *defaultIplementation) VerifySubject(
 
 // AttestResults writes an attestation captring the evaluation
 // results set.
-func (di *defaultIplementation) AttestResult(
-	ctx context.Context, opts *VerificationOptions, result *api.Result,
+func (di *defaultIplementation) AttestResults(
+	ctx context.Context, opts *VerificationOptions, results api.Results,
 ) error {
 	if !opts.AttestResults {
 		return nil
@@ -705,12 +749,19 @@ func (di *defaultIplementation) AttestResult(
 		return fmt.Errorf("opening results attestation file: %w", err)
 	}
 
-	// Write the statement to json
-	return di.AttestResultToWriter(f, result)
+	switch r := results.(type) {
+	case *api.Result:
+		// Write the statement to json
+		return di.AttestResultToWriter(f, r)
+	case *api.ResultSet:
+		return di.AttestResultSetToWriter(f, r)
+	default:
+		return fmt.Errorf("unable to cast result")
+	}
 }
 
-// AttestResults writes an attestation captring the evaluation
-// results set.
+// AttestResultToWriter writes an attestation capturing a evaluation
+// result set.
 func (di *defaultIplementation) AttestResultToWriter(
 	w io.Writer, result *api.Result,
 ) error {


### PR DESCRIPTION
This PR adds support  for templates in message errors and assessment messages

It also adds a more general interface to handle Results and ResultsSets in a single value.

Fixes https://github.com/carabiner-dev/ampel/issues/62

 Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>