### PR TITLE
Improve vex matching

### DIFF
--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -130,7 +130,7 @@ func TestIndexStatements(t *testing.T) {
 			si := &StatementIndex{}
 			si.IndexStatements(list)
 
-			require.Len(t, si.ProdIndex, 5)
+			require.Len(t, si.ProdIndex, 12)
 			require.Len(t, si.VulnIndex, 4)
 			require.Len(t, si.SubIndex, 4)
 		})


### PR DESCRIPTION
This PR adds two changes to improve VEX matching in the internal transformer:

1. The synthesized product the tranformer creates from the subject data now adds data from the URI
2. The vex indexer now matches on variations of the hashes with intoto and openvex variantes, we now also index and match on the product ID.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@carabiner.dev> 