### PR TITLE
VerifySubjectWithPolicySet and set chains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.1.1
 	github.com/carabiner-dev/hasher v0.2.2
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.2.0
+	github.com/carabiner-dev/policy v0.2.1-0.20250919015927-5cc363d0a0bc
 	github.com/fatih/color v1.18.0
 	github.com/google/cel-go v0.26.1
 	github.com/in-toto/attestation v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/carabiner-dev/openeox v0.0.0-20250606202227-fd40810cda47 h1:UTr5vQ7nS
 github.com/carabiner-dev/openeox v0.0.0-20250606202227-fd40810cda47/go.mod h1:40KVT1ee6L8VoWT44RvAQ0AtG91MFr5/zBzTmNiXQWY=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.2.0 h1:8grOlkoquleKjtFlOBISmn45PqRwDamMysG9GduqwFw=
-github.com/carabiner-dev/policy v0.2.0/go.mod h1:87aK4EjCvxcF/aJ+EwNyRINCsbtCXKtBG7c4dBuf3Y4=
+github.com/carabiner-dev/policy v0.2.1-0.20250919015927-5cc363d0a0bc h1:dUJ3cgjxifBFGzua3+HwHoE9rFsDUoKydD8Ymm7Ah5U=
+github.com/carabiner-dev/policy v0.2.1-0.20250919015927-5cc363d0a0bc/go.mod h1:87aK4EjCvxcF/aJ+EwNyRINCsbtCXKtBG7c4dBuf3Y4=
 github.com/carabiner-dev/signer v0.2.1 h1:qNRzDFnG+uLWHPTIC36hrh572bs66hYhBOwkGLcsq1I=
 github.com/carabiner-dev/signer v0.2.1/go.mod h1:VvN+m//2sBUQuZUnVie0WpIy+D9+v8+eJDoMG8nugA8=
 github.com/carabiner-dev/vcslocator v0.3.2 h1:/rfhELG1mvqFq0xi8LQSkfpAVoQDCGlWoL6J5tX9Inw=

