### PR TITLE
Avoid reparsing attestations

### DIFF
--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -160,7 +160,9 @@ func TestEvaluateChain(t *testing.T) {
 			t.Parallel()
 
 			// Load the attestations required by the test
-			attestations, err := di.ParseAttestations(t.Context(), tt.attestationPaths)
+			opts := &DefaultVerificationOptions
+			opts.AttestationFiles = tt.attestationPaths
+			attestations, err := di.ParseAttestations(t.Context(), opts)
 			require.NoError(t, err)
 
 			// Check if there is an evaluator foe the link's runtime

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -25,6 +25,10 @@ type VerificationOptions struct {
 	// AttestationFiles are additional attestations passed manually
 	AttestationFiles []string
 
+	// Attestations are preparsed attestations the policy evaluator receives
+	// when called, usually preparsed by the PolicySet evaluator.
+	Attestations []attestation.Envelope
+
 	// DefaultEvaluator is the default evaluator we use when a policy does
 	// not define one.
 	DefaultEvaluator class.Class


### PR DESCRIPTION
This PR modifies the verifier implementation to support passing parsed attestations to the policy evaluator to avoid reparsing them.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev>