### PR TITLE
Parallel evaluation support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
-	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
+	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.0.9 // indirect

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -134,6 +134,10 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSliceVar(
 		&o.PolicyKeyPaths, "policy-key", []string{}, "path to public keys to verify policies",
 	)
+
+	cmd.PersistentFlags().Int8Var(
+		&o.ParallelWorkers, "workers", verifier.DefaultVerificationOptions.ParallelWorkers, "number of evaluation threads to run in parallel",
+	)
 }
 
 func parseHash(estring string) (algo, value string, err error) {
@@ -208,6 +212,10 @@ func (o *verifyOptions) Validate() error {
 		if err := render.GetDriverBytType(o.Format); err != nil {
 			errs = append(errs, errors.New("invalid format"))
 		}
+	}
+
+	if o.ParallelWorkers <= 0 {
+		errs = append(errs, errors.New("parallel workers must be larger than 0"))
 	}
 
 	if len(o.AttestationFiles) == 0 && len(o.Collectors) == 0 {

--- a/pkg/evaluator/options/options.go
+++ b/pkg/evaluator/options/options.go
@@ -7,10 +7,12 @@ package options
 // the evaluator when executing the policy tenets.
 type EvaluatorOptions struct {
 	LoadDefaultPlugins bool
+	ParallelWorkers    int8
 }
 
 var Default = EvaluatorOptions{
 	LoadDefaultPlugins: true,
+	ParallelWorkers:    4,
 }
 
 type OptFunc func(*EvaluatorOptions) error

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -159,7 +159,7 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 	ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, evalContext)
 
 	var mtx sync.Mutex
-	t := throttler.New(4, len(policySet.Policies)*len(subjects))
+	t := throttler.New(int(opts.ParallelWorkers), len(policySet.Policies)*len(subjects))
 	// Now cycle each policy....
 	for i, pcy := range policySet.GetPolicies() {
 		// ... and evaluate against each subject

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -10,10 +10,12 @@ import (
 	"io"
 	"maps"
 	"slices"
+	"sync"
 
 	"github.com/carabiner-dev/attestation"
 	papi "github.com/carabiner-dev/policy/api/v1"
 	gointoto "github.com/in-toto/attestation/go/v1"
+	"github.com/nozzle/throttler"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/carabiner-dev/ampel/pkg/evaluator"
@@ -156,15 +158,27 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 	// Rebuild the go context as we are now shipping the chained subjects.
 	ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, evalContext)
 
+	var mtx sync.Mutex
+	t := throttler.New(4, len(policySet.Policies)*len(subjects))
 	// Now cycle each policy....
 	for i, pcy := range policySet.GetPolicies() {
 		// ... and evaluate against each subject
 		for _, subsubject := range subjects {
-			res, err := ampel.VerifySubjectWithPolicy(ctx, opts, pcy, subsubject)
-			if err != nil {
-				return nil, fmt.Errorf("evaluating policy #%d: %w", i, err)
+			go func() {
+				res, err := ampel.VerifySubjectWithPolicy(ctx, opts, pcy, subsubject)
+				if err != nil {
+					t.Done(fmt.Errorf("evaluating policy #%d: %w", i, err))
+					return
+				}
+				mtx.Lock()
+				resultSet.Results = append(resultSet.Results, res)
+				mtx.Unlock()
+				t.Done(nil)
+			}()
+			// Break and return on the first error
+			if numErrs := t.Throttle(); numErrs != 0 {
+				return nil, t.Err()
 			}
-			resultSet.Results = append(resultSet.Results, res)
 		}
 	}
 


### PR DESCRIPTION
This PR adds the patch to run policy evaluations in parallel.

When evaluating a policy set, ampel can now run the policy evaluations in parallel. The number of parallel threads can be controlled with the --workers flag.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>