--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -146,7 +146,7 @@ func (e *Evaluator) RegisterPlugin(plugin api.Plugin) error {
 
 func (e *Evaluator) ExecChainedSelector(
 	ctx context.Context, opts *options.EvaluatorOptions, chained *papi.ChainedPredicate, predicate attestation.Predicate,
-) (attestation.Subject, error) {
+) ([]attestation.Subject, error) {
 	evalContext, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
 	if !ok {
 		evalContext = evalcontext.EvaluationContext{}
@@ -165,12 +165,12 @@ func (e *Evaluator) ExecChainedSelector(
 		return nil, fmt.Errorf("compiling selector program: %w", err)
 	}
 
-	subject, err := e.impl.EvaluateChainedSelector(e.Environment, ast, vars)
+	subjects, err := e.impl.EvaluateChainedSelector(e.Environment, ast, vars)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating chained subject: %w", err)
 	}
-	logrus.Debugf("chained subject from selector: %+v", subject)
-	return subject, nil
+	logrus.Debugf("chained subject from selector: %+v", subjects)
+	return subjects, nil
 }
 
 // Exec executes each tenet and returns the combined results

--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -38,7 +38,7 @@ type CelEvaluatorImplementation interface {
 	Evaluate(*cel.Env, *cel.Ast, *map[string]any) (*papi.EvalResult, error)
 	Assert(*papi.ResultSet) bool
 	BuildSelectorVariables(*options.EvaluatorOptions, map[string]Plugin, *papi.Policy, attestation.Subject, *papi.ChainedPredicate, attestation.Predicate) (*map[string]any, error)
-	EvaluateChainedSelector(*cel.Env, *cel.Ast, *map[string]any) (attestation.Subject, error)
+	EvaluateChainedSelector(*cel.Env, *cel.Ast, *map[string]any) ([]attestation.Subject, error)
 }
 
 type defaulCelEvaluator struct{}
@@ -336,30 +336,9 @@ func deRefList(refList []ref.Val) []any {
 	return r
 }
 
-// EvaluateChainedSelector
-func (dce *defaulCelEvaluator) EvaluateChainedSelector(
-	//nolint:gocritic // This is passing a potentially large data set
-	env *cel.Env, ast *cel.Ast, vars *map[string]any,
-) (attestation.Subject, error) {
-	if env == nil {
-		return nil, fmt.Errorf("CEL environment not set")
-	}
-	if vars == nil {
-		return nil, fmt.Errorf("variable set undefined")
-	}
-
-	program, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
-	if err != nil {
-		return nil, fmt.Errorf("generating program from AST: %w", err)
-	}
-
-	// First evaluate the tenet.
-	result, _, err := program.Eval(*vars)
-	if err != nil {
-		return nil, fmt.Errorf("evaluation error: %w", err)
-	}
-
-	switch v := result.Value().(type) {
+// decodeValue
+func decodeValue(val ref.Val) (attestation.Subject, error) {
+	switch v := val.Value().(type) {
 	case string:
 		algo, val, ok := strings.Cut(v, ":")
 		if !ok {
@@ -369,12 +348,10 @@ func (dce *defaulCelEvaluator) EvaluateChainedSelector(
 			return nil, fmt.Errorf("invalid hash algorithm returned from selector (%q)", v)
 		}
 		return &intoto.ResourceDescriptor{
-			Digest: map[string]string{
-				strings.ToLower(algo): val,
-			},
+			Digest: map[string]string{strings.ToLower(algo): val},
 		}, nil
 	case map[ref.Val]ref.Val, *structpb.Struct:
-		res, err := result.ConvertToNative(reflect.TypeOf(&intoto.ResourceDescriptor{}))
+		res, err := val.ConvertToNative(reflect.TypeOf(&intoto.ResourceDescriptor{}))
 		if err != nil {
 			return nil, fmt.Errorf("converting eval result to Subject: %w", err)
 		}
@@ -403,8 +380,52 @@ func (dce *defaulCelEvaluator) EvaluateChainedSelector(
 		}
 		return subj, nil
 	default:
-		return nil, fmt.Errorf("predicate selector must return string or resource descr (got %T)", result.Value())
+		return nil, fmt.Errorf("predicate selector must return string or resource descr (got %T)", val.Value())
 	}
+}
+
+// EvaluateChainedSelector runs the cahin selector and returns the list of subjects
+// extracted from the attestation data. This function returns a list of subjects,
+// depending on the context used it must only one, or a list.
+func (dce *defaulCelEvaluator) EvaluateChainedSelector(
+	//nolint:gocritic // This is passing a potentially large data set
+	env *cel.Env, ast *cel.Ast, vars *map[string]any,
+) ([]attestation.Subject, error) {
+	if env == nil {
+		return nil, fmt.Errorf("CEL environment not set")
+	}
+	if vars == nil {
+		return nil, fmt.Errorf("variable set undefined")
+	}
+
+	program, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+	if err != nil {
+		return nil, fmt.Errorf("generating program from AST: %w", err)
+	}
+
+	// First evaluate the tenet.
+	result, _, err := program.Eval(*vars)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation error: %w", err)
+	}
+	ret := []attestation.Subject{}
+	switch v := result.Value().(type) {
+	case []ref.Val:
+		for _, val := range v {
+			sub, err := decodeValue(val)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, sub)
+		}
+	default:
+		s, err := decodeValue(result)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, s)
+	}
+	return ret, nil
 }
 
 // Evaluate the precompiled ASTs

--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -353,7 +353,7 @@ func decodeValue(val ref.Val) (attestation.Subject, error) {
 	case map[ref.Val]ref.Val, *structpb.Struct:
 		res, err := val.ConvertToNative(reflect.TypeOf(&intoto.ResourceDescriptor{}))
 		if err != nil {
-			return nil, fmt.Errorf("converting eval result to Subject: %w", err)
+			return nil, fmt.Errorf("converting eval result to Subject %+v: %w", v, err)
 		}
 		subj, ok := res.(*intoto.ResourceDescriptor)
 		if !ok {

--- a/pkg/evaluator/cel/implementation_test.go
+++ b/pkg/evaluator/cel/implementation_test.go
@@ -17,21 +17,22 @@ import (
 func TestEvaluateChainedSelector(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name          string
-		code          string
-		predicatePath string
-		expected      *intoto.ResourceDescriptor
-		mustErr       bool
+		name           string
+		code           string
+		predicatePath  string
+		expectedLength int
+		expected       *intoto.ResourceDescriptor
+		mustErr        bool
 	}{
-		{"slsa", "predicate.data.materials[0]", "testdata/slsa-v0.2.json", &intoto.ResourceDescriptor{
+		{"slsa", "predicate.data.materials[0]", "testdata/slsa-v0.2.json", 1, &intoto.ResourceDescriptor{
 			Uri:    "git+https://github.com/slsa-framework/slsa-verifier@refs/tags/v2.6.0",
 			Digest: map[string]string{"sha1": "3714a2a4684014deb874a0e737dffa0ee02dd647", "gitCommit": "3714a2a4684014deb874a0e737dffa0ee02dd647"},
 		}, false},
-		{"string", "\"sha1:\"+predicate.data.materials[0].digest[\"sha1\"]", "testdata/slsa-v0.2.json", &intoto.ResourceDescriptor{
+		{"string", "\"sha1:\"+predicate.data.materials[0].digest[\"sha1\"]", "testdata/slsa-v0.2.json", 1, &intoto.ResourceDescriptor{
 			Digest: map[string]string{"sha1": "3714a2a4684014deb874a0e737dffa0ee02dd647"},
 		}, false},
-		{"bad-string", "\"bad string\"", "testdata/slsa-v0.2.json", nil, true},
-		{"bad-structure", "[1,2,3]", "testdata/slsa-v0.2.json", nil, true},
+		{"bad-string", "\"bad string\"", "testdata/slsa-v0.2.json", 1, nil, true},
+		{"bad-structure", "[1,2,3]", "testdata/slsa-v0.2.json", 1, nil, true},
 	} {
 		ev := &defaulCelEvaluator{}
 
@@ -62,9 +63,10 @@ func TestEvaluateChainedSelector(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, res)
-			require.Equal(t, tc.expected.GetUri(), res.GetUri())
-			require.Equal(t, tc.expected.GetName(), res.GetName())
-			require.Equal(t, tc.expected.GetDigest(), res.GetDigest())
+			require.Len(t, res, tc.expectedLength)
+			require.Equal(t, tc.expected.GetUri(), res[0].GetUri())
+			require.Equal(t, tc.expected.GetName(), res[0].GetName())
+			require.Equal(t, tc.expected.GetDigest(), res[0].GetDigest())
 		})
 	}
 }

--- a/pkg/evaluator/evalcontext/context.go
+++ b/pkg/evaluator/evalcontext/context.go
@@ -26,5 +26,9 @@ type (
 		Context map[string]*papi.ContextVal
 		// Context values from evaluation invocation
 		ContextValues map[string]any
+		// ChainedSubjects is a precomputed chain that informs the
+		// policy evaluator how the subject was obtained, typically
+		// by the policy set.
+		ChainedSubjects []*papi.ChainedSubject
 	}
 )

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -32,5 +32,5 @@ func (f *Factory) Get(opts *options.EvaluatorOptions, c class.Class) (Evaluator,
 // Evaluator
 type Evaluator interface {
 	ExecTenet(context.Context, *options.EvaluatorOptions, *papi.Tenet, []attestation.Predicate) (*papi.EvalResult, error)
-	ExecChainedSelector(context.Context, *options.EvaluatorOptions, *papi.ChainedPredicate, attestation.Predicate) (attestation.Subject, error)
+	ExecChainedSelector(context.Context, *options.EvaluatorOptions, *papi.ChainedPredicate, attestation.Predicate) ([]attestation.Subject, error)
 }

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -620,6 +620,16 @@ func (di *defaultIplementation) ProcessChainedSubjects(
 		return nil, nil, false, fmt.Errorf("unable to complete evidence chain, no subject returned")
 	}
 
+	// If we got a precomputed chain (from the policy set) it precedes the
+	// policy computed at the policy level.
+	// Add the (eval) context, to the (go) context :P
+	evalContext, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
+	if ok {
+		if evalContext.ChainedSubjects != nil {
+			chain = slices.Concat(evalContext.ChainedSubjects, chain)
+		}
+	}
+
 	return subjects[0], chain, fail, nil
 }
 

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -71,8 +71,8 @@ type AmpelVerifier interface {
 	// the resulting list of subjects from the evaluator.
 	ProcessPolicySetChainedSubjects(context.Context, *VerificationOptions, map[class.Class]evaluator.Evaluator, *collector.Agent, *papi.PolicySet, map[string]any, attestation.Subject, []attestation.Envelope) ([]attestation.Subject, []*papi.ChainedSubject, bool, error)
 
-	// AssembleEvalContext builds the policy context by mixing defaults and defined values
-	AssembleEvalContext(context.Context, *VerificationOptions, map[string]*papi.ContextVal) (map[string]any, error)
+	// AssembleEvalContextValues builds the policy context values by mixing defaults and defined values
+	AssembleEvalContextValues(context.Context, *VerificationOptions, map[string]*papi.ContextVal) (map[string]any, error)
 }
 
 type defaultIplementation struct{}
@@ -631,8 +631,9 @@ func newResourceDescriptorFromSubject(s attestation.Subject) *gointoto.ResourceD
 	}
 }
 
-// AssembleEvalContext puts together the context.
-func (di *defaultIplementation) AssembleEvalContext(ctx context.Context, opts *VerificationOptions, contextValues map[string]*papi.ContextVal) (map[string]any, error) {
+// AssembleEvalContextValues puts together the context values by assembling the context
+// considering its defaults, received values from upstream and value providers.
+func (di *defaultIplementation) AssembleEvalContextValues(ctx context.Context, opts *VerificationOptions, contextValues map[string]*papi.ContextVal) (map[string]any, error) {
 	errs := []error{}
 
 	// Load the context definitions as received from invocation

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -461,7 +461,7 @@ func (di *defaultIplementation) evaluateChain(
 		}
 
 		// Only fetch more attestations from the configured sources if we need more:
-		if len(attestations) == 0 {
+		if len(attestations) == 0 && agent != nil {
 			moreatts, err := agent.FetchAttestationsBySubject(
 				ctx, []attestation.Subject{subject}, collector.WithQuery(q),
 			)
@@ -481,7 +481,7 @@ func (di *defaultIplementation) evaluateChain(
 		// Here, we warn if we get more than one attestation for the chained
 		// predicate. Probably this should be limited to only one.
 		if len(attestations) > 1 {
-			logrus.Warn("Chained subject builder got more than one statement")
+			logrus.Warn("Chained subject builder got more than one matching statement")
 		}
 
 		if err := attestations[0].Verify(opts.Keys); err != nil {

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -7,10 +7,195 @@ import (
 	"testing"
 	"time"
 
+	"github.com/carabiner-dev/attestation"
 	papi "github.com/carabiner-dev/policy/api/v1"
+	gointoto "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/carabiner-dev/ampel/pkg/evaluator"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
+	eoptions "github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
+
+func TestEvaluateChain(t *testing.T) {
+	t.Parallel()
+	di := &defaultIplementation{}
+	factory := evaluator.Factory{}
+
+	def, err := factory.Get(&eoptions.Default, DefaultVerificationOptions.DefaultEvaluator)
+	require.NoError(t, err)
+	evaluators := map[class.Class]evaluator.Evaluator{
+		"default": def,
+		DefaultVerificationOptions.DefaultEvaluator: def,
+	}
+
+	defaultSubject := &gointoto.ResourceDescriptor{
+		Name: "test",
+		Digest: map[string]string{
+			"sha256": "851074691728c479a4c83628de8310eaca792cc7",
+		},
+	}
+	for _, tt := range []struct {
+		name             string
+		mustErr          bool
+		expectedSubjects int
+		subject          attestation.Subject
+		attestationPaths []string
+		chainLinks       []*papi.ChainLink
+	}{
+		{
+			"self", false, 0, defaultSubject, []string{}, []*papi.ChainLink{},
+		},
+		{
+			// test final multi
+			"sbom", false, 170, defaultSubject,
+			[]string{"testdata/wtf-frontend.spdx.json"},
+			[]*papi.ChainLink{
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: `predicates[0].data.packages.filter(pkg, has(pkg.checksums) && size(pkg.checksums) > 0).map(pkg, { "name": has(pkg.name) ? pkg.name : "", "digest": pkg.checksums.map(checksum, { string(checksum.algorithm).lowerAscii(): dyn(checksum.checksumValue) })[0], 'uri': has(pkg.externalRefs) && size(pkg.externalRefs) > 0 ? dyn(pkg.externalRefs.filter(ref, ref.referenceType == 'purl')[0].referenceLocator) : dyn('')   })`,
+						},
+					},
+				},
+			},
+		},
+		// test intermediates not multi
+		// test final single
+		{
+			// test final multi
+			"multi", false, 2, defaultSubject,
+			[]string{"testdata/wtf-frontend.spdx.json"},
+			[]*papi.ChainLink{
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type: "https://spdx.dev/Document",
+							// Selector: "predicates[0].data.packages",
+							Selector: `["sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b", "sha256:0d413b00f20df75f452cdd3562edfa85983bde65917004be299902b734d24d8b"]`,
+						},
+					},
+				},
+			},
+		},
+		{
+			// test final multi
+			"no-matching-attestations", true, 0, defaultSubject,
+			[]string{"testdata/wtf-frontend.spdx.json"},
+			[]*papi.ChainLink{
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://cyclonedx.org/bom",
+							Selector: `"sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b"`,
+						},
+					},
+				},
+			},
+		},
+		{
+			"ensure-multi-intermediates-fail", true, 0, defaultSubject,
+			[]string{"testdata/wtf-frontend.spdx.json"},
+			[]*papi.ChainLink{
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: "'sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b'",
+						},
+					},
+				},
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: `["sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b", "sha256:0d413b00f20df75f452cdd3562edfa85983bde65917004be299902b734d24d8b"]`,
+						},
+					},
+				},
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: "'sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b'",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ensure-final-can-be-multi", false, 2, defaultSubject,
+			[]string{"testdata/wtf-frontend.spdx.json"},
+			[]*papi.ChainLink{
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: "'sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b'",
+						},
+					},
+				},
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: "'sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b'",
+						},
+					},
+				},
+				{
+					Source: &papi.ChainLink_Predicate{
+						Predicate: &papi.ChainedPredicate{
+							Type:     "https://spdx.dev/Document",
+							Selector: `["sha256:cdd80609c252ba5336de7033518cfe15f9e466a53c1de14545cc6ec22e56252b", "sha256:0d413b00f20df75f452cdd3562edfa85983bde65917004be299902b734d24d8b"]`,
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Load the attestations required by the test
+			attestations, err := di.ParseAttestations(t.Context(), tt.attestationPaths)
+			require.NoError(t, err)
+
+			// Check if there is an evaluator foe the link's runtime
+			for _, l := range tt.chainLinks {
+				if runtime := l.GetPredicate().GetRuntime(); runtime != "" {
+					if _, ok := evaluators[class.Class(runtime)]; ok {
+						continue
+					}
+					ev, err := factory.Get(&eoptions.Default, class.Class(runtime))
+					require.NoError(t, err)
+					evaluators[class.Class(runtime)] = ev
+				}
+			}
+
+			// should we test policyFail?
+			subjects, chain, _, err := di.evaluateChain(
+				t.Context(), &DefaultVerificationOptions, evaluators,
+				nil, // the vollector agent should not be required
+				tt.chainLinks,
+				nil, // no context values in tests
+				tt.subject, attestations, []*papi.Identity{}, "",
+			)
+			if tt.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			t.Logf("Got subjects:\n%+v", subjects)
+			t.Logf("Got chain:\n%+v", chain)
+
+			require.Len(t, subjects, tt.expectedSubjects)
+		})
+	}
+}
 
 func TestCheckPolicy(t *testing.T) {
 	t.Parallel()

--- a/pkg/verifier/testdata/wtf-frontend.spdx.json
+++ b/pkg/verifier/testdata/wtf-frontend.spdx.json
@@ -1,0 +1,5413 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "wtf-frontend@0.0.0",
+  "documentNamespace": "http://spdx.org/spdxdocs/wtf-frontend-0.0.0-***",
+  "creationInfo": {
+    "created": "2025-09-13T18:34:00.795Z",
+    "creators": [
+      "Tool: npm/cli-11.6.0"
+    ]
+  },
+  "documentDescribes": [
+    "SPDXRef-Package-wtf-frontend-0.0.0"
+  ],
+  "packages": [
+    {
+      "name": "wtf-frontend",
+      "SPDXID": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "versionInfo": "0.0.0",
+      "packageFileName": "",
+      "primaryPackagePurpose": "LIBRARY",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "homepage": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/wtf-frontend@0.0.0"
+        }
+      ]
+    },
+    {
+      "name": "@alloc/quick-lru",
+      "SPDXID": "SPDXRef-Package-alloc.quick-lru-5.2.0",
+      "versionInfo": "5.2.0",
+      "packageFileName": "node_modules/@alloc/quick-lru",
+      "description": "Simple “Least Recently Used” (LRU) cache",
+      "downloadLocation": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/quick-lru#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40alloc/quick-lru@5.2.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f"
+        }
+      ]
+    },
+    {
+      "name": "@babel/parser",
+      "SPDXID": "SPDXRef-Package-babel.parser-7.24.5",
+      "versionInfo": "7.24.5",
+      "packageFileName": "node_modules/@babel/parser",
+      "description": "A JavaScript parser",
+      "downloadLocation": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://babel.dev/docs/en/next/babel-parser",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/parser@7.24.5"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "10ebf920af1aaf08772c8e3b773d5bd2d2946ffd6e8470271c93ab8e0b50308a6ed6e5ddf66945ac983d214806520678d428742bc4443d36293bb07be9be2f26"
+        }
+      ]
+    },
+    {
+      "name": "@babel/runtime",
+      "SPDXID": "SPDXRef-Package-babel.runtime-7.26.10",
+      "versionInfo": "7.26.10",
+      "packageFileName": "node_modules/@babel/runtime",
+      "description": "babel's modular runtime helpers",
+      "downloadLocation": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://babel.dev/docs/en/next/babel-runtime",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/runtime@7.26.10"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d9624c79140f1ca48f7a6aa4fdac06ac08ae15fcc198e20f5ca8b302c561587f5826a2d9d07f874b873c9681c6816eaeb49dc4fde8d7414b2219a432d8d67d17"
+        }
+      ]
+    },
+    {
+      "name": "@esbuild/darwin-arm64",
+      "SPDXID": "SPDXRef-Package-esbuild.darwin-arm64-0.25.0",
+      "versionInfo": "0.25.0",
+      "packageFileName": "node_modules/@esbuild/darwin-arm64",
+      "description": "The macOS ARM 64-bit binary for esbuild, a JavaScript bundler.",
+      "downloadLocation": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/evanw/esbuild#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40esbuild/darwin-arm64@0.25.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "995c1d51be524643dac9569d20e23bf0aeda0273da9a87854766d3e67b3315467d3fc5292b8adab4e7586d9657612a8f28c1df4b5c1d1c2264d4fd4466945dbf"
+        }
+      ]
+    },
+    {
+      "name": "@flavorly/vanilla-components",
+      "SPDXID": "SPDXRef-Package-flavorly.vanilla-components-0.7.65",
+      "versionInfo": "0.7.65",
+      "packageFileName": "node_modules/@flavorly/vanilla-components",
+      "description": "🤌 A lightweight Vue 3 Component Library based on VariantJS & Headless UI",
+      "downloadLocation": "https://registry.npmjs.org/@flavorly/vanilla-components/-/vanilla-components-0.7.65.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/flavorly/vanilla-components#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40flavorly/vanilla-components@0.7.65"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "aa05e2a3b891f375a847e3c3ea1b5bfbb3d1786f4027cc809e09ad8c0c8a61e3092a8ec3bf19b85a08ba36bc2c92ab72b92e39310beb7c4af8fae0092e3c0f6c"
+        }
+      ]
+    },
+    {
+      "name": "@headlessui/vue",
+      "SPDXID": "SPDXRef-Package-headlessui.vue-1.7.22",
+      "versionInfo": "1.7.22",
+      "packageFileName": "node_modules/@headlessui/vue",
+      "description": "A set of completely unstyled, fully accessible UI components for Vue 3, designed to integrate beautifully with Tailwind CSS.",
+      "downloadLocation": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.22.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tailwindlabs/headlessui#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40headlessui/vue@1.7.22"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "1e87df8e8a25ab5ad8f8b39f27e07f3af921b815d704581df2806537e9754c0a666b6741d049f4b9c159af042d6f7dd299c0aa777d8441dd32d3ba3389758d62"
+        }
+      ]
+    },
+    {
+      "name": "@isaacs/cliui",
+      "SPDXID": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "versionInfo": "8.0.2",
+      "packageFileName": "node_modules/@isaacs/cliui",
+      "description": "easily create complex multi-column command-line-interfaces",
+      "downloadLocation": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/yargs/cliui#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40isaacs/cliui@8.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10"
+        }
+      ]
+    },
+    {
+      "name": "@jridgewell/gen-mapping",
+      "SPDXID": "SPDXRef-Package-jridgewell.gen-mapping-0.3.5",
+      "versionInfo": "0.3.5",
+      "packageFileName": "node_modules/@jridgewell/gen-mapping",
+      "description": "Generate source maps",
+      "downloadLocation": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jridgewell/gen-mapping#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40jridgewell/gen-mapping@0.3.5"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "2332fc66810320145613394271184e682ba963237981d20af90e9f6c574f0e0e87a97ea3a6422d9fb0c52295bd2d0cd71ba0dff6c03bf8e2a7ab4aa5cff19a42"
+        }
+      ]
+    },
+    {
+      "name": "@jridgewell/resolve-uri",
+      "SPDXID": "SPDXRef-Package-jridgewell.resolve-uri-3.1.2",
+      "versionInfo": "3.1.2",
+      "packageFileName": "node_modules/@jridgewell/resolve-uri",
+      "description": "Resolve a URI relative to an optional base URI",
+      "downloadLocation": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jridgewell/resolve-uri#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40jridgewell/resolve-uri@3.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b"
+        }
+      ]
+    },
+    {
+      "name": "@jridgewell/set-array",
+      "SPDXID": "SPDXRef-Package-jridgewell.set-array-1.2.1",
+      "versionInfo": "1.2.1",
+      "packageFileName": "node_modules/@jridgewell/set-array",
+      "description": "Like a Set, but provides the index of the `key` in the backing array",
+      "downloadLocation": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jridgewell/set-array#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40jridgewell/set-array@1.2.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "47c80b45365eca9d37ca6ccfffa2e297fdbcb46786133871d6ada4ef4dca19644023555dbcf217746ef4549736a40330dcd03a24a2f986116ed6c257d0c9e7fc"
+        }
+      ]
+    },
+    {
+      "name": "@jridgewell/sourcemap-codec",
+      "SPDXID": "SPDXRef-Package-jridgewell.sourcemap-codec-1.4.15",
+      "versionInfo": "1.4.15",
+      "packageFileName": "node_modules/@jridgewell/sourcemap-codec",
+      "description": "Encode/decode sourcemap mappings",
+      "downloadLocation": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jridgewell/sourcemap-codec#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40jridgewell/sourcemap-codec@1.4.15"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "785dabc4246e9442971d34620eb0f2e9eacc616a8dc382cf750f14400e21baec5a42c55e44f165da833ca031b130584951665ff4c7292ed25ab030d96ff0697a"
+        }
+      ]
+    },
+    {
+      "name": "@jridgewell/trace-mapping",
+      "SPDXID": "SPDXRef-Package-jridgewell.trace-mapping-0.3.25",
+      "versionInfo": "0.3.25",
+      "packageFileName": "node_modules/@jridgewell/trace-mapping",
+      "description": "Trace the original position through a source map",
+      "downloadLocation": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jridgewell/trace-mapping#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40jridgewell/trace-mapping@0.3.25"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "bcd93a684c326c6b5ac169b2fcfcf09c60ce8c290b5920f6c2abe3186020380c02196c926177d8a31b74d082644c5fbc2dbe7b0f039bdc06b4a3d080a5ea6261"
+        }
+      ]
+    },
+    {
+      "name": "@nodelib/fs.scandir",
+      "SPDXID": "SPDXRef-Package-nodelib.fs.scandir-2.1.5",
+      "versionInfo": "2.1.5",
+      "packageFileName": "node_modules/@nodelib/fs.scandir",
+      "description": "List files and directories inside the specified directory",
+      "downloadLocation": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/nodelib/nodelib/tree/master#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40nodelib/fs.scandir@2.1.5"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada"
+        }
+      ]
+    },
+    {
+      "name": "@nodelib/fs.stat",
+      "SPDXID": "SPDXRef-Package-nodelib.fs.stat-2.0.5",
+      "versionInfo": "2.0.5",
+      "packageFileName": "node_modules/@nodelib/fs.stat",
+      "description": "Get the status of a file with some features",
+      "downloadLocation": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/nodelib/nodelib/tree/master#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40nodelib/fs.stat@2.0.5"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "46484f3e9db3aea0c0400ff68cd867ced70f025bfae17761229edaef8e78039a2f23b06e93182decc5fbb9dc00bb7ce0d437293d4d2bcf7555d5279aaaf638f8"
+        }
+      ]
+    },
+    {
+      "name": "@nodelib/fs.walk",
+      "SPDXID": "SPDXRef-Package-nodelib.fs.walk-1.2.8",
+      "versionInfo": "1.2.8",
+      "packageFileName": "node_modules/@nodelib/fs.walk",
+      "description": "A library for efficiently walking a directory recursively",
+      "downloadLocation": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/nodelib/nodelib/tree/master#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40nodelib/fs.walk@1.2.8"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a"
+        }
+      ]
+    },
+    {
+      "name": "@pkgjs/parseargs",
+      "SPDXID": "SPDXRef-Package-pkgjs.parseargs-0.11.0",
+      "versionInfo": "0.11.0",
+      "packageFileName": "node_modules/@pkgjs/parseargs",
+      "description": "Polyfill of future proposal for `util.parseArgs()`",
+      "downloadLocation": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/pkgjs/parseargs#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40pkgjs/parseargs@0.11.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "fb55648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e"
+        }
+      ]
+    },
+    {
+      "name": "@popperjs/core",
+      "SPDXID": "SPDXRef-Package-popperjs.core-2.11.8",
+      "versionInfo": "2.11.8",
+      "packageFileName": "node_modules/@popperjs/core",
+      "description": "Tooltip and Popover Positioning Engine",
+      "downloadLocation": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/popperjs/popper-core#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40popperjs/core@2.11.8"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3f5b2dd1a92c0ab9fdb06661a7c18c63006742c6ef016b19017e38a1734dbcb1c6a8039ca15c668d98a886cb7043b4aa2a76d1e3b6a474d8beba57960fcfa0e8"
+        }
+      ]
+    },
+    {
+      "name": "@rollup/rollup-darwin-arm64",
+      "SPDXID": "SPDXRef-Package-rollup.rollup-darwin-arm64-4.40.1",
+      "versionInfo": "4.40.1",
+      "packageFileName": "node_modules/@rollup/rollup-darwin-arm64",
+      "description": "Native bindings for Rollup",
+      "downloadLocation": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://rollupjs.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40rollup/rollup-darwin-arm64@4.40.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "5565c6212585635f2fff4272354cb8038e8a08509bf4d56c1fed75d345cfdf596e77e4f395ecc16f3db8098cdb9c0e31eb0e21c7e3580970df9ef0d53ba95c00"
+        }
+      ]
+    },
+    {
+      "name": "@tailwindcss/aspect-ratio",
+      "SPDXID": "SPDXRef-Package-tailwindcss.aspect-ratio-0.4.2",
+      "versionInfo": "0.4.2",
+      "packageFileName": "node_modules/@tailwindcss/aspect-ratio",
+      "downloadLocation": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tailwindlabs/tailwindcss-aspect-ratio#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40tailwindcss/aspect-ratio@0.4.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "f103ebca9b247c16bb40832e2878364c0ec1a844babe106b0cb3aff149dbe85705c9ddd38ca6dcea57266fd50f407c5f976e2c5e8278d6ec7f1fba9042f7da49"
+        }
+      ]
+    },
+    {
+      "name": "@tailwindcss/forms",
+      "SPDXID": "SPDXRef-Package-tailwindcss.forms-0.5.7",
+      "versionInfo": "0.5.7",
+      "packageFileName": "node_modules/@tailwindcss/forms",
+      "downloadLocation": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tailwindlabs/tailwindcss-forms#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40tailwindcss/forms@0.5.7"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "404ed7ebd89023e657c25744fabcdab2f6c98b257f8eed451871f4427d96dc529bb98b6aa7c2ca732ea24b0efd7d5513e7f56f7fed1780b09e6151be515ea13b"
+        }
+      ]
+    },
+    {
+      "name": "@tailwindcss/typography",
+      "SPDXID": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "versionInfo": "0.5.13",
+      "packageFileName": "node_modules/@tailwindcss/typography",
+      "description": "A Tailwind CSS plugin for automatically styling plain HTML content with beautiful typographic defaults.",
+      "downloadLocation": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.13.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tailwindlabs/tailwindcss-typography#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40tailwindcss/typography@0.5.13"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "00319c27c757db57555472304d1833adcba763a618f6e4a50071c654abe403ebcb739a8bc04b33bcab6ce34971ef3d2a738725a63725c0b78ae6b5425763ffbb"
+        }
+      ]
+    },
+    {
+      "name": "postcss-selector-parser",
+      "SPDXID": "SPDXRef-Package-postcss-selector-parser-6.0.10",
+      "versionInfo": "6.0.10",
+      "packageFileName": "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser",
+      "downloadLocation": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/postcss-selector-parser",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-selector-parser@6.0.10"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "210ed365da1aa9b4fe2c2a52860e3a8e7655961583db0ea241801c6177c701167b5f5b7f50686171e403b395f4706a8abd894734ebafece6b5c666f4a10b80df"
+        }
+      ]
+    },
+    {
+      "name": "@tanstack/virtual-core",
+      "SPDXID": "SPDXRef-Package-tanstack.virtual-core-3.5.0",
+      "versionInfo": "3.5.0",
+      "packageFileName": "node_modules/@tanstack/virtual-core",
+      "description": "Headless UI for virtualizing scrollable elements in TS/JS + Frameworks",
+      "downloadLocation": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.5.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tanstack/virtual#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40tanstack/virtual-core@3.5.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "2a73d10a4413caa85a9cd0b42badc6046df003c23e0f57d0b959c0bdc045f1fd776a438a790a758126eee9fefbcc2c61124ef6ee2579a109db1cb6331eb1022e"
+        }
+      ]
+    },
+    {
+      "name": "@tanstack/vue-virtual",
+      "SPDXID": "SPDXRef-Package-tanstack.vue-virtual-3.5.0",
+      "versionInfo": "3.5.0",
+      "packageFileName": "node_modules/@tanstack/vue-virtual",
+      "description": "Headless UI for virtualizing scrollable elements in Vue",
+      "downloadLocation": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.5.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tanstack/virtual#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40tanstack/vue-virtual@3.5.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c2f450f2c1719ff343af75af2395da6e1168bd9e4c066a44724d861e94f162e9e657adcebe9977d2546ee96e413d0a37e5ad46a8367e3efce5cfa58359136aab"
+        }
+      ]
+    },
+    {
+      "name": "@types/estree",
+      "SPDXID": "SPDXRef-Package-types.estree-1.0.7",
+      "versionInfo": "1.0.7",
+      "packageFileName": "node_modules/@types/estree",
+      "description": "TypeScript definitions for estree",
+      "downloadLocation": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/estree",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/estree@1.0.7"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c36f08a1250226989d0ff4c6be2670c0c25c90d1122595c5bbb341679609e261149cdada527f4f9bc1d2666fe30c5d690d660ab29584ee85698628143d16a421"
+        }
+      ]
+    },
+    {
+      "name": "@types/lodash",
+      "SPDXID": "SPDXRef-Package-types.lodash-4.17.4",
+      "versionInfo": "4.17.4",
+      "packageFileName": "node_modules/@types/lodash",
+      "description": "TypeScript definitions for lodash",
+      "downloadLocation": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/lodash@4.17.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c1808fdba64bc5a4f7477f6488ddbe1dc278913777535c1a23f718ee2bd662a14fea95b764da6f8ba59de8f1d9c7b4ffb7ccf4be5917320dd060b6bb0d9fc825"
+        }
+      ]
+    },
+    {
+      "name": "@types/resize-observer-browser",
+      "SPDXID": "SPDXRef-Package-types.resize-observer-browser-0.1.11",
+      "versionInfo": "0.1.11",
+      "packageFileName": "node_modules/@types/resize-observer-browser",
+      "description": "TypeScript definitions for resize-observer-browser",
+      "downloadLocation": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/resize-observer-browser",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/resize-observer-browser@0.1.11"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "70dc39887f0990c91bdd0902a1eec369989ac1b0d01145fcb7b8ae41a453c8b3b240247687e89b043e0626dee9e728541eb94e78bed9b5bc4d1de8a9a8db01cd"
+        }
+      ]
+    },
+    {
+      "name": "@vitejs/plugin-vue",
+      "SPDXID": "SPDXRef-Package-vitejs.plugin-vue-5.2.1",
+      "versionInfo": "5.2.1",
+      "packageFileName": "node_modules/@vitejs/plugin-vue",
+      "downloadLocation": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vitejs/plugin-vue@5.2.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "731877d78b73696c0e2ea55eb368279c2b6f04370cd5431d9fe88547e523027e35d5d3d3ded3a6aab2636cc77b92866930098133f1aa795e27f607bb25288925"
+        }
+      ]
+    },
+    {
+      "name": "@vue/compiler-core",
+      "SPDXID": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/compiler-core",
+      "description": "@vue/compiler-core",
+      "downloadLocation": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-core#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/compiler-core@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "13e472a98db82a7c835ec0ae42b23e9a571d5b700b343e94ec6a9affe6d5c1b729711dc145121c905a33ed0c9de134e59ee82dc2e23b6208dbbec2e6c5bfb2be"
+        }
+      ]
+    },
+    {
+      "name": "@vue/compiler-dom",
+      "SPDXID": "SPDXRef-Package-vue.compiler-dom-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/compiler-dom",
+      "description": "@vue/compiler-dom",
+      "downloadLocation": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-dom#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/compiler-dom@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "9144efa1c846fe8560135c395624abdca50187d5fb0968ab79b0376decd36c1e59281419c11d8cc23f6ea12291305733e2048ccf32d704f0fa2a908b6fd9ef5b"
+        }
+      ]
+    },
+    {
+      "name": "@vue/compiler-sfc",
+      "SPDXID": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/compiler-sfc",
+      "description": "@vue/compiler-sfc",
+      "downloadLocation": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-sfc#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/compiler-sfc@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "9c3c27b541000ecb16f1ed2bae6134f8eace37099195e803035a43e90855797c63232b55d37c83a937b2f520438802ecbc077953866b10a6ccc955e15fa98218"
+        }
+      ]
+    },
+    {
+      "name": "@vue/compiler-ssr",
+      "SPDXID": "SPDXRef-Package-vue.compiler-ssr-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/compiler-ssr",
+      "description": "@vue/compiler-ssr",
+      "downloadLocation": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/compiler-ssr#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/compiler-ssr@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "095473489225b73306e4572276c5b48ca3509cd4580bc6d3db555e83230cb479a15b750e23b9279947a1cecc172eb1310cb13a95009976b843e28808edcfafbb"
+        }
+      ]
+    },
+    {
+      "name": "@vue/reactivity",
+      "SPDXID": "SPDXRef-Package-vue.reactivity-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/reactivity",
+      "description": "@vue/reactivity",
+      "downloadLocation": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/reactivity#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/reactivity@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "90ad20e0d9275ba257db2c922e9b26da396e9d9265dbf449199d07f5d74775f0551dc373c66434b12d1bd3d8a9981a10a58f093362a6530f9aeac3bc668fb320"
+        }
+      ]
+    },
+    {
+      "name": "@vue/runtime-core",
+      "SPDXID": "SPDXRef-Package-vue.runtime-core-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/runtime-core",
+      "description": "@vue/runtime-core",
+      "downloadLocation": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/runtime-core#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/runtime-core@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "eda600f4611b38e76f8aa56f72ec1e4cb7b965ae2a05991463b4af113eaf13c932ca9c5581a4f58b11cb838babb4e96b02976071d807a1364252e4c66a9ff958"
+        }
+      ]
+    },
+    {
+      "name": "@vue/runtime-dom",
+      "SPDXID": "SPDXRef-Package-vue.runtime-dom-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/runtime-dom",
+      "description": "@vue/runtime-dom",
+      "downloadLocation": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/runtime-dom#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/runtime-dom@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "49c3a63fbd3fdcd3ccf935bd86f540cfa5565ad649aa46dd7fbc3ac92b30b3e12caad1ef921c5a58b79cad3a2b171b1ac1e94ce58b3d1670c432de813c10d2d1"
+        }
+      ]
+    },
+    {
+      "name": "@vue/server-renderer",
+      "SPDXID": "SPDXRef-Package-vue.server-renderer-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/server-renderer",
+      "description": "@vue/server-renderer",
+      "downloadLocation": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/server-renderer#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/server-renderer@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "76500c12ebe6780deb26c38c27627591753ba3ba4ec60b0d1d5afd2bc841dc8988912b81ac8772d2f17aea1f207fc4ee8a77f54cade63c0cf6fb6b2ac9fdcacc"
+        }
+      ]
+    },
+    {
+      "name": "@vue/shared",
+      "SPDXID": "SPDXRef-Package-vue.shared-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/@vue/shared",
+      "description": "internal utils shared across @vue packages",
+      "downloadLocation": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/shared#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40vue/shared@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "0cbdcd998d8e165aa6618af3a77f728b72c390ac5ae6f655c3159d437ac6d1e92e5ac707ada7886e723cb7e6992bbaa162a12a58a4d47628da76e9dbf699eb80"
+        }
+      ]
+    },
+    {
+      "name": "@yaireo/tagify",
+      "SPDXID": "SPDXRef-Package-yaireo.tagify-4.26.5",
+      "versionInfo": "4.26.5",
+      "packageFileName": "node_modules/@yaireo/tagify",
+      "description": "lightweight, efficient Tags input component in Vanilla JS / React / Angular [super customizable, tiny size & top performance]",
+      "downloadLocation": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.26.5.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/yairEO/tagify",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40yaireo/tagify@4.26.5"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "59c350163987eff2e57ebf353466676a5529af2e0fae00cdd9b76b81070de7580d74c0bccd4b11d409801cbeb25b8aa6786160d192dbb63569b202871be308c3"
+        }
+      ]
+    },
+    {
+      "name": "ansi-regex",
+      "SPDXID": "SPDXRef-Package-ansi-regex-6.0.1",
+      "versionInfo": "6.0.1",
+      "packageFileName": "node_modules/ansi-regex",
+      "description": "Regular expression for matching ANSI escape codes",
+      "downloadLocation": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/ansi-regex#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ansi-regex@6.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "9f933ce797ca6f64ac7cc222145a15ac0047242f10b47c15c7e98758fdd0704a811d889e9e3e5d1d28236f1b42d161195d8b78c1c0faceb4049433e116e6607c"
+        }
+      ]
+    },
+    {
+      "name": "ansi-styles",
+      "SPDXID": "SPDXRef-Package-ansi-styles-6.2.1",
+      "versionInfo": "6.2.1",
+      "packageFileName": "node_modules/ansi-styles",
+      "description": "ANSI escape codes for styling strings in the terminal",
+      "downloadLocation": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/ansi-styles#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ansi-styles@6.2.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "6cdefdf2015f417faf8b0dd1ef2ac6591aa7acdda84641245238e5e09367e04f06c716e3b46dc56eb108218de5f3f86bc14c0878266f8b842e3933f8304ad5ba"
+        }
+      ]
+    },
+    {
+      "name": "any-promise",
+      "SPDXID": "SPDXRef-Package-any-promise-1.3.0",
+      "versionInfo": "1.3.0",
+      "packageFileName": "node_modules/any-promise",
+      "description": "Resolve any installed ES6 compatible promise",
+      "downloadLocation": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "http://github.com/kevinbeaty/any-promise",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/any-promise@1.3.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "ed4be629a95646dd708232f546b1b1a12256ff44191487a0a5e1af646f648e9f2fad1bb9e574c76f09eaab61a95e6f6e2db72e8719b722a5fd381e0c651d5bd8"
+        }
+      ]
+    },
+    {
+      "name": "anymatch",
+      "SPDXID": "SPDXRef-Package-anymatch-3.1.3",
+      "versionInfo": "3.1.3",
+      "packageFileName": "node_modules/anymatch",
+      "description": "Matches strings against configurable strings, globs, regular expressions, and/or functions",
+      "downloadLocation": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/anymatch",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/anymatch@3.1.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "28c45e154af4078b7e0fe381923477298aafa1ca765da4b33b9e54701ea681031ddca6dc13e9964f2bd557b0ffcec7446cd9d5e9a71952eb64887417bd3af547"
+        }
+      ]
+    },
+    {
+      "name": "arg",
+      "SPDXID": "SPDXRef-Package-arg-5.0.2",
+      "versionInfo": "5.0.2",
+      "packageFileName": "node_modules/arg",
+      "description": "Unopinionated, no-frills CLI argument parser",
+      "downloadLocation": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vercel/arg#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/arg@5.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3d88f214e2ca43dcb9ec9bd0e902e8f1d02036ab3087c33544c25875076e4fac5b59280adfa3ff67fbfea7cf3ca4cebd8cc31f4bc5ddf05e88d6443f23d1d41a"
+        }
+      ]
+    },
+    {
+      "name": "autoprefixer",
+      "SPDXID": "SPDXRef-Package-autoprefixer-10.4.19",
+      "versionInfo": "10.4.19",
+      "packageFileName": "node_modules/autoprefixer",
+      "description": "Parse CSS and add vendor prefixes to CSS rules using values from the Can I Use website",
+      "downloadLocation": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/autoprefixer#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/autoprefixer@10.4.19"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "05a10d476fb3059f315e1338a5468a531955771674119863bdba29c275e6c5151fa839b04a90b69408bf417bf1ecd45d3c2a3558a11c105ea657ae2c8b5cf813"
+        }
+      ]
+    },
+    {
+      "name": "balanced-match",
+      "SPDXID": "SPDXRef-Package-balanced-match-1.0.2",
+      "versionInfo": "1.0.2",
+      "packageFileName": "node_modules/balanced-match",
+      "description": "Match balanced character pairs, like \"{\" and \"}\"",
+      "downloadLocation": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/juliangruber/balanced-match",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/balanced-match@1.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f"
+        }
+      ]
+    },
+    {
+      "name": "binary-extensions",
+      "SPDXID": "SPDXRef-Package-binary-extensions-2.3.0",
+      "versionInfo": "2.3.0",
+      "packageFileName": "node_modules/binary-extensions",
+      "description": "List of binary file extensions",
+      "downloadLocation": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/binary-extensions#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/binary-extensions@2.3.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "09e87eee8c79a9eecb26e2c7a18d1f7a1de91ee5031c071151ec8bd95620859c1fa64348cbffbc39c8346b752e4a86336af9b2970b8b59039fde19748e330c23"
+        }
+      ]
+    },
+    {
+      "name": "brace-expansion",
+      "SPDXID": "SPDXRef-Package-brace-expansion-2.0.1",
+      "versionInfo": "2.0.1",
+      "packageFileName": "node_modules/brace-expansion",
+      "description": "Brace expansion as known from sh/bash",
+      "downloadLocation": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/juliangruber/brace-expansion",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/brace-expansion@2.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "5e7008bd0f1e33e902e9a50bc7ac2e422c15b27cec8bd7775b1cd5dc5a564c6035f45eb6d64c1d6ec01c14a5e02941d95accbe998ea22f5b074f1584142cad0c"
+        }
+      ]
+    },
+    {
+      "name": "braces",
+      "SPDXID": "SPDXRef-Package-braces-3.0.3",
+      "versionInfo": "3.0.3",
+      "packageFileName": "node_modules/braces",
+      "description": "Bash-like brace expansion, implemented in JavaScript. Safer than other brace expansion libs, with complete support for the Bash 4.3 braces specification, without sacrificing speed.",
+      "downloadLocation": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/braces",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/braces@3.0.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc"
+        }
+      ]
+    },
+    {
+      "name": "browserslist",
+      "SPDXID": "SPDXRef-Package-browserslist-4.23.0",
+      "versionInfo": "4.23.0",
+      "packageFileName": "node_modules/browserslist",
+      "description": "Share target browsers between different front-end tools, like Autoprefixer, Stylelint and babel-env-preset",
+      "downloadLocation": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/browserslist/browserslist#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/browserslist@4.23.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "416f0788cd6c8614f61aece4be495f8dc2838961571ce78508803f86e24fc07b2c97073276093b5fecf6cd7a448a33fdf14098ec76ee6d9b79276660bdfd0269"
+        }
+      ]
+    },
+    {
+      "name": "camelcase-css",
+      "SPDXID": "SPDXRef-Package-camelcase-css-2.0.1",
+      "versionInfo": "2.0.1",
+      "packageFileName": "node_modules/camelcase-css",
+      "description": "Convert a kebab-cased CSS property into a camelCased DOM property.",
+      "downloadLocation": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/stevenvachon/camelcase-css#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/camelcase-css@2.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "40e4af7af86c9628e0630471e91bfbcca74c17c95b466c7eb901b1dbebc373e288fde067b32f648ade5a8f6dc0806bb7a5ae2df408306e75d6a92fa2398fb668"
+        }
+      ]
+    },
+    {
+      "name": "caniuse-lite",
+      "SPDXID": "SPDXRef-Package-caniuse-lite-1.0.30001620",
+      "versionInfo": "1.0.30001620",
+      "packageFileName": "node_modules/caniuse-lite",
+      "description": "A smaller version of caniuse-db, with only the essentials!",
+      "downloadLocation": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/browserslist/caniuse-lite#readme",
+      "licenseDeclared": "CC-BY-4.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/caniuse-lite@1.0.30001620"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "589bd8b0e8ddd7f058518e92346528b0af435227413c34e7380447a777d29853b57a4771698ea7291b6d115adf326622f3472d4b4933d708969a6d787d57377b"
+        }
+      ]
+    },
+    {
+      "name": "chokidar",
+      "SPDXID": "SPDXRef-Package-chokidar-3.6.0",
+      "versionInfo": "3.6.0",
+      "packageFileName": "node_modules/chokidar",
+      "description": "Minimal and efficient cross-platform file watching library",
+      "downloadLocation": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/paulmillr/chokidar",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/chokidar@3.6.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "ed54f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f"
+        }
+      ]
+    },
+    {
+      "name": "glob-parent",
+      "SPDXID": "SPDXRef-Package-glob-parent-5.1.2",
+      "versionInfo": "5.1.2",
+      "packageFileName": "node_modules/chokidar/node_modules/glob-parent",
+      "description": "Extract the non-magic parent path from a glob string.",
+      "downloadLocation": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/gulpjs/glob-parent#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/glob-parent@5.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "00e22049009ea62258c0fdc04671b1fb95674eed870587736c63f8e5e2f0d6faf7cc1def64b7b279dd6c0bd8676dc39cf7f4ab33233944f42b906cf8692f59a3"
+        }
+      ]
+    },
+    {
+      "name": "color-convert",
+      "SPDXID": "SPDXRef-Package-color-convert-2.0.1",
+      "versionInfo": "2.0.1",
+      "packageFileName": "node_modules/color-convert",
+      "description": "Plain color conversion functions",
+      "downloadLocation": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/Qix-/color-convert#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/color-convert@2.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529"
+        }
+      ]
+    },
+    {
+      "name": "color-name",
+      "SPDXID": "SPDXRef-Package-color-name-1.1.4",
+      "versionInfo": "1.1.4",
+      "packageFileName": "node_modules/color-name",
+      "description": "A list of color names and its values",
+      "downloadLocation": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/colorjs/color-name",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/color-name@1.1.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40"
+        }
+      ]
+    },
+    {
+      "name": "commander",
+      "SPDXID": "SPDXRef-Package-commander-4.1.1",
+      "versionInfo": "4.1.1",
+      "packageFileName": "node_modules/commander",
+      "description": "the complete solution for node.js command-line programs",
+      "downloadLocation": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tj/commander.js#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/commander@4.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "34e2a6f31864cc08f3171f01dafe4e0074febb9a5141cd9409ad95abd8d82ffdf5a36c22f66c4103b2c816cdec5795520b8f73ea91217db3142ef4a12a3dba58"
+        }
+      ]
+    },
+    {
+      "name": "cross-spawn",
+      "SPDXID": "SPDXRef-Package-cross-spawn-7.0.6",
+      "versionInfo": "7.0.6",
+      "packageFileName": "node_modules/cross-spawn",
+      "description": "Cross platform child_process#spawn and child_process#spawnSync",
+      "downloadLocation": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/moxystudio/node-cross-spawn",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/cross-spawn@7.0.6"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc"
+        }
+      ]
+    },
+    {
+      "name": "cssesc",
+      "SPDXID": "SPDXRef-Package-cssesc-3.0.0",
+      "versionInfo": "3.0.0",
+      "packageFileName": "node_modules/cssesc",
+      "description": "A JavaScript library for escaping CSS strings and identifiers while generating the shortest possible ASCII-only output.",
+      "downloadLocation": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://mths.be/cssesc",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/cssesc@3.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "fd36ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56"
+        }
+      ]
+    },
+    {
+      "name": "csstype",
+      "SPDXID": "SPDXRef-Package-csstype-3.1.3",
+      "versionInfo": "3.1.3",
+      "packageFileName": "node_modules/csstype",
+      "description": "Strict TypeScript and Flow types for style based on MDN data",
+      "downloadLocation": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/frenic/csstype#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/csstype@3.1.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "335b9090c97cad02bfb330f42cd86dab120f2e98a61a6f2c381c14ee52e70a949b4f2637c9e53555cee5e0a4f9cd3e2cff23b11c7e4eeed22eb8b3829cb00347"
+        }
+      ]
+    },
+    {
+      "name": "date-fns",
+      "SPDXID": "SPDXRef-Package-date-fns-2.30.0",
+      "versionInfo": "2.30.0",
+      "packageFileName": "node_modules/date-fns",
+      "description": "Modern JavaScript date utility library",
+      "downloadLocation": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/date-fns/date-fns#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/date-fns@2.30.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "7e750bbcea719c2e7f560dcd0a259e943b0b89473d6d1c003ecffe2df4cb36f7ad142b424cdfb2433d790bf7ece00c17d51f4ae462ed2df9fc416f9d5a2b1a03"
+        }
+      ]
+    },
+    {
+      "name": "date-fns-tz",
+      "SPDXID": "SPDXRef-Package-date-fns-tz-2.0.1",
+      "versionInfo": "2.0.1",
+      "packageFileName": "node_modules/date-fns-tz",
+      "description": "Time zone support for date-fns v2 with the Intl API",
+      "downloadLocation": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/marnusw/date-fns-tz#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/date-fns-tz@2.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "7c9086dcfc31f075282e191ea5db0fed9e51b2e7148be6413b1c8ce5dd1967a73849d62eb2dab454c98ebba59fedb962fb24bf270a7dd53382aa7f6331c56b50"
+        }
+      ]
+    },
+    {
+      "name": "didyoumean",
+      "SPDXID": "SPDXRef-Package-didyoumean-1.2.2",
+      "versionInfo": "1.2.2",
+      "packageFileName": "node_modules/didyoumean",
+      "description": "Match human-quality input to potential matches by edit distance.",
+      "downloadLocation": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/dcporter/didyoumean.js",
+      "licenseDeclared": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/didyoumean@1.2.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "831b727ea320ec62b285099bd39e8aeccdf1b33cbf9b21fcc3e078453f905c142cbc039d7375f29aa0c33c7c750603e0b1d000e522227e89daf3d62d4404c3cf"
+        }
+      ]
+    },
+    {
+      "name": "dlv",
+      "SPDXID": "SPDXRef-Package-dlv-1.1.3",
+      "versionInfo": "1.1.3",
+      "packageFileName": "node_modules/dlv",
+      "description": "Safely get a dot-notated property within an object.",
+      "downloadLocation": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/developit/dlv#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/dlv@1.1.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "f87972b728e53ca9c81bc5ee446f16be604ff31b3c3fbd72f9228a4ba6575a81202ee78fc6d0e8504887ed691d78f5ab439241a44e9aa15a9f65f2544248d7c0"
+        }
+      ]
+    },
+    {
+      "name": "eastasianwidth",
+      "SPDXID": "SPDXRef-Package-eastasianwidth-0.2.0",
+      "versionInfo": "0.2.0",
+      "packageFileName": "node_modules/eastasianwidth",
+      "description": "Get East Asian Width from a character.",
+      "downloadLocation": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/komagata/eastasianwidth#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/eastasianwidth@0.2.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "23cf1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58"
+        }
+      ]
+    },
+    {
+      "name": "electron-to-chromium",
+      "SPDXID": "SPDXRef-Package-electron-to-chromium-1.4.774",
+      "versionInfo": "1.4.774",
+      "packageFileName": "node_modules/electron-to-chromium",
+      "description": "Provides a list of electron-to-chromium version mappings",
+      "downloadLocation": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.774.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/kilian/electron-to-chromium#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/electron-to-chromium@1.4.774"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d77d8ed5709def37139334b7160900cca9a706e3498caf168dc4ed36ea32963ecc61bab0e5e5de86343938af75834ce6ece4ca20f79a006e023e845f0fd33532"
+        }
+      ]
+    },
+    {
+      "name": "emoji-regex",
+      "SPDXID": "SPDXRef-Package-emoji-regex-9.2.2",
+      "versionInfo": "9.2.2",
+      "packageFileName": "node_modules/emoji-regex",
+      "description": "A regular expression to match all Emoji-only symbols as per the Unicode Standard.",
+      "downloadLocation": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://mths.be/emoji-regex",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/emoji-regex@9.2.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca"
+        }
+      ]
+    },
+    {
+      "name": "entities",
+      "SPDXID": "SPDXRef-Package-entities-4.5.0",
+      "versionInfo": "4.5.0",
+      "packageFileName": "node_modules/entities",
+      "description": "Encode & decode XML and HTML entities with ease & speed",
+      "downloadLocation": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/fb55/entities#readme",
+      "licenseDeclared": "BSD-2-Clause",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/entities@4.5.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "5748631f87463e1f40a39a74328458e8156ab700a3873eaf2392d3f00279e47fb883dff8bdb1f1d48e787d2d17b9c94b8431c0acf40288c8c3c6368bf1f3f187"
+        }
+      ]
+    },
+    {
+      "name": "esbuild",
+      "SPDXID": "SPDXRef-Package-esbuild-0.25.0",
+      "versionInfo": "0.25.0",
+      "packageFileName": "node_modules/esbuild",
+      "description": "An extremely fast JavaScript and CSS bundler and minifier.",
+      "downloadLocation": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/evanw/esbuild#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/esbuild@0.25.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "057ab99aa73c96d6da377e1c0ea5ae60ac8d857f03fd9d09d7176d750f14708208c89cb3f9930a52de7cb45dd2ad9f398dc7cdfcf658863479b8340060d55bbb"
+        }
+      ]
+    },
+    {
+      "name": "escalade",
+      "SPDXID": "SPDXRef-Package-escalade-3.1.2",
+      "versionInfo": "3.1.2",
+      "packageFileName": "node_modules/escalade",
+      "description": "A tiny (183B to 210B) and fast utility to ascend parent directories",
+      "downloadLocation": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/lukeed/escalade#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/escalade@3.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "12b08730269ed7dbd1f2f4067b9d3122c5689b2d7dae0ea016edfeaf78e410ee3ab2e2cc58192cbd5ca81a0415fa339f97ce1948e4a59afe86c5af3d3e64c698"
+        }
+      ]
+    },
+    {
+      "name": "estree-walker",
+      "SPDXID": "SPDXRef-Package-estree-walker-2.0.2",
+      "versionInfo": "2.0.2",
+      "packageFileName": "node_modules/estree-walker",
+      "description": "Traverse an ESTree-compliant AST",
+      "downloadLocation": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/Rich-Harris/estree-walker#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/estree-walker@2.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "45f924fcca7f0cbec95637b7bb5f05c45ba34254cd476aba41f312301ec0bc2071f753468ff6dade409fcdad1fe9d5436f0ed89517ff9c3ae7ee942b082c90ff"
+        }
+      ]
+    },
+    {
+      "name": "fast-glob",
+      "SPDXID": "SPDXRef-Package-fast-glob-3.3.2",
+      "versionInfo": "3.3.2",
+      "packageFileName": "node_modules/fast-glob",
+      "description": "It's a very fast and efficient glob library for Node.js",
+      "downloadLocation": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/mrmlnc/fast-glob#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fast-glob@3.3.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a17dabb80150c1ffceae3f26ef7ed8e5a7710d03b42c007bfd2e4c9f109d4cd0dde29e81b32215b2ff4942c0136d34aaf0a1d1a4bc081db56550d6adc5dfb53b"
+        }
+      ]
+    },
+    {
+      "name": "fastq",
+      "SPDXID": "SPDXRef-Package-fastq-1.17.1",
+      "versionInfo": "1.17.1",
+      "packageFileName": "node_modules/fastq",
+      "description": "Fast, in memory work queue",
+      "downloadLocation": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/mcollina/fastq#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fastq@1.17.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "b11543de55952175a0e81cbaf1937bbe1a3d6b5a5070dfd604568002c0c31739498efa06c743fccfb575b7bda0ac525f261bb760f641baedb97fb29ac368cdd7"
+        }
+      ]
+    },
+    {
+      "name": "fill-range",
+      "SPDXID": "SPDXRef-Package-fill-range-7.1.1",
+      "versionInfo": "7.1.1",
+      "packageFileName": "node_modules/fill-range",
+      "description": "Fill in a range of numbers or letters, optionally passing an increment or `step` to use, or create a regex-compatible range with `options.toRegex`",
+      "downloadLocation": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jonschlinkert/fill-range",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fill-range@7.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "62c1a97b75872caf19622e2d583836272dde6d1cf6ad7a300f19e57786e4401d3471cff5670f405a70b48bdced0c98ad8afb50bda23d29a2f22ab73e8415b4ca"
+        }
+      ]
+    },
+    {
+      "name": "foreground-child",
+      "SPDXID": "SPDXRef-Package-foreground-child-3.1.1",
+      "versionInfo": "3.1.1",
+      "packageFileName": "node_modules/foreground-child",
+      "description": "Run a child as if it's the foreground process. Give it stdio. Exit when it exits.",
+      "downloadLocation": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tapjs/foreground-child#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/foreground-child@3.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "4cc28352722d7ba6df6f99d6bfb57f71a235ebd38782fc236fb5785a4794bdb410763af9ad62aa1c588a59bfdf70ec01f82cc14fea9b5a3be3f8357046c92922"
+        }
+      ]
+    },
+    {
+      "name": "fraction.js",
+      "SPDXID": "SPDXRef-Package-fraction.js-4.3.7",
+      "versionInfo": "4.3.7",
+      "packageFileName": "node_modules/fraction.js",
+      "description": "A rational number library",
+      "downloadLocation": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://www.xarg.org/2014/03/rational-numbers-in-javascript/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fraction.js@4.3.7"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "66c0dfc4ee75c06017444639e5aee56bd2d2716a70bfd47122b60006b96f3850651ff4a13e7aedb177ae5087d728a39589c37143ea3c2536c9be34b833cf727b"
+        }
+      ]
+    },
+    {
+      "name": "fsevents",
+      "SPDXID": "SPDXRef-Package-fsevents-2.3.3",
+      "versionInfo": "2.3.3",
+      "packageFileName": "node_modules/fsevents",
+      "description": "Native Access to MacOS FSEvents",
+      "downloadLocation": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/fsevents/fsevents",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fsevents@2.3.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43"
+        }
+      ]
+    },
+    {
+      "name": "function-bind",
+      "SPDXID": "SPDXRef-Package-function-bind-1.1.2",
+      "versionInfo": "1.1.2",
+      "packageFileName": "node_modules/function-bind",
+      "description": "Implementation of Function.prototype.bind",
+      "downloadLocation": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/Raynos/function-bind",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/function-bind@1.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648"
+        }
+      ]
+    },
+    {
+      "name": "glob",
+      "SPDXID": "SPDXRef-Package-glob-10.3.15",
+      "versionInfo": "10.3.15",
+      "packageFileName": "node_modules/glob",
+      "description": "the most correct and second fastest glob implementation in JavaScript",
+      "downloadLocation": "https://registry.npmjs.org/glob/-/glob-10.3.15.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/node-glob#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/glob@10.3.15"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d1ce91949b754c808bcaf258200a716fc1ac5e86a2d0a50fec0c4a280b6c617760251d6618451aec38304a16dd9359e5cb43d8a198f4d717788736eaddfb23a7"
+        }
+      ]
+    },
+    {
+      "name": "glob-parent",
+      "SPDXID": "SPDXRef-Package-glob-parent-6.0.2",
+      "versionInfo": "6.0.2",
+      "packageFileName": "node_modules/glob-parent",
+      "description": "Extract the non-magic parent path from a glob string.",
+      "downloadLocation": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/gulpjs/glob-parent#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/glob-parent@6.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0"
+        }
+      ]
+    },
+    {
+      "name": "hasown",
+      "SPDXID": "SPDXRef-Package-hasown-2.0.2",
+      "versionInfo": "2.0.2",
+      "packageFileName": "node_modules/hasown",
+      "description": "A robust, ES3 compatible, \"has own property\" predicate.",
+      "downloadLocation": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/inspect-js/hasOwn#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hasown@2.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d21254f5208fbe633320175916a34f5d66ba76a87b59d1f470823dcbe0b24bcac6de72f8f01725adaf4798a8555541f23d6347e58ef10f0001edb7e04a391431"
+        }
+      ]
+    },
+    {
+      "name": "is-binary-path",
+      "SPDXID": "SPDXRef-Package-is-binary-path-2.1.0",
+      "versionInfo": "2.1.0",
+      "packageFileName": "node_modules/is-binary-path",
+      "description": "Check if a file path is a binary file",
+      "downloadLocation": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/is-binary-path#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/is-binary-path@2.1.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "64c11161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f"
+        }
+      ]
+    },
+    {
+      "name": "is-core-module",
+      "SPDXID": "SPDXRef-Package-is-core-module-2.13.1",
+      "versionInfo": "2.13.1",
+      "packageFileName": "node_modules/is-core-module",
+      "description": "Is this specifier a node.js core module?",
+      "downloadLocation": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/inspect-js/is-core-module",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/is-core-module@2.13.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "847ac88ef66c7ed3acbca4a7d9345897adf3bf1b201342bed2660ca07ea00f8a264792160762b29e2bc141cce8dfec05d5c0a48f3be9b6723d434b0f53aea297"
+        }
+      ]
+    },
+    {
+      "name": "is-extglob",
+      "SPDXID": "SPDXRef-Package-is-extglob-2.1.1",
+      "versionInfo": "2.1.1",
+      "packageFileName": "node_modules/is-extglob",
+      "description": "Returns true if a string has an extglob.",
+      "downloadLocation": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jonschlinkert/is-extglob",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/is-extglob@2.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1"
+        }
+      ]
+    },
+    {
+      "name": "is-fullwidth-code-point",
+      "SPDXID": "SPDXRef-Package-is-fullwidth-code-point-3.0.0",
+      "versionInfo": "3.0.0",
+      "packageFileName": "node_modules/is-fullwidth-code-point",
+      "description": "Check if the character represented by a given Unicode code point is fullwidth",
+      "downloadLocation": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/is-fullwidth-code-point#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/is-fullwidth-code-point@3.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742"
+        }
+      ]
+    },
+    {
+      "name": "is-glob",
+      "SPDXID": "SPDXRef-Package-is-glob-4.0.3",
+      "versionInfo": "4.0.3",
+      "packageFileName": "node_modules/is-glob",
+      "description": "Returns `true` if the given string looks like a glob pattern or an extglob pattern. This makes it easy to create code that only uses external modules like node-glob when necessary, resulting in much faster code execution and initialization time, and a better user experience.",
+      "downloadLocation": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/is-glob",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/is-glob@4.0.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a"
+        }
+      ]
+    },
+    {
+      "name": "is-number",
+      "SPDXID": "SPDXRef-Package-is-number-7.0.0",
+      "versionInfo": "7.0.0",
+      "packageFileName": "node_modules/is-number",
+      "description": "Returns true if a number or string value is a finite number. Useful for regex matches, parsing, user input, etc.",
+      "downloadLocation": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jonschlinkert/is-number",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/is-number@7.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e350a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e"
+        }
+      ]
+    },
+    {
+      "name": "isexe",
+      "SPDXID": "SPDXRef-Package-isexe-2.0.0",
+      "versionInfo": "2.0.0",
+      "packageFileName": "node_modules/isexe",
+      "description": "Minimal module to check if a file is executable.",
+      "downloadLocation": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/isexe#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/isexe@2.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23"
+        }
+      ]
+    },
+    {
+      "name": "jackspeak",
+      "SPDXID": "SPDXRef-Package-jackspeak-2.3.6",
+      "versionInfo": "2.3.6",
+      "packageFileName": "node_modules/jackspeak",
+      "description": "A very strict and proper argument parser.",
+      "downloadLocation": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/jackspeak#readme",
+      "licenseDeclared": "BlueOak-1.0.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/jackspeak@2.3.6"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "377c824bf35e82c381a2473c18074cf147267ec2a2492f1c8a985e0ff9e2bf3afbd341fe9ec30ec498d09efc0e711615b8591d1f4c0652f5b659b5c69ab6466d"
+        }
+      ]
+    },
+    {
+      "name": "jiti",
+      "SPDXID": "SPDXRef-Package-jiti-1.21.0",
+      "versionInfo": "1.21.0",
+      "packageFileName": "node_modules/jiti",
+      "description": "Runtime typescript and ESM support for Node.js",
+      "downloadLocation": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/unjs/jiti#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/jiti@1.21.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "805a8021bb8acb2b28ff71b6aa188ed8e33ab2163a10f3ff474fa69036f2b29c4a6b387c0570c2e45885b148e573381d373fef7eb6b475adb2f9a1ebbac2c6fd"
+        }
+      ]
+    },
+    {
+      "name": "js-tokens",
+      "SPDXID": "SPDXRef-Package-js-tokens-4.0.0",
+      "versionInfo": "4.0.0",
+      "packageFileName": "node_modules/js-tokens",
+      "description": "A regex that tokenizes JavaScript.",
+      "downloadLocation": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/lydell/js-tokens#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/js-tokens@4.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29"
+        }
+      ]
+    },
+    {
+      "name": "lilconfig",
+      "SPDXID": "SPDXRef-Package-lilconfig-2.1.0",
+      "versionInfo": "2.1.0",
+      "packageFileName": "node_modules/lilconfig",
+      "description": "A zero-dependency alternative to cosmiconfig",
+      "downloadLocation": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/antonk52/lilconfig#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lilconfig@2.1.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "bad58eb7f187cee5319cb2b107a764f3546839ea0d78781bad78ae1a4e32c85e6a951cfe888556bb9e84d9fa861c5ad7cf440d5212c1ffc9caaaf447eba24a19"
+        }
+      ]
+    },
+    {
+      "name": "lines-and-columns",
+      "SPDXID": "SPDXRef-Package-lines-and-columns-1.2.4",
+      "versionInfo": "1.2.4",
+      "packageFileName": "node_modules/lines-and-columns",
+      "description": "Maps lines and columns to character offsets and back.",
+      "downloadLocation": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/eventualbuddha/lines-and-columns#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lines-and-columns@1.2.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406"
+        }
+      ]
+    },
+    {
+      "name": "lodash",
+      "SPDXID": "SPDXRef-Package-lodash-4.17.21",
+      "versionInfo": "4.17.21",
+      "packageFileName": "node_modules/lodash",
+      "description": "Lodash modular utilities.",
+      "downloadLocation": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://lodash.com/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash@4.17.21"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "bf690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b81764daec43e2c54c61d5c558dc5cfb35ecb85b65519e74026ff17675b6f8f916f4a"
+        }
+      ]
+    },
+    {
+      "name": "lodash.castarray",
+      "SPDXID": "SPDXRef-Package-lodash.castarray-4.4.0",
+      "versionInfo": "4.4.0",
+      "packageFileName": "node_modules/lodash.castarray",
+      "description": "The lodash method `_.castArray` exported as a module.",
+      "downloadLocation": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://lodash.com/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.castarray@4.4.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "695c7cced3efeffd942db02b189d98e366c6d66110e661a3a5dbeb6c9709154dd36d8c9b7be4252d2e29b2df73579db29b2da29f52a914f8999c03804f10f8f9"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isplainobject",
+      "SPDXID": "SPDXRef-Package-lodash.isplainobject-4.0.6",
+      "versionInfo": "4.0.6",
+      "packageFileName": "node_modules/lodash.isplainobject",
+      "description": "The lodash method `_.isPlainObject` exported as a module.",
+      "downloadLocation": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://lodash.com/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isplainobject@4.0.6"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a125f3696ca908c1e43c2dcdbc111a3c77f42ac0399af3eb38f810583b1b83c9fba2b676f743340660bf8e0459e2f709e834c0863aec49881db16fc5f8c14e04"
+        }
+      ]
+    },
+    {
+      "name": "lodash.merge",
+      "SPDXID": "SPDXRef-Package-lodash.merge-4.6.2",
+      "versionInfo": "4.6.2",
+      "packageFileName": "node_modules/lodash.merge",
+      "description": "The Lodash method `_.merge` exported as a module.",
+      "downloadLocation": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://lodash.com/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.merge@4.6.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321"
+        }
+      ]
+    },
+    {
+      "name": "loose-envify",
+      "SPDXID": "SPDXRef-Package-loose-envify-1.4.0",
+      "versionInfo": "1.4.0",
+      "packageFileName": "node_modules/loose-envify",
+      "description": "Fast (and loose) selective `process.env` replacer using js-tokens instead of an AST",
+      "downloadLocation": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/zertosh/loose-envify",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/loose-envify@1.4.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add"
+        }
+      ]
+    },
+    {
+      "name": "lru-cache",
+      "SPDXID": "SPDXRef-Package-lru-cache-10.2.2",
+      "versionInfo": "10.2.2",
+      "packageFileName": "node_modules/lru-cache",
+      "description": "A cache object that deletes the least-recently-used items.",
+      "downloadLocation": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/node-lru-cache#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lru-cache@10.2.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "f61a77569dbf845414888c0aa3c5c2785567ae0f0f9374d834f211eed2400ca8b961f705eef11a2bb6af1474e54b2de438a61a25069a95f128e98b9775c78139"
+        }
+      ]
+    },
+    {
+      "name": "magic-string",
+      "SPDXID": "SPDXRef-Package-magic-string-0.30.10",
+      "versionInfo": "0.30.10",
+      "packageFileName": "node_modules/magic-string",
+      "description": "Modify strings, generate sourcemaps",
+      "downloadLocation": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/rich-harris/magic-string#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/magic-string@0.30.10"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "8884704c87f440a5775009d82b83d4f2e8847384918798d7d26c292301133e91dd8553387f9dd14b04bfbd7bcdd498465fe0acec1f2a22addde801f8f4ee5f01"
+        }
+      ]
+    },
+    {
+      "name": "merge2",
+      "SPDXID": "SPDXRef-Package-merge2-1.4.1",
+      "versionInfo": "1.4.1",
+      "packageFileName": "node_modules/merge2",
+      "description": "Merge multiple streams into one stream in sequence or parallel.",
+      "downloadLocation": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/teambition/merge2",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/merge2@1.4.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "f2aed51203095b827cb5c7d53f2f20d3d35c43065d6f0144aa17bf5999282338e7ff74c60f0b4e098b571b10373bcb4fce97330820e0bfe3f63f9cb4d1924e3a"
+        }
+      ]
+    },
+    {
+      "name": "micromatch",
+      "SPDXID": "SPDXRef-Package-micromatch-4.0.8",
+      "versionInfo": "4.0.8",
+      "packageFileName": "node_modules/micromatch",
+      "description": "Glob matching for javascript/node.js. A replacement and faster alternative to minimatch and multimatch.",
+      "downloadLocation": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/micromatch",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/micromatch@4.0.8"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3d7c1f06162ed210423f0f039f413e58361beda7f77522d558a8b71c6bfce08745e13c85a02d32b3115dd06a31c3b9d2bf84ff3f3109431b18b0488508aa3604"
+        }
+      ]
+    },
+    {
+      "name": "mini-svg-data-uri",
+      "SPDXID": "SPDXRef-Package-mini-svg-data-uri-1.4.4",
+      "versionInfo": "1.4.4",
+      "packageFileName": "node_modules/mini-svg-data-uri",
+      "description": "Small, efficient encoding of SVG data URIs for CSS, HTML, etc.",
+      "downloadLocation": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tigt/mini-svg-data-uri#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mini-svg-data-uri@1.4.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "afd75e0def69e452543d9024dc0e7dc061fb222f58ae38d6c348e6c3f96249b1e5d821e2c978fa15c0d70eed8add38d5017aa225d6b0df1c7095966bf44ea71e"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-minimatch-9.0.4",
+      "versionInfo": "9.0.4",
+      "packageFileName": "node_modules/minimatch",
+      "description": "a glob matcher in javascript",
+      "downloadLocation": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/minimatch#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@9.0.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "2aa5a1f957217f170c3510098e3dad9ec48974d6c7b1582790185336b5bb023568e8ebcbb71c3ccdf4fda0bc35252a21945cc9f230a84e06a85ef27e907b7a7f"
+        }
+      ]
+    },
+    {
+      "name": "minipass",
+      "SPDXID": "SPDXRef-Package-minipass-7.1.1",
+      "versionInfo": "7.1.1",
+      "packageFileName": "node_modules/minipass",
+      "description": "minimal implementation of a PassThrough stream",
+      "downloadLocation": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/minipass#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minipass@7.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "519ede43e87ccb0211016d6120497602a770cc9b9c53f2a9e7dfbc92465e4af69f5e1663ba5db8ec1bc826311515578e37a77b94ce3a5d7d475c276e2804bc54"
+        }
+      ]
+    },
+    {
+      "name": "mz",
+      "SPDXID": "SPDXRef-Package-mz-2.7.0",
+      "versionInfo": "2.7.0",
+      "packageFileName": "node_modules/mz",
+      "description": "modernize node.js to current ECMAScript standards",
+      "downloadLocation": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/normalize/mz#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/mz@2.7.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "cfcd4634eee79d830486b1a1f4b7b29a8138f98af45a7e4c70721930ae5c7d00a5f8d0d7d3cb0266051cf7fe8c1e78bd216b852e6d59dc74c25eedb3f5f37ad9"
+        }
+      ]
+    },
+    {
+      "name": "nanoid",
+      "SPDXID": "SPDXRef-Package-nanoid-3.3.8",
+      "versionInfo": "3.3.8",
+      "packageFileName": "node_modules/nanoid",
+      "description": "A tiny (116 bytes), secure URL-friendly unique string ID generator",
+      "downloadLocation": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/ai/nanoid#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/nanoid@3.3.8"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "58d2dfe5277ca19c4e9be4f3a6971893c8153a03fe979f31372e7c0f49db5273b1396456be570257891417b96d988e8fb2b2e5fc180a1324b89aab060a114dd3"
+        }
+      ]
+    },
+    {
+      "name": "node-releases",
+      "SPDXID": "SPDXRef-Package-node-releases-2.0.14",
+      "versionInfo": "2.0.14",
+      "packageFileName": "node_modules/node-releases",
+      "description": "Node.js releases data",
+      "downloadLocation": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chicoxyzzy/node-releases#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/node-releases@2.0.14"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "cb5d30396b7cc99a6a5e63a0468efb59a1c49a1610606340eb2e36d4f2ac2985842bc696f9ca80a616e8ad90e1a9fc8aadb64437dd823755f629b69f636b3b63"
+        }
+      ]
+    },
+    {
+      "name": "normalize-path",
+      "SPDXID": "SPDXRef-Package-normalize-path-3.0.0",
+      "versionInfo": "3.0.0",
+      "packageFileName": "node_modules/normalize-path",
+      "description": "Normalize slashes in a file path to be posix/unix-like forward slashes. Also condenses repeat slashes to a single slash and removes and trailing slashes, unless disabled.",
+      "downloadLocation": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jonschlinkert/normalize-path",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/normalize-path@3.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c"
+        }
+      ]
+    },
+    {
+      "name": "normalize-range",
+      "SPDXID": "SPDXRef-Package-normalize-range-0.1.2",
+      "versionInfo": "0.1.2",
+      "packageFileName": "node_modules/normalize-range",
+      "description": "Utility for normalizing a numeric range, with a wrapping function useful for polar coordinates",
+      "downloadLocation": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jamestalmage/normalize-range#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/normalize-range@0.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "6dda24fd7bca208de75299259d5e8fda1c6d30dac26e83a301cc81b909d61213baeb9170ad2351c54f80aa9b32bcee8b80660fb2937e96ee422edc388cf44a34"
+        }
+      ]
+    },
+    {
+      "name": "object-assign",
+      "SPDXID": "SPDXRef-Package-object-assign-4.1.1",
+      "versionInfo": "4.1.1",
+      "packageFileName": "node_modules/object-assign",
+      "description": "ES2015 `Object.assign()` ponyfill",
+      "downloadLocation": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/object-assign#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/object-assign@4.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52"
+        }
+      ]
+    },
+    {
+      "name": "object-hash",
+      "SPDXID": "SPDXRef-Package-object-hash-3.0.0",
+      "versionInfo": "3.0.0",
+      "packageFileName": "node_modules/object-hash",
+      "description": "Generate hashes from javascript objects in node and the browser.",
+      "downloadLocation": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/puleos/object-hash",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/object-hash@3.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "4529fd17af0f8c7f47aad96db129ea602d575e859ef418eee7edb5dd1f7c70d1adb5a83dabdc80393cdd6ecaaf21aeda366e567df059169598af6696ae495603"
+        }
+      ]
+    },
+    {
+      "name": "path-key",
+      "SPDXID": "SPDXRef-Package-path-key-3.1.1",
+      "versionInfo": "3.1.1",
+      "packageFileName": "node_modules/path-key",
+      "description": "Get the PATH environment variable key cross-platform",
+      "downloadLocation": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/path-key#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/path-key@3.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9"
+        }
+      ]
+    },
+    {
+      "name": "path-parse",
+      "SPDXID": "SPDXRef-Package-path-parse-1.0.7",
+      "versionInfo": "1.0.7",
+      "packageFileName": "node_modules/path-parse",
+      "description": "Node.js path.parse() ponyfill",
+      "downloadLocation": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/jbgutierrez/path-parse#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/path-parse@1.0.7"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3"
+        }
+      ]
+    },
+    {
+      "name": "path-scurry",
+      "SPDXID": "SPDXRef-Package-path-scurry-1.11.1",
+      "versionInfo": "1.11.1",
+      "packageFileName": "node_modules/path-scurry",
+      "description": "walk paths fast and efficiently",
+      "downloadLocation": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/path-scurry#readme",
+      "licenseDeclared": "BlueOak-1.0.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/path-scurry@1.11.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c"
+        }
+      ]
+    },
+    {
+      "name": "picocolors",
+      "SPDXID": "SPDXRef-Package-picocolors-1.1.1",
+      "versionInfo": "1.1.1",
+      "packageFileName": "node_modules/picocolors",
+      "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
+      "downloadLocation": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/alexeyraspopov/picocolors#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/picocolors@1.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454"
+        }
+      ]
+    },
+    {
+      "name": "picomatch",
+      "SPDXID": "SPDXRef-Package-picomatch-2.3.1",
+      "versionInfo": "2.3.1",
+      "packageFileName": "node_modules/picomatch",
+      "description": "Blazing fast and accurate glob matcher written in JavaScript, with no dependencies and full support for standard and extended Bash glob features, including braces, extglobs, POSIX brackets, and regular expressions.",
+      "downloadLocation": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/picomatch",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/picomatch@2.3.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "254ded7874cd8e6136542185cee63c117cc20d5c04a81d9af1fb08bf0692b4784058911e55dd68d500fcd0253af997445d748b6d2b2e2f0263902056a9141454"
+        }
+      ]
+    },
+    {
+      "name": "pify",
+      "SPDXID": "SPDXRef-Package-pify-2.3.0",
+      "versionInfo": "2.3.0",
+      "packageFileName": "node_modules/pify",
+      "description": "Promisify a callback-style function",
+      "downloadLocation": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/pify#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/pify@2.3.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "b9d82c018f9f4e7befee423b69ac5bab058d6f4007881d2a04ef3d3d928f9284e618e81d6eb1c3283fb40765f8b937c9fc54f5474f6bf604ec8d48cd268b6ea2"
+        }
+      ]
+    },
+    {
+      "name": "pirates",
+      "SPDXID": "SPDXRef-Package-pirates-4.0.6",
+      "versionInfo": "4.0.6",
+      "packageFileName": "node_modules/pirates",
+      "description": "Properly hijack require, i.e., properly define require hooks and customizations",
+      "downloadLocation": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/danez/pirates#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/pirates@4.0.6"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "b1a2ec1fb59e6183e20f6e4b0ee2d1458fe2fba1da3d8afa1b539494ddfda2dce4493c4a9ee6d1f514f14b7fca939d2cd60d894e01705900d0ca9942e7f48766"
+        }
+      ]
+    },
+    {
+      "name": "postcss",
+      "SPDXID": "SPDXRef-Package-postcss-8.5.3",
+      "versionInfo": "8.5.3",
+      "packageFileName": "node_modules/postcss",
+      "description": "Tool for transforming styles with JS plugins",
+      "downloadLocation": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://postcss.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss@8.5.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "7657bd037c98c65052aedf05bbe2298c64fc498f213749a5680e8663cb743f93e320e65e9942f3fc4d819e6ff675c50e7a76bbe4e4cd90723beae64135452adc"
+        }
+      ]
+    },
+    {
+      "name": "postcss-import",
+      "SPDXID": "SPDXRef-Package-postcss-import-15.1.0",
+      "versionInfo": "15.1.0",
+      "packageFileName": "node_modules/postcss-import",
+      "description": "PostCSS plugin to import CSS files",
+      "downloadLocation": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/postcss-import#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-import@15.1.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "869afe274e41d855585005c778ad58c88dbaec9fdd0c384c53a07a722be6f21498d636099c15f1cca0ca0ecc33266b4b1ebcab8e19c38eaaa9ff8f6df0500b7b"
+        }
+      ]
+    },
+    {
+      "name": "postcss-js",
+      "SPDXID": "SPDXRef-Package-postcss-js-4.0.1",
+      "versionInfo": "4.0.1",
+      "packageFileName": "node_modules/postcss-js",
+      "description": "PostCSS for CSS-in-JS and styles in JS objects",
+      "downloadLocation": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/postcss-js#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-js@4.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "7432c5f2910ed7dd6124cb651c53d16bcc6c8b31da33cd8c2df364507754b55115ded813a79a23fbca9b12a60ce7b48b7dcef82926f0fffe1278999ad8b45523"
+        }
+      ]
+    },
+    {
+      "name": "postcss-load-config",
+      "SPDXID": "SPDXRef-Package-postcss-load-config-4.0.2",
+      "versionInfo": "4.0.2",
+      "packageFileName": "node_modules/postcss-load-config",
+      "description": "Autoload Config for PostCSS",
+      "downloadLocation": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/postcss-load-config#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-load-config@4.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "6d2561c8918bd34c0c5683d4cc05409db1285b2a91c648efeb8b54978dbb48a9cfac436daba849c14a23ae8333d9507e43579d9a2e087eb00fa5a9a2e5556031"
+        }
+      ]
+    },
+    {
+      "name": "lilconfig",
+      "SPDXID": "SPDXRef-Package-lilconfig-3.1.1",
+      "versionInfo": "3.1.1",
+      "packageFileName": "node_modules/postcss-load-config/node_modules/lilconfig",
+      "description": "A zero-dependency alternative to cosmiconfig",
+      "downloadLocation": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/antonk52/lilconfig#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lilconfig@3.1.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3b5f297fb9f2bc74dc92e9cf5825755d4357535a62bb4d72d9bec04c9d29a6452493ca1ca95581ad88c9042c070e30ff65671fcab0343f880a8735868b910835"
+        }
+      ]
+    },
+    {
+      "name": "postcss-nested",
+      "SPDXID": "SPDXRef-Package-postcss-nested-6.0.1",
+      "versionInfo": "6.0.1",
+      "packageFileName": "node_modules/postcss-nested",
+      "description": "PostCSS plugin to unwrap nested rules like how Sass does it",
+      "downloadLocation": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/postcss-nested#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-nested@6.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "984a78c4f322e5b49688c6ec8283df70fef896c58b1e441b65cdec63e8d661deb9094c17ad4693a747e63696b4d597044ca94881474537f3294b6c59b6a2fd75"
+        }
+      ]
+    },
+    {
+      "name": "postcss-selector-parser",
+      "SPDXID": "SPDXRef-Package-postcss-selector-parser-6.0.16",
+      "versionInfo": "6.0.16",
+      "packageFileName": "node_modules/postcss-selector-parser",
+      "downloadLocation": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/postcss/postcss-selector-parser",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-selector-parser@6.0.16"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "03445526b5fe21491565b5b70a5ae8456bab7ab70586279ebc7077f2caf6fa5f5e50294caa899edcb9849a7865372fb932bd8460de81d8a6b0f7061d77e5478b"
+        }
+      ]
+    },
+    {
+      "name": "postcss-value-parser",
+      "SPDXID": "SPDXRef-Package-postcss-value-parser-4.2.0",
+      "versionInfo": "4.2.0",
+      "packageFileName": "node_modules/postcss-value-parser",
+      "description": "Transforms css values and at-rule params into the tree",
+      "downloadLocation": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/TrySound/postcss-value-parser",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/postcss-value-parser@4.2.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779"
+        }
+      ]
+    },
+    {
+      "name": "prop-types",
+      "SPDXID": "SPDXRef-Package-prop-types-15.8.1",
+      "versionInfo": "15.8.1",
+      "packageFileName": "node_modules/prop-types",
+      "description": "Runtime type checking for React props and similar objects.",
+      "downloadLocation": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://facebook.github.io/react/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/prop-types@15.8.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972"
+        }
+      ]
+    },
+    {
+      "name": "queue-microtask",
+      "SPDXID": "SPDXRef-Package-queue-microtask-1.2.3",
+      "versionInfo": "1.2.3",
+      "packageFileName": "node_modules/queue-microtask",
+      "description": "fast, tiny `queueMicrotask` shim for modern engines",
+      "downloadLocation": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/feross/queue-microtask",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/queue-microtask@1.2.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4"
+        }
+      ]
+    },
+    {
+      "name": "react",
+      "SPDXID": "SPDXRef-Package-react-18.3.1",
+      "versionInfo": "18.3.1",
+      "packageFileName": "node_modules/react",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "downloadLocation": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://reactjs.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/react@18.3.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689"
+        }
+      ]
+    },
+    {
+      "name": "react-dom",
+      "SPDXID": "SPDXRef-Package-react-dom-18.3.1",
+      "versionInfo": "18.3.1",
+      "packageFileName": "node_modules/react-dom",
+      "description": "React package for working with the DOM.",
+      "downloadLocation": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://reactjs.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/react-dom@18.3.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423"
+        }
+      ]
+    },
+    {
+      "name": "react-is",
+      "SPDXID": "SPDXRef-Package-react-is-16.13.1",
+      "versionInfo": "16.13.1",
+      "packageFileName": "node_modules/react-is",
+      "description": "Brand checking of React Elements.",
+      "downloadLocation": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://reactjs.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/react-is@16.13.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d"
+        }
+      ]
+    },
+    {
+      "name": "read-cache",
+      "SPDXID": "SPDXRef-Package-read-cache-1.0.0",
+      "versionInfo": "1.0.0",
+      "packageFileName": "node_modules/read-cache",
+      "description": "Reads and caches the entire contents of a file until it is modified",
+      "downloadLocation": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/TrySound/read-cache#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/read-cache@1.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3b076ffc5b7b2233a09bf8b4c6f3436752eb4403517dec386f6a6b1773963102f12dfbb76d2f055610acad208c2b8951e7a63dc9af804e1a13a43093c429a944"
+        }
+      ]
+    },
+    {
+      "name": "readdirp",
+      "SPDXID": "SPDXRef-Package-readdirp-3.6.0",
+      "versionInfo": "3.6.0",
+      "packageFileName": "node_modules/readdirp",
+      "description": "Recursive version of fs.readdir with streaming API.",
+      "downloadLocation": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/paulmillr/readdirp",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/readdirp@3.6.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "84e4b4f3da27f1176ea9d6e1bd0e59dfb0341128ecab3eaa9d171f7ec314df8f7916e4dda929beedb849dbd26f20eb010c41276a7e433eef6ddd3a3d55194ccc"
+        }
+      ]
+    },
+    {
+      "name": "regenerator-runtime",
+      "SPDXID": "SPDXRef-Package-regenerator-runtime-0.14.1",
+      "versionInfo": "0.14.1",
+      "packageFileName": "node_modules/regenerator-runtime",
+      "description": "Runtime for Regenerator-compiled generator and async functions.",
+      "downloadLocation": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/facebook/regenerator/tree/main#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/regenerator-runtime@0.14.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "7589e11e1d2726831f9e466ce869a684592700646b2f39cebb99dcf4c2fe109c46bebc7a1fbb5eb9ebea56a0ae3dc3cafffdde0ebae34217a15d5c7d72790677"
+        }
+      ]
+    },
+    {
+      "name": "resolve",
+      "SPDXID": "SPDXRef-Package-resolve-1.22.8",
+      "versionInfo": "1.22.8",
+      "packageFileName": "node_modules/resolve",
+      "description": "resolve like require.resolve() on behalf of files asynchronously and synchronously",
+      "downloadLocation": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/browserify/resolve#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/resolve@1.22.8"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a0a59e3c2c6aa5de8594bbc6575554d31edb90f9a608da25c738cc7f835cce80e741c216ac017e70fb599f98ba9fe45f0f677d8b4b73a4a9c6e98935ebcc88cb"
+        }
+      ]
+    },
+    {
+      "name": "reusify",
+      "SPDXID": "SPDXRef-Package-reusify-1.0.4",
+      "versionInfo": "1.0.4",
+      "packageFileName": "node_modules/reusify",
+      "description": "Reuse objects and functions with style",
+      "downloadLocation": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/mcollina/reusify#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/reusify@1.0.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "53d9c7f3c6b77dcfde902175974fd43f5228b22b888f24e1ee106f5d530762055c7c6bedf3ded782e8f650e2c3788e411b69bbfeec3268b553e9f6ed0b04f2cf"
+        }
+      ]
+    },
+    {
+      "name": "rollup",
+      "SPDXID": "SPDXRef-Package-rollup-4.40.1",
+      "versionInfo": "4.40.1",
+      "packageFileName": "node_modules/rollup",
+      "description": "Next-generation ES module bundler",
+      "downloadLocation": "https://registry.npmjs.org/rollup/-/rollup-4.40.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://rollupjs.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/rollup@4.40.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "0b956fbe0082c9fca8b55213200bfee1e7d5cad97917bc2dfbf2368bdabd1997045d6f413f9d9860e5c2e7c8a0522f8b159547ba412b208a90496c2ffccdd647"
+        }
+      ]
+    },
+    {
+      "name": "run-parallel",
+      "SPDXID": "SPDXRef-Package-run-parallel-1.2.0",
+      "versionInfo": "1.2.0",
+      "packageFileName": "node_modules/run-parallel",
+      "description": "Run an array of functions in parallel",
+      "downloadLocation": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/feross/run-parallel",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/run-parallel@1.2.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e65e15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004"
+        }
+      ]
+    },
+    {
+      "name": "scheduler",
+      "SPDXID": "SPDXRef-Package-scheduler-0.23.2",
+      "versionInfo": "0.23.2",
+      "packageFileName": "node_modules/scheduler",
+      "description": "Cooperative scheduler for the browser environment.",
+      "downloadLocation": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://reactjs.org/",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/scheduler@0.23.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd"
+        }
+      ]
+    },
+    {
+      "name": "shebang-command",
+      "SPDXID": "SPDXRef-Package-shebang-command-2.0.0",
+      "versionInfo": "2.0.0",
+      "packageFileName": "node_modules/shebang-command",
+      "description": "Get the command from a shebang",
+      "downloadLocation": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/kevva/shebang-command#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/shebang-command@2.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c"
+        }
+      ]
+    },
+    {
+      "name": "shebang-regex",
+      "SPDXID": "SPDXRef-Package-shebang-regex-3.0.0",
+      "versionInfo": "3.0.0",
+      "packageFileName": "node_modules/shebang-regex",
+      "description": "Regular expression for matching a shebang line",
+      "downloadLocation": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/shebang-regex#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/shebang-regex@3.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4"
+        }
+      ]
+    },
+    {
+      "name": "signal-exit",
+      "SPDXID": "SPDXRef-Package-signal-exit-4.1.0",
+      "versionInfo": "4.1.0",
+      "packageFileName": "node_modules/signal-exit",
+      "description": "when you want to fire an event no matter how a process exits.",
+      "downloadLocation": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/tapjs/signal-exit#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/signal-exit@4.1.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af"
+        }
+      ]
+    },
+    {
+      "name": "source-map-js",
+      "SPDXID": "SPDXRef-Package-source-map-js-1.2.1",
+      "versionInfo": "1.2.1",
+      "packageFileName": "node_modules/source-map-js",
+      "description": "Generates and consumes source maps",
+      "downloadLocation": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/7rulnik/source-map-js",
+      "licenseDeclared": "BSD-3-Clause",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/source-map-js@1.2.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40"
+        }
+      ]
+    },
+    {
+      "name": "string-width",
+      "SPDXID": "SPDXRef-Package-string-width-5.1.2",
+      "versionInfo": "5.1.2",
+      "packageFileName": "node_modules/string-width",
+      "description": "Get the visual width of a string - the number of columns required to display it",
+      "downloadLocation": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/string-width#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/string-width@5.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8"
+        }
+      ]
+    },
+    {
+      "name": "string-width",
+      "SPDXID": "SPDXRef-Package-string-width-4.2.3",
+      "versionInfo": "4.2.3",
+      "packageFileName": "node_modules/string-width-cjs",
+      "description": "Get the visual width of a string - the number of columns required to display it",
+      "downloadLocation": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/sindresorhus/string-width#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/string-width@4.2.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe"
+        }
+      ]
+    },
+    {
+      "name": "ansi-regex",
+      "SPDXID": "SPDXRef-Package-ansi-regex-5.0.1",
+      "versionInfo": "5.0.1",
+      "packageFileName": "node_modules/string-width-cjs/node_modules/ansi-regex",
+      "description": "Regular expression for matching ANSI escape codes",
+      "downloadLocation": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/ansi-regex#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ansi-regex@5.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15"
+        }
+      ]
+    },
+    {
+      "name": "emoji-regex",
+      "SPDXID": "SPDXRef-Package-emoji-regex-8.0.0",
+      "versionInfo": "8.0.0",
+      "packageFileName": "node_modules/string-width-cjs/node_modules/emoji-regex",
+      "description": "A regular expression to match all Emoji-only symbols as per the Unicode Standard.",
+      "downloadLocation": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://mths.be/emoji-regex",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/emoji-regex@8.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8"
+        }
+      ]
+    },
+    {
+      "name": "strip-ansi",
+      "SPDXID": "SPDXRef-Package-strip-ansi-6.0.1",
+      "versionInfo": "6.0.1",
+      "packageFileName": "node_modules/string-width-cjs/node_modules/strip-ansi",
+      "description": "Strip ANSI escape codes from a string",
+      "downloadLocation": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/strip-ansi#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/strip-ansi@6.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4"
+        }
+      ]
+    },
+    {
+      "name": "strip-ansi",
+      "SPDXID": "SPDXRef-Package-strip-ansi-7.1.0",
+      "versionInfo": "7.1.0",
+      "packageFileName": "node_modules/strip-ansi",
+      "description": "Strip ANSI escape codes from a string",
+      "downloadLocation": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/strip-ansi#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/strip-ansi@7.1.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "8aae9e55523ae274104d162ad8ab44836776b94ecb125853270b07e18cc81d9b21c658199acff021ce15a03413946fc8bd522b04a1b4e82ad99e9d2abfb86471"
+        }
+      ]
+    },
+    {
+      "name": "sucrase",
+      "SPDXID": "SPDXRef-Package-sucrase-3.35.0",
+      "versionInfo": "3.35.0",
+      "packageFileName": "node_modules/sucrase",
+      "description": "Super-fast alternative to Babel for when you can target modern JS runtimes",
+      "downloadLocation": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/alangpierce/sucrase#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/sucrase@3.35.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "f046d50e2bbd88dfe7112c31792c4329ed1dba7b5ad463a51ee7e64925f1303db3dbfb4c6690cca6f5d01ac73e6a31a8f32dae6149a2c5a49151cfd03e843418"
+        }
+      ]
+    },
+    {
+      "name": "supports-preserve-symlinks-flag",
+      "SPDXID": "SPDXRef-Package-supports-preserve-symlinks-flag-1.0.0",
+      "versionInfo": "1.0.0",
+      "packageFileName": "node_modules/supports-preserve-symlinks-flag",
+      "description": "Determine if the current node version supports the `--preserve-symlinks` flag.",
+      "downloadLocation": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/inspect-js/node-supports-preserve-symlinks-flag#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/supports-preserve-symlinks-flag@1.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3"
+        }
+      ]
+    },
+    {
+      "name": "tailwindcss",
+      "SPDXID": "SPDXRef-Package-tailwindcss-3.4.3",
+      "versionInfo": "3.4.3",
+      "packageFileName": "node_modules/tailwindcss",
+      "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
+      "downloadLocation": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://tailwindcss.com",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/tailwindcss@3.4.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "53bb31424fe7dfdec19b1e091db271fe248e3afe46f882377f59292e963641e52fe4370f75c4ec60b96eb197ead4db611d2d5cd5c668c859a691ec75af391ed0"
+        }
+      ]
+    },
+    {
+      "name": "thenify",
+      "SPDXID": "SPDXRef-Package-thenify-3.3.1",
+      "versionInfo": "3.3.1",
+      "packageFileName": "node_modules/thenify",
+      "description": "Promisify a callback-based function",
+      "downloadLocation": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/thenables/thenify#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/thenify@3.3.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "455652215e481b5d079377a7a2dae1bf3d13f5e9ba7321c12e41ff60066e2aa77c85190a8527c218870fd8a518d043f19ddcc034198d965cd63f06a4f9b85e4b"
+        }
+      ]
+    },
+    {
+      "name": "thenify-all",
+      "SPDXID": "SPDXRef-Package-thenify-all-1.6.0",
+      "versionInfo": "1.6.0",
+      "packageFileName": "node_modules/thenify-all",
+      "description": "Promisifies all the selected functions in an object",
+      "downloadLocation": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/thenables/thenify-all#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/thenify-all@1.6.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "44dc501ffa88f3fb77b615c90f072cb543b8cdeaa8eb8f94cbffac355441c785e7d8e5fe399f683fe8899cd16aa6516b6b665455e28249ada85568b74f8b9598"
+        }
+      ]
+    },
+    {
+      "name": "tinyglobby",
+      "SPDXID": "SPDXRef-Package-tinyglobby-0.2.13",
+      "versionInfo": "0.2.13",
+      "packageFileName": "node_modules/tinyglobby",
+      "description": "A fast and minimal alternative to globby and fast-glob",
+      "downloadLocation": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/SuperchupuDev/tinyglobby#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/tinyglobby@0.2.13"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "984c33a5482b2f24a5bde0701150cc2a4e41e7b6e12cf628bd17cf0170f9800ffdf0ea67d2b0838f71ad2f016f0af1f944af6e3c2131511396e4d8c3c2faa4c7"
+        }
+      ]
+    },
+    {
+      "name": "fdir",
+      "SPDXID": "SPDXRef-Package-fdir-6.4.4",
+      "versionInfo": "6.4.4",
+      "packageFileName": "node_modules/tinyglobby/node_modules/fdir",
+      "description": "The fastest directory crawler & globbing alternative to glob, fast-glob, & tiny-glob. Crawls 1m files in < 1s",
+      "downloadLocation": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/thecodrr/fdir#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fdir@6.4.4"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "d4d64ff862b819fb80bf73ea2afc504433237524598e792aeca7e194dac234d959d3281016979b7eb9df9eafd6edfa549c0bfd6865a6635ccac7b1582f783086"
+        }
+      ]
+    },
+    {
+      "name": "picomatch",
+      "SPDXID": "SPDXRef-Package-picomatch-4.0.2",
+      "versionInfo": "4.0.2",
+      "packageFileName": "node_modules/tinyglobby/node_modules/picomatch",
+      "description": "Blazing fast and accurate glob matcher written in JavaScript, with no dependencies and full support for standard and extended Bash glob features, including braces, extglobs, POSIX brackets, and regular expressions.",
+      "downloadLocation": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/picomatch",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/picomatch@4.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "33b04057a465732e6efa6ea83e100f160253cc08a85ffe81d03c72bc3968f65f3e4f79cb29badcce0d962d4cb3778e4bf11a9f50cc863f37a46ccbd7d8b764c2"
+        }
+      ]
+    },
+    {
+      "name": "to-regex-range",
+      "SPDXID": "SPDXRef-Package-to-regex-range-5.0.1",
+      "versionInfo": "5.0.1",
+      "packageFileName": "node_modules/to-regex-range",
+      "description": "Pass two numbers, get a regex-compatible source string for matching ranges. Validated against more than 2.78 million test assertions.",
+      "downloadLocation": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/micromatch/to-regex-range",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/to-regex-range@5.0.1"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "eb93fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1"
+        }
+      ]
+    },
+    {
+      "name": "ts-interface-checker",
+      "SPDXID": "SPDXRef-Package-ts-interface-checker-0.1.13",
+      "versionInfo": "0.1.13",
+      "packageFileName": "node_modules/ts-interface-checker",
+      "description": "Runtime library to validate data against TypeScript interfaces",
+      "downloadLocation": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/gristlabs/ts-interface-checker#readme",
+      "licenseDeclared": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ts-interface-checker@0.1.13"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "63f6abbdb9feaebcf72422a5f42e2454d7d37d29b6fe6129e454b3e44b194803463d2950ae9448e4ce0f285fa6267139da338ef743e73d273752bddb4d0c3480"
+        }
+      ]
+    },
+    {
+      "name": "update-browserslist-db",
+      "SPDXID": "SPDXRef-Package-update-browserslist-db-1.0.16",
+      "versionInfo": "1.0.16",
+      "packageFileName": "node_modules/update-browserslist-db",
+      "description": "CLI tool to update caniuse-lite to refresh target browsers from Browserslist config",
+      "downloadLocation": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/browserslist/update-db#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/update-browserslist-db@1.0.16"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "2956d3c6505895c921179c207f26574d69cc9fb30c66332ef571bc6cf96589438ff5385a17842784ff2aae3ac7ec34731df4a4d2842fd704e85be880e466a311"
+        }
+      ]
+    },
+    {
+      "name": "util-deprecate",
+      "SPDXID": "SPDXRef-Package-util-deprecate-1.0.2",
+      "versionInfo": "1.0.2",
+      "packageFileName": "node_modules/util-deprecate",
+      "description": "The Node.js `util.deprecate()` function with browser support",
+      "downloadLocation": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/TooTallNate/util-deprecate",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/util-deprecate@1.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73"
+        }
+      ]
+    },
+    {
+      "name": "v-calendar",
+      "SPDXID": "SPDXRef-Package-v-calendar-3.1.2",
+      "versionInfo": "3.1.2",
+      "packageFileName": "node_modules/v-calendar",
+      "description": "A calendar and date picker plugin for Vue.js.",
+      "downloadLocation": "https://registry.npmjs.org/v-calendar/-/v-calendar-3.1.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://vcalendar.io",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/v-calendar@3.1.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "4035ab9e9e0f582a7351b95cb60a384f9e7c3eb1e01f30ed4274de50dccac5f35fdbd16409e169c0677d6ca8c0aa4b5a6b66892dcc91978e53e659f592edf892"
+        }
+      ]
+    },
+    {
+      "name": "vite",
+      "SPDXID": "SPDXRef-Package-vite-6.3.3",
+      "versionInfo": "6.3.3",
+      "packageFileName": "node_modules/vite",
+      "description": "Native-ESM powered web dev build tool",
+      "downloadLocation": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://vite.dev",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/vite@6.3.3"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e675c7f90b042db14a86c11f58b907aef811a53746273a8e67ebad49d98f4efc079af53a2134e6df1c7e991bac8a191c23c19e0bb9420f29f7903b62922f6c73"
+        }
+      ]
+    },
+    {
+      "name": "vue",
+      "SPDXID": "SPDXRef-Package-vue-3.4.27",
+      "versionInfo": "3.4.27",
+      "packageFileName": "node_modules/vue",
+      "description": "The progressive JavaScript framework for building modern web UI.",
+      "downloadLocation": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/vuejs/core/tree/main/packages/vue#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/vue@3.4.27"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "f2cff9eae2baaf4d6bd62706fda10e1eac8c5717756e461c49ef63f0770ab6bff14ce156be7cc85537a1356fb962df3d7fe0cb05ee00e7af699d92d2e47cc030"
+        }
+      ]
+    },
+    {
+      "name": "vue-screen-utils",
+      "SPDXID": "SPDXRef-Package-vue-screen-utils-1.0.0-beta.13",
+      "versionInfo": "1.0.0-beta.13",
+      "packageFileName": "node_modules/vue-screen-utils",
+      "description": "A dependency-free collection of screen utility functions in Vue 3.",
+      "downloadLocation": "https://registry.npmjs.org/vue-screen-utils/-/vue-screen-utils-1.0.0-beta.13.tgz",
+      "filesAnalyzed": false,
+      "homepage": "NOASSERTION",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/vue-screen-utils@1.0.0-beta.13"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "109ffc4c034a8458fe2de7c3b8ebd9ca4c0caf7aeb2c53cb35bfbe94d06a3cea558a04f601cb5183a89c1fd4454159b89c7c251c81d21a6e4e63f0a56abf7222"
+        }
+      ]
+    },
+    {
+      "name": "which",
+      "SPDXID": "SPDXRef-Package-which-2.0.2",
+      "versionInfo": "2.0.2",
+      "packageFileName": "node_modules/which",
+      "description": "Like which(1) unix command. Find the first instance of an executable in the PATH.",
+      "downloadLocation": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/isaacs/node-which#readme",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/which@2.0.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c"
+        }
+      ]
+    },
+    {
+      "name": "wrap-ansi",
+      "SPDXID": "SPDXRef-Package-wrap-ansi-8.1.0",
+      "versionInfo": "8.1.0",
+      "packageFileName": "node_modules/wrap-ansi",
+      "description": "Wordwrap a string with ANSI escape codes",
+      "downloadLocation": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/wrap-ansi#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/wrap-ansi@8.1.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09"
+        }
+      ]
+    },
+    {
+      "name": "wrap-ansi",
+      "SPDXID": "SPDXRef-Package-wrap-ansi-7.0.0",
+      "versionInfo": "7.0.0",
+      "packageFileName": "node_modules/wrap-ansi-cjs",
+      "description": "Wordwrap a string with ANSI escape codes",
+      "downloadLocation": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/wrap-ansi#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/wrap-ansi@7.0.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9"
+        }
+      ]
+    },
+    {
+      "name": "ansi-styles",
+      "SPDXID": "SPDXRef-Package-ansi-styles-4.3.0",
+      "versionInfo": "4.3.0",
+      "packageFileName": "node_modules/wrap-ansi-cjs/node_modules/ansi-styles",
+      "description": "ANSI escape codes for styling strings in the terminal",
+      "downloadLocation": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://github.com/chalk/ansi-styles#readme",
+      "licenseDeclared": "MIT",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ansi-styles@4.3.0"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212"
+        }
+      ]
+    },
+    {
+      "name": "yaml",
+      "SPDXID": "SPDXRef-Package-yaml-2.4.2",
+      "versionInfo": "2.4.2",
+      "packageFileName": "node_modules/yaml",
+      "description": "JavaScript parser and stringifier for YAML",
+      "downloadLocation": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
+      "filesAnalyzed": false,
+      "homepage": "https://eemeli.org/yaml/",
+      "licenseDeclared": "ISC",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/yaml@2.4.2"
+        }
+      ],
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "07756a0d9f89020d67669684996b535d49419dea06c7a08f33d6f44c434ae9aa12bb9b7bddd22db9dc1d8268bab4794865921de1d67db2470043651b73201e54"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-flavorly.vanilla-components-0.7.65",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-headlessui.vue-1.7.22",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-popperjs.core-2.11.8",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss.aspect-ratio-0.4.2",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss.forms-0.5.7",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-yaireo.tagify-4.26.5",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vitejs.plugin-vue-5.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vite-6.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-wtf-frontend-0.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-regenerator-runtime-0.14.1",
+      "relatedSpdxElement": "SPDXRef-Package-babel.runtime-7.26.10",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-flavorly.vanilla-components-0.7.65",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-headlessui.vue-1.7.22",
+      "relatedSpdxElement": "SPDXRef-Package-flavorly.vanilla-components-0.7.65",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-popperjs.core-2.11.8",
+      "relatedSpdxElement": "SPDXRef-Package-flavorly.vanilla-components-0.7.65",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-v-calendar-3.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-flavorly.vanilla-components-0.7.65",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-headlessui.vue-1.7.22",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tanstack.vue-virtual-3.5.0",
+      "relatedSpdxElement": "SPDXRef-Package-headlessui.vue-1.7.22",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-string-width-5.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-string-width-4.2.3",
+      "relatedSpdxElement": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-7.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-wrap-ansi-8.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-wrap-ansi-7.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.set-array-1.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-jridgewell.gen-mapping-0.3.5",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.sourcemap-codec-1.4.15",
+      "relatedSpdxElement": "SPDXRef-Package-jridgewell.gen-mapping-0.3.5",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.trace-mapping-0.3.25",
+      "relatedSpdxElement": "SPDXRef-Package-jridgewell.gen-mapping-0.3.5",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.resolve-uri-3.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-jridgewell.trace-mapping-0.3.25",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.sourcemap-codec-1.4.15",
+      "relatedSpdxElement": "SPDXRef-Package-jridgewell.trace-mapping-0.3.25",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-nodelib.fs.stat-2.0.5",
+      "relatedSpdxElement": "SPDXRef-Package-nodelib.fs.scandir-2.1.5",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-run-parallel-1.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-nodelib.fs.scandir-2.1.5",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-nodelib.fs.scandir-2.1.5",
+      "relatedSpdxElement": "SPDXRef-Package-nodelib.fs.walk-1.2.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fastq-1.17.1",
+      "relatedSpdxElement": "SPDXRef-Package-nodelib.fs.walk-1.2.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.aspect-ratio-0.4.2",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.forms-0.5.7",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mini-svg-data-uri-1.4.4",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.forms-0.5.7",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lodash.castarray-4.4.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lodash.isplainobject-4.0.6",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lodash.merge-4.6.2",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-selector-parser-6.0.10",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss.typography-0.5.13",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-cssesc-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-selector-parser-6.0.10",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-util-deprecate-1.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-selector-parser-6.0.10",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-tanstack.vue-virtual-3.5.0",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tanstack.virtual-core-3.5.0",
+      "relatedSpdxElement": "SPDXRef-Package-tanstack.vue-virtual-3.5.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vite-6.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-vitejs.plugin-vue-5.2.1",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vitejs.plugin-vue-5.2.1",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-babel.parser-7.24.5",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-entities-4.5.0",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-estree-walker-2.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-source-map-js-1.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-dom-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-dom-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-babel.parser-7.24.5",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-estree-walker-2.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-magic-string-0.30.10",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-source-map-js-1.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-core-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-ssr-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-dom-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-ssr-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-dom-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.compiler-ssr-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.reactivity-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.runtime-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.reactivity-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.runtime-core-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-csstype-3.1.3",
+      "relatedSpdxElement": "SPDXRef-Package-vue.runtime-dom-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.runtime-dom-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.runtime-core-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.runtime-dom-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.server-renderer-3.4.27",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.server-renderer-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-ssr-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue.server-renderer-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-prop-types-15.8.1",
+      "relatedSpdxElement": "SPDXRef-Package-yaireo.tagify-4.26.5",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-react-18.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-yaireo.tagify-4.26.5",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-react-dom-18.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-yaireo.tagify-4.26.5",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-normalize-path-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-anymatch-3.1.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-2.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-anymatch-3.1.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-browserslist-4.23.0",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-caniuse-lite-1.0.30001620",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fraction.js-4.3.7",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-normalize-range-0.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picocolors-1.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-value-parser-4.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-autoprefixer-10.4.19",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-balanced-match-1.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-brace-expansion-2.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fill-range-7.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-braces-3.0.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-caniuse-lite-1.0.30001620",
+      "relatedSpdxElement": "SPDXRef-Package-browserslist-4.23.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-electron-to-chromium-1.4.774",
+      "relatedSpdxElement": "SPDXRef-Package-browserslist-4.23.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-node-releases-2.0.14",
+      "relatedSpdxElement": "SPDXRef-Package-browserslist-4.23.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-update-browserslist-db-1.0.16",
+      "relatedSpdxElement": "SPDXRef-Package-browserslist-4.23.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-anymatch-3.1.3",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-braces-3.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-glob-parent-5.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-binary-path-2.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-glob-4.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-normalize-path-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-readdirp-3.6.0",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fsevents-2.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-chokidar-3.6.0",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-glob-4.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-glob-parent-5.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-color-name-1.1.4",
+      "relatedSpdxElement": "SPDXRef-Package-color-convert-2.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-path-key-3.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-cross-spawn-7.0.6",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-shebang-command-2.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-cross-spawn-7.0.6",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-which-2.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-cross-spawn-7.0.6",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-babel.runtime-7.26.10",
+      "relatedSpdxElement": "SPDXRef-Package-date-fns-2.30.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-date-fns-2.30.0",
+      "relatedSpdxElement": "SPDXRef-Package-date-fns-tz-2.0.1",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-esbuild.darwin-arm64-0.25.0",
+      "relatedSpdxElement": "SPDXRef-Package-esbuild-0.25.0",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-nodelib.fs.stat-2.0.5",
+      "relatedSpdxElement": "SPDXRef-Package-fast-glob-3.3.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-nodelib.fs.walk-1.2.8",
+      "relatedSpdxElement": "SPDXRef-Package-fast-glob-3.3.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-glob-parent-5.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-fast-glob-3.3.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-merge2-1.4.1",
+      "relatedSpdxElement": "SPDXRef-Package-fast-glob-3.3.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-micromatch-4.0.8",
+      "relatedSpdxElement": "SPDXRef-Package-fast-glob-3.3.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-glob-4.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-glob-parent-5.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-reusify-1.0.4",
+      "relatedSpdxElement": "SPDXRef-Package-fastq-1.17.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-to-regex-range-5.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-fill-range-7.1.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-cross-spawn-7.0.6",
+      "relatedSpdxElement": "SPDXRef-Package-foreground-child-3.1.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-signal-exit-4.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-foreground-child-3.1.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-foreground-child-3.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-glob-10.3.15",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jackspeak-2.3.6",
+      "relatedSpdxElement": "SPDXRef-Package-glob-10.3.15",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-minimatch-9.0.4",
+      "relatedSpdxElement": "SPDXRef-Package-glob-10.3.15",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-minipass-7.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-glob-10.3.15",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-path-scurry-1.11.1",
+      "relatedSpdxElement": "SPDXRef-Package-glob-10.3.15",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-glob-4.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-glob-parent-6.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-function-bind-1.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-hasown-2.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-binary-extensions-2.3.0",
+      "relatedSpdxElement": "SPDXRef-Package-is-binary-path-2.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-hasown-2.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-is-core-module-2.13.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-extglob-2.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-is-glob-4.0.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-isaacs.cliui-8.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-jackspeak-2.3.6",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-pkgjs.parseargs-0.11.0",
+      "relatedSpdxElement": "SPDXRef-Package-jackspeak-2.3.6",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-js-tokens-4.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-loose-envify-1.4.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.sourcemap-codec-1.4.15",
+      "relatedSpdxElement": "SPDXRef-Package-magic-string-0.30.10",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-braces-3.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-micromatch-4.0.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-2.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-micromatch-4.0.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-brace-expansion-2.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-minimatch-9.0.4",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-any-promise-1.3.0",
+      "relatedSpdxElement": "SPDXRef-Package-mz-2.7.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-object-assign-4.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-mz-2.7.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-thenify-all-1.6.0",
+      "relatedSpdxElement": "SPDXRef-Package-mz-2.7.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lru-cache-10.2.2",
+      "relatedSpdxElement": "SPDXRef-Package-path-scurry-1.11.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-minipass-7.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-path-scurry-1.11.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-nanoid-3.3.8",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-8.5.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picocolors-1.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-8.5.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-source-map-js-1.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-8.5.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-import-15.1.0",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-value-parser-4.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-import-15.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-read-cache-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-import-15.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-resolve-1.22.8",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-import-15.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-js-4.0.1",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-camelcase-css-2.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-js-4.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-load-config-4.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lilconfig-3.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-load-config-4.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-yaml-2.4.2",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-load-config-4.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-nested-6.0.1",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-selector-parser-6.0.16",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-nested-6.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-cssesc-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-selector-parser-6.0.16",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-util-deprecate-1.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-postcss-selector-parser-6.0.16",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-loose-envify-1.4.0",
+      "relatedSpdxElement": "SPDXRef-Package-prop-types-15.8.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-object-assign-4.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-prop-types-15.8.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-react-is-16.13.1",
+      "relatedSpdxElement": "SPDXRef-Package-prop-types-15.8.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-loose-envify-1.4.0",
+      "relatedSpdxElement": "SPDXRef-Package-react-18.3.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-react-18.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-react-dom-18.3.1",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-loose-envify-1.4.0",
+      "relatedSpdxElement": "SPDXRef-Package-react-dom-18.3.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-scheduler-0.23.2",
+      "relatedSpdxElement": "SPDXRef-Package-react-dom-18.3.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-pify-2.3.0",
+      "relatedSpdxElement": "SPDXRef-Package-read-cache-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-2.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-readdirp-3.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-core-module-2.13.1",
+      "relatedSpdxElement": "SPDXRef-Package-resolve-1.22.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-path-parse-1.0.7",
+      "relatedSpdxElement": "SPDXRef-Package-resolve-1.22.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-supports-preserve-symlinks-flag-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-resolve-1.22.8",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-types.estree-1.0.7",
+      "relatedSpdxElement": "SPDXRef-Package-rollup-4.40.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fsevents-2.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-rollup-4.40.1",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-rollup.rollup-darwin-arm64-4.40.1",
+      "relatedSpdxElement": "SPDXRef-Package-rollup-4.40.1",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-queue-microtask-1.2.3",
+      "relatedSpdxElement": "SPDXRef-Package-run-parallel-1.2.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-loose-envify-1.4.0",
+      "relatedSpdxElement": "SPDXRef-Package-scheduler-0.23.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-shebang-regex-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-shebang-command-2.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-eastasianwidth-0.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-5.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-emoji-regex-9.2.2",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-5.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-7.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-5.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-emoji-regex-8.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-4.2.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-fullwidth-code-point-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-4.2.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-4.2.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ansi-regex-5.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ansi-regex-6.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-strip-ansi-7.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ansi-regex-5.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jridgewell.gen-mapping-0.3.5",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-commander-4.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-glob-10.3.15",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lines-and-columns-1.2.4",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-mz-2.7.0",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-pirates-4.0.6",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ts-interface-checker-0.1.13",
+      "relatedSpdxElement": "SPDXRef-Package-sucrase-3.35.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-alloc.quick-lru-5.2.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-arg-5.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-chokidar-3.6.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-didyoumean-1.2.2",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-dlv-1.1.3",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fast-glob-3.3.2",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-glob-parent-6.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-glob-4.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jiti-1.21.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lilconfig-2.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-micromatch-4.0.8",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-normalize-path-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-object-hash-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picocolors-1.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-import-15.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-js-4.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-load-config-4.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-nested-6.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-selector-parser-6.0.16",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-resolve-1.22.8",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-sucrase-3.35.0",
+      "relatedSpdxElement": "SPDXRef-Package-tailwindcss-3.4.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-any-promise-1.3.0",
+      "relatedSpdxElement": "SPDXRef-Package-thenify-3.3.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-thenify-3.3.1",
+      "relatedSpdxElement": "SPDXRef-Package-thenify-all-1.6.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fdir-6.4.4",
+      "relatedSpdxElement": "SPDXRef-Package-tinyglobby-0.2.13",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-4.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-tinyglobby-0.2.13",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-4.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-fdir-6.4.4",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-number-7.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-to-regex-range-5.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-browserslist-4.23.0",
+      "relatedSpdxElement": "SPDXRef-Package-update-browserslist-db-1.0.16",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-escalade-3.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-update-browserslist-db-1.0.16",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picocolors-1.1.1",
+      "relatedSpdxElement": "SPDXRef-Package-update-browserslist-db-1.0.16",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-popperjs.core-2.11.8",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-types.lodash-4.17.4",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-types.resize-observer-browser-0.1.11",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-date-fns-2.30.0",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-date-fns-tz-2.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-lodash-4.17.21",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-screen-utils-1.0.0-beta.13",
+      "relatedSpdxElement": "SPDXRef-Package-v-calendar-3.1.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-jiti-1.21.0",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-yaml-2.4.2",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-esbuild-0.25.0",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fdir-6.4.4",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-4.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-postcss-8.5.3",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-rollup-4.40.1",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-tinyglobby-0.2.13",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-fsevents-2.3.3",
+      "relatedSpdxElement": "SPDXRef-Package-vite-6.3.3",
+      "relationshipType": "OPTIONAL_DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-picomatch-4.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-fdir-6.4.4",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.shared-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-dom-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.compiler-sfc-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.runtime-dom-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue.server-renderer-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue-3.4.27",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-vue-3.4.27",
+      "relatedSpdxElement": "SPDXRef-Package-vue-screen-utils-1.0.0-beta.13",
+      "relationshipType": "PREREQUISITE_FOR"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-isexe-2.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-which-2.0.2",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ansi-styles-6.2.1",
+      "relatedSpdxElement": "SPDXRef-Package-wrap-ansi-8.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-string-width-5.1.2",
+      "relatedSpdxElement": "SPDXRef-Package-wrap-ansi-8.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-7.1.0",
+      "relatedSpdxElement": "SPDXRef-Package-wrap-ansi-8.1.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ansi-styles-4.3.0",
+      "relatedSpdxElement": "SPDXRef-Package-wrap-ansi-7.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-string-width-4.2.3",
+      "relatedSpdxElement": "SPDXRef-Package-wrap-ansi-7.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-wrap-ansi-7.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-color-convert-2.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-ansi-styles-4.3.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-emoji-regex-8.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-4.2.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-is-fullwidth-code-point-3.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-4.2.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-string-width-4.2.3",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-ansi-regex-5.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-strip-ansi-6.0.1",
+      "relationshipType": "DEPENDENCY_OF"
+    }
+  ]
+}

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -133,7 +133,7 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 
 	// Here we build the context that will be common for all policies as defined
 	// in the policy set.
-	evalContextValues, err := ampel.impl.AssembleEvalContextValues(ctx, opts, policySet.Common.Context)
+	evalContextValues, err := ampel.impl.AssembleEvalContextValues(ctx, opts, policySet.GetCommon().GetContext())
 	if err != nil {
 		return nil, fmt.Errorf("assembling policy context: %w", err)
 	}

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -8,16 +8,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"slices"
-	"time"
 
 	"github.com/carabiner-dev/attestation"
 	papi "github.com/carabiner-dev/policy/api/v1"
 	gointoto "github.com/in-toto/attestation/go/v1"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/carabiner-dev/ampel/pkg/evaluator/evalcontext"
+	"github.com/carabiner-dev/ampel/pkg/evaluator"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
 type PolicyError struct {
@@ -40,57 +40,9 @@ func (ampel *Ampel) Verify(
 		}
 		return res, nil
 	case *papi.PolicySet:
-		rs := &papi.ResultSet{
-			Id:        v.Id,
-			Meta:      v.Meta,
-			DateStart: timestamppb.Now(),
-			Subject: &gointoto.ResourceDescriptor{
-				Name:   subject.GetName(),
-				Uri:    subject.GetUri(),
-				Digest: subject.GetDigest(),
-			},
-			Results: []*papi.Result{},
-		}
-
-		// If the policyset has a context defined, load the definition in the
-		// (golang) context to send it down the wire to each policy evaluation.
-		if v.GetCommon() != nil && v.GetCommon().GetContext() != nil {
-			evalContext, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
-			if !ok {
-				evalContext = evalcontext.EvaluationContext{}
-			}
-			evalContext.Context = v.GetCommon().GetContext()
-			ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, evalContext)
-		}
-
-		for i, p := range v.Policies {
-			if len(opts.Policies) > 0 && !slices.Contains(opts.Policies, p.Id) {
-				continue
-			}
-			res, err := ampel.VerifySubjectWithPolicy(ctx, opts, p, subject)
-			if err != nil {
-				return nil, fmt.Errorf("evaluating policy #%d: %w", i, err)
-			}
-			rs.Results = append(rs.Results, res)
-		}
-		if err := rs.Assert(); err != nil {
-			return nil, fmt.Errorf("asserting ResultSet: %w", err)
-		}
-
-		// Fail the evaluation if the PolicySet is expired:
-		if opts.EnforceExpiration && v.GetMeta() != nil &&
-			v.GetMeta().GetExpiration() != nil &&
-			v.GetMeta().GetExpiration().AsTime().Before(time.Now()) {
-			// TODO(puerco): The ResultSet object does not have a way to set
-			// error messages, we have no way to inform the user that the
-			// PolicySet is expired.
-			//
-			// See https://github.com/carabiner-dev/policy/issues/28
-			logrus.Debugf(
-				"FAIL: PolicySet expired on %s",
-				v.GetMeta().GetExpiration().AsTime().Format(time.UnixDate),
-			)
-			rs.Status = papi.StatusFAIL
+		rs, err := ampel.VerifySubjectWithPolicySet(ctx, opts, v, subject)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating policy set: %w", err)
 		}
 		return rs, nil
 	case []*papi.PolicySet:
