### PR TITLE
Policy verification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.1.1
 	github.com/carabiner-dev/hasher v0.2.2
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.1.2
+	github.com/carabiner-dev/policy v0.2.0
 	github.com/fatih/color v1.18.0
 	github.com/google/cel-go v0.26.1
 	github.com/in-toto/attestation v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/carabiner-dev/openeox v0.0.0-20250606202227-fd40810cda47 h1:UTr5vQ7nS
 github.com/carabiner-dev/openeox v0.0.0-20250606202227-fd40810cda47/go.mod h1:40KVT1ee6L8VoWT44RvAQ0AtG91MFr5/zBzTmNiXQWY=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.1.2 h1:LJ2dePzim2HLNJ4KFncsP6FU1ewMWF+0vRxxEQstQ+Q=
-github.com/carabiner-dev/policy v0.1.2/go.mod h1:IMF/eTqD8nvXpWr3gmYTvckHZP7VM4Z+B6atFfH02lI=
+github.com/carabiner-dev/policy v0.2.0 h1:8grOlkoquleKjtFlOBISmn45PqRwDamMysG9GduqwFw=
+github.com/carabiner-dev/policy v0.2.0/go.mod h1:87aK4EjCvxcF/aJ+EwNyRINCsbtCXKtBG7c4dBuf3Y4=
 github.com/carabiner-dev/signer v0.2.1 h1:qNRzDFnG+uLWHPTIC36hrh572bs66hYhBOwkGLcsq1I=
 github.com/carabiner-dev/signer v0.2.1/go.mod h1:VvN+m//2sBUQuZUnVie0WpIy+D9+v8+eJDoMG8nugA8=
 github.com/carabiner-dev/vcslocator v0.3.2 h1:/rfhELG1mvqFq0xi8LQSkfpAVoQDCGlWoL6J5tX9Inw=


### PR DESCRIPTION
This PR implements policy signature verification. 

Ampel now leverages our policy framework's Verify methods introduced in v0.2.0. Policy verification is exposed through a couple of new switches to enforce verification and identity checks:

```
      --policy-key strings      path to public keys to verify policies
      --policy-signer strings   signer identities to verify signed policies
      --policy-verify           verify policy signatures (default true)
```

By default, ampel will verify a policy's signature. Policies wrapped in sigstore envelopes will be checked without any other required data. DSSE wrapped policies need to have their public keys defined to pass verification.

Fixes https://github.com/carabiner-dev/ampel/issues/102

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>