### PR TITLE
Initial Output Support for SLSA VSA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/carabiner-dev/ampel
 go 1.24.6
 
 require (
-	github.com/carabiner-dev/attestation v0.2.0
-	github.com/carabiner-dev/collector v0.2.2
+	github.com/carabiner-dev/attestation v0.2.1-0.20251001041625-bb99ace51432
+	github.com/carabiner-dev/collector v0.2.3-0.20250930230641-f92162e029c6
 	github.com/carabiner-dev/command v0.1.1
 	github.com/carabiner-dev/hasher v0.2.2
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.2.1-0.20250923010748-bd6ba141f214
+	github.com/carabiner-dev/policy v0.2.1-0.20251001043056-48cc1759d7d2
 	github.com/fatih/color v1.18.0
 	github.com/google/cel-go v0.26.1
 	github.com/in-toto/attestation v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -724,12 +724,8 @@ github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
-github.com/carabiner-dev/attestation v0.2.0 h1:vEqAIapcHjIoEQad9GrKtEx2czeu7t4cun+1bCEtN1o=
-github.com/carabiner-dev/attestation v0.2.0/go.mod h1:dLPe3DPL/0YpKJpNDCQJZdtkZIuWTAH1G0N8V5LJ41c=
 github.com/carabiner-dev/attestation v0.2.1-0.20251001041625-bb99ace51432 h1:0NS1D5dXcH4UCoo14agPpl8WE2nuTsvr/L3KzNLUGQ8=
 github.com/carabiner-dev/attestation v0.2.1-0.20251001041625-bb99ace51432/go.mod h1:dLPe3DPL/0YpKJpNDCQJZdtkZIuWTAH1G0N8V5LJ41c=
-github.com/carabiner-dev/collector v0.2.2 h1:nsrFu2YNCMDYyyioW+qfslDpSr3BefEw5C+lp1XWGTc=
-github.com/carabiner-dev/collector v0.2.2/go.mod h1:RZIZVqNuShBQOpFyzN3TwsXKrnpxpzEV81PBsBgLnQs=
 github.com/carabiner-dev/collector v0.2.3-0.20250930230641-f92162e029c6 h1:rket0y1TJNmsWbkSgO0vHeHIlbhzRyPhMJng3OikEOQ=
 github.com/carabiner-dev/collector v0.2.3-0.20250930230641-f92162e029c6/go.mod h1:RZIZVqNuShBQOpFyzN3TwsXKrnpxpzEV81PBsBgLnQs=
 github.com/carabiner-dev/command v0.1.1 h1:Vl68ekV2YYtrLukVpTX20YC9aDS37k2EYKYUZbRsVP4=
@@ -746,10 +742,6 @@ github.com/carabiner-dev/openeox v0.0.0-20250606202227-fd40810cda47 h1:UTr5vQ7nS
 github.com/carabiner-dev/openeox v0.0.0-20250606202227-fd40810cda47/go.mod h1:40KVT1ee6L8VoWT44RvAQ0AtG91MFr5/zBzTmNiXQWY=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.2.1-0.20250923010748-bd6ba141f214 h1:S+OXyLM8guS19QWf0RuZ2GtYNstxMbERqhljfZulI7Y=
-github.com/carabiner-dev/policy v0.2.1-0.20250923010748-bd6ba141f214/go.mod h1:87aK4EjCvxcF/aJ+EwNyRINCsbtCXKtBG7c4dBuf3Y4=
-github.com/carabiner-dev/policy v0.2.1-0.20251001013941-3f553942a7c2 h1:+oPpAd5iYP1BWDjH7HnTnPKjHbJQWaNKE1qLryYfZw0=
-github.com/carabiner-dev/policy v0.2.1-0.20251001013941-3f553942a7c2/go.mod h1:Vy9V3jGv3huEOX3at+t2kRX/FoG3S/sdRhQT5e/rWxI=
 github.com/carabiner-dev/policy v0.2.1-0.20251001043056-48cc1759d7d2 h1:VSXRlY6i62BqysdKSehqX/Mtm+ET7UaBE2DUH8P2+Ms=
 github.com/carabiner-dev/policy v0.2.1-0.20251001043056-48cc1759d7d2/go.mod h1:Vy9V3jGv3huEOX3at+t2kRX/FoG3S/sdRhQT5e/rWxI=
 github.com/carabiner-dev/signer v0.2.1 h1:qNRzDFnG+uLWHPTIC36hrh572bs66hYhBOwkGLcsq1I=

--- a/go.sum
+++ b/go.sum
@@ -726,8 +726,12 @@ github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oM
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/carabiner-dev/attestation v0.2.0 h1:vEqAIapcHjIoEQad9GrKtEx2czeu7t4cun+1bCEtN1o=
 github.com/carabiner-dev/attestation v0.2.0/go.mod h1:dLPe3DPL/0YpKJpNDCQJZdtkZIuWTAH1G0N8V5LJ41c=
+github.com/carabiner-dev/attestation v0.2.1-0.20251001041625-bb99ace51432 h1:0NS1D5dXcH4UCoo14agPpl8WE2nuTsvr/L3KzNLUGQ8=
+github.com/carabiner-dev/attestation v0.2.1-0.20251001041625-bb99ace51432/go.mod h1:dLPe3DPL/0YpKJpNDCQJZdtkZIuWTAH1G0N8V5LJ41c=
 github.com/carabiner-dev/collector v0.2.2 h1:nsrFu2YNCMDYyyioW+qfslDpSr3BefEw5C+lp1XWGTc=
 github.com/carabiner-dev/collector v0.2.2/go.mod h1:RZIZVqNuShBQOpFyzN3TwsXKrnpxpzEV81PBsBgLnQs=
+github.com/carabiner-dev/collector v0.2.3-0.20250930230641-f92162e029c6 h1:rket0y1TJNmsWbkSgO0vHeHIlbhzRyPhMJng3OikEOQ=
+github.com/carabiner-dev/collector v0.2.3-0.20250930230641-f92162e029c6/go.mod h1:RZIZVqNuShBQOpFyzN3TwsXKrnpxpzEV81PBsBgLnQs=
 github.com/carabiner-dev/command v0.1.1 h1:Vl68ekV2YYtrLukVpTX20YC9aDS37k2EYKYUZbRsVP4=
 github.com/carabiner-dev/command v0.1.1/go.mod h1:svMEE2UmWE6ITNQ1HeFS/MFh/LfhFVDSWsRwRmQzWQ8=
 github.com/carabiner-dev/ghrfs v0.3.2 h1:SBxmC7H2efJzebzrpZNsXB/03eZTeBORguXvKftpif4=
@@ -744,6 +748,10 @@ github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
 github.com/carabiner-dev/policy v0.2.1-0.20250923010748-bd6ba141f214 h1:S+OXyLM8guS19QWf0RuZ2GtYNstxMbERqhljfZulI7Y=
 github.com/carabiner-dev/policy v0.2.1-0.20250923010748-bd6ba141f214/go.mod h1:87aK4EjCvxcF/aJ+EwNyRINCsbtCXKtBG7c4dBuf3Y4=
+github.com/carabiner-dev/policy v0.2.1-0.20251001013941-3f553942a7c2 h1:+oPpAd5iYP1BWDjH7HnTnPKjHbJQWaNKE1qLryYfZw0=
+github.com/carabiner-dev/policy v0.2.1-0.20251001013941-3f553942a7c2/go.mod h1:Vy9V3jGv3huEOX3at+t2kRX/FoG3S/sdRhQT5e/rWxI=
+github.com/carabiner-dev/policy v0.2.1-0.20251001043056-48cc1759d7d2 h1:VSXRlY6i62BqysdKSehqX/Mtm+ET7UaBE2DUH8P2+Ms=
+github.com/carabiner-dev/policy v0.2.1-0.20251001043056-48cc1759d7d2/go.mod h1:Vy9V3jGv3huEOX3at+t2kRX/FoG3S/sdRhQT5e/rWxI=
 github.com/carabiner-dev/signer v0.2.1 h1:qNRzDFnG+uLWHPTIC36hrh572bs66hYhBOwkGLcsq1I=
 github.com/carabiner-dev/signer v0.2.1/go.mod h1:VvN+m//2sBUQuZUnVie0WpIy+D9+v8+eJDoMG8nugA8=
 github.com/carabiner-dev/vcslocator v0.3.2 h1:/rfhELG1mvqFq0xi8LQSkfpAVoQDCGlWoL6J5tX9Inw=

--- a/internal/drivers/vsa/driver.go
+++ b/internal/drivers/vsa/driver.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package vsa
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/carabiner-dev/attestation"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	v1 "github.com/in-toto/attestation/go/predicates/vsa/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const ampelId = "https://carabiner.dev/ampel"
+
+// slsaVersion version used as base to compute the VSA
+const slsaVersion = "1.1"
+
+func New() *Driver {
+	return &Driver{}
+}
+
+type Driver struct{}
+
+func renderAttestation(w io.Writer, att *v1.VerificationSummary) error {
+	jsonData, err := protojson.Marshal(att)
+	if err != nil {
+		return fmt.Errorf("marshaling vsa: %w", err)
+	}
+
+	if _, err := w.Write(jsonData); err != nil {
+		return fmt.Errorf("writing VSA data: %w", err)
+	}
+	return nil
+}
+
+// resultStringToSLSAResult translates from our policy evalt status strings to SLSA's
+func resultStringToSLSAResult(status string) string {
+	switch status {
+	case papi.StatusPASS, papi.StatusSOFTFAIL:
+		return "PASSED"
+	case papi.StatusFAIL:
+		return "FAILED"
+	default:
+		return ""
+	}
+}
+
+// RenderResultSet renders a results set in a VSA
+func (d *Driver) RenderResultSet(w io.Writer, set *papi.ResultSet) error {
+	vsaData := &v1.VerificationSummary{
+		Verifier: &v1.VerificationSummary_Verifier{
+			Id: ampelId,
+		},
+		TimeVerified: set.GetDateEnd(),
+		ResourceUri:  set.GetSubject().GetUri(),
+		Policy: &v1.VerificationSummary_Policy{
+			Uri:    set.GetPolicySet().GetSourceURL(),
+			Digest: set.GetPolicySet().GetLocation().GetDigest(),
+		},
+		InputAttestations:  []*v1.VerificationSummary_InputAttestation{},
+		VerificationResult: resultStringToSLSAResult(set.GetStatus()),
+		VerifiedLevels:     []string{},
+		DependencyLevels:   nil,
+		SlsaVersion:        slsaVersion,
+	}
+
+	inputs := []attestation.Subject{}
+	depLevels := map[string]uint64{}
+
+	for _, a := range set.Results {
+		for _, er := range a.EvalResults {
+			for _, stRef := range er.GetStatements() {
+				if !hasSubject(inputs, stRef.GetAttestation()) {
+					inputs = append(inputs, stRef.GetAttestation())
+				}
+			}
+		}
+
+		// Collect any SLSA levels into the dep count
+		if a.GetStatus() != papi.StatusPASS {
+			continue
+		}
+		for _, ctl := range a.GetMeta().GetControls() {
+			// Compute the label from the control
+			if ctl.Id == "" {
+				continue
+			}
+			label := ctl.Label()
+			label = strings.ReplaceAll(label, "-", "_")
+			if !strings.HasPrefix(label, "SLSA_") {
+				continue
+			}
+
+			// Here, we add the level to the verified levels when the result
+			// subject matches the policyset subject. If not, then we assume the
+			// policyset was chained to verify dependencies.
+			if attestation.SubjectsMatch(set.GetSubject(), a.GetSubject()) {
+				if !slices.Contains(vsaData.VerifiedLevels, label) {
+					vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
+				}
+			} else {
+				depLevels[label]++
+			}
+		}
+	}
+	if len(depLevels) > 0 {
+		vsaData.DependencyLevels = depLevels
+	}
+
+	vsaData.InputAttestations = subjectsToSummaryInputs(inputs)
+	return renderAttestation(w, vsaData)
+}
+
+// RenderResult renders a policy evaluation result into a VSA
+func (d *Driver) RenderResult(w io.Writer, result *papi.Result) error {
+	vsaData := &v1.VerificationSummary{
+		Verifier: &v1.VerificationSummary_Verifier{
+			Id: ampelId,
+		},
+		TimeVerified: result.GetDateEnd(),
+		ResourceUri:  result.GetSubject().GetUri(),
+		Policy: &v1.VerificationSummary_Policy{
+			Uri:    result.GetPolicy().GetLocation().GetUri(),
+			Digest: result.GetPolicy().GetLocation().GetDigest(),
+		},
+		// Populated later
+		InputAttestations:  []*v1.VerificationSummary_InputAttestation{},
+		VerificationResult: resultStringToSLSAResult(result.GetStatus()),
+		VerifiedLevels:     []string{},
+		DependencyLevels:   nil,
+		SlsaVersion:        slsaVersion,
+	}
+
+	// Add the input attestations recorded in the result
+	inputs := []attestation.Subject{}
+	for _, er := range result.EvalResults {
+		// Add the statements to the collection
+		for _, stRef := range er.GetStatements() {
+			if !hasSubject(inputs, stRef.GetAttestation()) {
+				inputs = append(inputs, stRef.GetAttestation())
+			}
+		}
+	}
+	vsaData.InputAttestations = subjectsToSummaryInputs(inputs)
+
+	return renderAttestation(w, vsaData)
+}
+
+func subjectsToSummaryInputs(inputs []attestation.Subject) []*v1.VerificationSummary_InputAttestation {
+	ret := []*v1.VerificationSummary_InputAttestation{}
+	for _, s := range inputs {
+		i := &v1.VerificationSummary_InputAttestation{
+			Uri:    s.GetUri(),
+			Digest: s.GetDigest(),
+		}
+		ret = append(ret, i)
+	}
+	if len(ret) == 0 {
+		return nil
+	}
+	return ret
+}
+
+func hasSubject(haystack []attestation.Subject, needle attestation.Subject) bool {
+	for _, sut := range haystack {
+		if attestation.SubjectsMatch(sut, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/drivers/vsa/driver.go
+++ b/internal/drivers/vsa/driver.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-const ampelId = "https://carabiner.dev/ampel"
+const ampelId = "https://carabiner.dev/ampel@v1"
 
 // slsaVersion version used as base to compute the VSA
 const slsaVersion = "1.1"
@@ -134,6 +134,15 @@ func (d *Driver) RenderResult(w io.Writer, result *papi.Result) error {
 		VerifiedLevels:     []string{},
 		DependencyLevels:   nil,
 		SlsaVersion:        slsaVersion,
+	}
+
+	// Add the verified level if its a slsa control
+	for _, ctl := range result.GetMeta().GetControls() {
+		label := strings.ReplaceAll(ctl.Label(), "-", "_")
+		if !strings.HasPrefix(label, "SLSA_") {
+			continue
+		}
+		vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
 	}
 
 	// Add the input attestations recorded in the result

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -14,6 +14,7 @@ import (
 	"github.com/carabiner-dev/ampel/internal/drivers/html"
 	"github.com/carabiner-dev/ampel/internal/drivers/markdown"
 	"github.com/carabiner-dev/ampel/internal/drivers/tty"
+	"github.com/carabiner-dev/ampel/internal/drivers/vsa"
 )
 
 type driversList map[string]Driver
@@ -25,10 +26,11 @@ var (
 
 func LoadDefaultDrivers() {
 	drMtx.Lock()
-	drivers["tty"] = tty.New()
-	drivers["markdown"] = markdown.New()
-	drivers["html"] = html.New()
 	drivers["attestation"] = attester.New()
+	drivers["html"] = html.New()
+	drivers["markdown"] = markdown.New()
+	drivers["tty"] = tty.New()
+	drivers["vsa"] = vsa.New()
 	drMtx.Unlock()
 }
 


### PR DESCRIPTION
This PR adds support to output the evaluation results in a SLSA VSA attestation.

To fully use it, policies need to refernce SLSA in their framework section and pass `--format=vsa` in the output

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>