@@ -111,6 +63,96 @@ func (ampel *Ampel) Verify(
 	default:
 		return nil, fmt.Errorf("did not get a policy or policy set")
 	}
+}
+
+// VerifySubjectWithPolicySet runs a subject through a policy set.
+func (ampel *Ampel) VerifySubjectWithPolicySet(
+	ctx context.Context, opts *VerificationOptions, policySet *papi.PolicySet, subject attestation.Subject,
+) (*papi.ResultSet, error) {
+	// This is the resultSet to be returned
+	resultSet := &papi.ResultSet{
+		Id:        policySet.GetId(),
+		Meta:      policySet.GetMeta(),
+		DateStart: timestamppb.Now(),
+		Subject: &gointoto.ResourceDescriptor{
+			Name:   subject.GetName(),
+			Uri:    subject.GetUri(),
+			Digest: subject.GetDigest(),
+		},
+		Results: []*papi.Result{},
+	}
+
+	// Check if the policy is viable before
+	if err := ampel.impl.CheckPolicySet(ctx, opts, policySet); err != nil {
+		// If the policy failed validation, don't err. Fail the policy
+		perr := PolicyError{}
+		if errors.As(err, &perr) {
+			return failPolicySetWithError(resultSet, perr), nil
+		}
+		// ..else something broke
+		return nil, fmt.Errorf("checking policy: %w", err)
+	}
+
+	// Build the required evaluators
+	evaluators := map[class.Class]evaluator.Evaluator{}
+	// TODO(puerco): We should BuildEvaluators to get the already built evaluators
+	for _, p := range policySet.Policies {
+		policyEvals, err := ampel.impl.BuildEvaluators(opts, p)
+		if err != nil {
+			return nil, fmt.Errorf("building evaluators: %w", err)
+		}
+		maps.Insert(evaluators, maps.All(policyEvals))
+	}
+
+	// Parse any extra attestation files defined in the options
+	atts, err := ampel.impl.ParseAttestations(ctx, opts.AttestationFiles)
+	if err != nil {
+		return nil, fmt.Errorf("parsing single attestations: %w", err)
+	}
+
+	// Here we build the context that will be common for all policies as defined
+	// in the policy set.
+	evalContext, err := ampel.impl.AssembleEvalContext(ctx, opts, policySet.Common.Context)
+	if err != nil {
+		return nil, fmt.Errorf("assembling policy context: %w", err)
+	}
+
+	// Now process the chain
+	// FIXME: The chain (second arg) needs to be passed along and composed in
+	// the policy eval.
+	subjects, _, policyFail, err := ampel.impl.ProcessPolicySetChainedSubjects(
+		ctx, opts, evaluators, ampel.Collector, policySet, evalContext, subject, atts,
+	)
+	if err != nil {
+		// If policyFail is true, then we don't return an error but rather
+		// a policy fail result based on the error
+		if policyFail {
+			return failPolicySetWithError(resultSet, err), nil
+		}
+		return nil, fmt.Errorf("processing chained subject: %w", err)
+	}
+
+	// Now cycle each policy....
+	for i, pcy := range policySet.GetPolicies() {
+		// ... and evaluate against each subject
+		for _, subsubject := range subjects {
+			res, err := ampel.VerifySubjectWithPolicy(ctx, opts, pcy, subsubject)
+			if err != nil {
+				return nil, fmt.Errorf("evaluating policy #%d: %w", i, err)
+			}
+			resultSet.Results = append(resultSet.Results, res)
+		}
+	}
+
+	resultSet.DateEnd = timestamppb.Now()
+
+	// Assert the policy set
+	if err := resultSet.Assert(); err != nil {
+		return nil, fmt.Errorf("asserting ResultSet: %w", err)
+	}
+
+	// Succcess!
+	return resultSet, nil
 }
 
 // VerifySubjectWithPolicy verifies a subject against a single policy
@@ -140,7 +182,7 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 		return nil, fmt.Errorf("parsing single attestations: %w", err)
 	}
 
-	evalContext, err := ampel.impl.AssemblePolicyEvalContext(ctx, opts, policy)
+	evalContext, err := ampel.impl.AssembleEvalContext(ctx, opts, policy.GetContext())
 	if err != nil {
 		return nil, fmt.Errorf("assembling policy context: %w", err)
 	}
@@ -251,6 +293,23 @@ func (ampel *Ampel) AttestResults(w io.Writer, results papi.Results) error {
 	default:
 		return fmt.Errorf("results are not result or resultset")
 	}
+}
+
+// failPolicySetWithError completes a policy set and sets the specified error
+func failPolicySetWithError(set *papi.ResultSet, err error) *papi.ResultSet {
+	guidance := ""
+	//nolint:errorlint
+	if pe, ok := err.(PolicyError); ok {
+		guidance = pe.Guidance
+	}
+
+	set.Error = &papi.Error{
+		Message:  err.Error(),
+		Guidance: guidance,
+	}
+
+	set.DateEnd = timestamppb.Now()
+	return set
 }
 
 // failPolicyWithError returns a failed status result for the policicy where all

--- a/pkg/verifier/verifier_test.go
+++ b/pkg/verifier/verifier_test.go
@@ -62,7 +62,9 @@ func TestPolicySetExpiration(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ampel := &Ampel{}
+			ampel := &Ampel{
+				impl: &defaultIplementation{},
+			}
 			res, err := ampel.Verify(t.Context(), tt.opts, tt.policySet, sub)
 			if tt.mustErr {
 				require.Error(t, err)


### PR DESCRIPTION
With ths patch, ampel now supports verfying a subject with a full policy set. Most improtantly, we now have the capability to define chained subjects at the policyset level, this unleashes verificaton of subcomponents by applying the loaded policy to a list of subjects resulting from a selector execution 🚀 🚀 🚀 🚀 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>