### PR TITLE
Add VSA as side-attestation format

### DIFF
--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -79,6 +79,10 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 		&o.AttestResults, "attest-results", o.AttestResults, "write an attestation with the evaluation results to --results-path",
 	)
 
+	cmd.PersistentFlags().StringVar(
+		&o.AttestFormat, "attest-format", verifier.DefaultVerificationOptions.AttestFormat, fmt.Sprintf("format used when attest-results is true %v", verifier.ResultsAttestationFormats),
+	)
+
 	cmd.PersistentFlags().StringSliceVarP(
 		&o.ContextStringVals, "context", "x", []string{}, "evaluation context value definitions",
 	)
@@ -197,7 +201,9 @@ func (o *verifyOptions) LoadPublicKeys() error {
 }
 
 func (o *verifyOptions) Validate() error {
-	errs := []error{}
+	errs := []error{
+		o.VerificationOptions.Validate(),
+	}
 	if o.SubjectFile == "" && o.SubjectHash == "" {
 		errs = append(errs, fmt.Errorf("no subject specified (use --subject, --subject-file or --subject-hash)"))
 	}

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -374,16 +374,8 @@ using a collector.
 				return fmt.Errorf("running subject verification: %w", err)
 			}
 
-			// Generate the results attestation
-			if opts.AttestResults {
-				attFile, err := os.Create(opts.ResultsAttestationPath)
-				if err != nil {
-					return fmt.Errorf("unable to open results attestation path")
-				}
-
-				if err := ampel.AttestResults(attFile, results); err != nil {
-					return fmt.Errorf("writing results attestation: %w", err)
-				}
+			if err := attestResults(&opts, ampel, results); err != nil {
+				return fmt.Errorf("attesting results: %w", err)
 			}
 
 			eng := render.NewEngine()
@@ -418,6 +410,43 @@ using a collector.
 
 	opts.AddFlags(evalCmd)
 	parentCmd.AddCommand(evalCmd)
+}
+
+func attestResults(opts *verifyOptions, ampel *verifier.Ampel, results papi.Results) error {
+	// Generate the results attestation
+	if !opts.AttestResults {
+		return nil
+	}
+	attFile, err := os.Create(opts.ResultsAttestationPath)
+	if err != nil {
+		return fmt.Errorf("unable to open results attestation path")
+	}
+
+	switch opts.AttestFormat {
+	case "ampel", "":
+		if err := ampel.AttestResults(attFile, results); err != nil {
+			return fmt.Errorf("writing results attestation: %w", err)
+		}
+	default:
+		eng := render.NewEngine()
+		if err := eng.SetDriver(opts.AttestFormat); err != nil {
+			return fmt.Errorf("loading VSA attestation driver: %w", err)
+		}
+		switch r := results.(type) {
+		case *papi.Result:
+			if err := eng.RenderResult(attFile, r); err != nil {
+				return err
+			}
+		case *papi.ResultSet:
+			if err := eng.RenderResultSet(attFile, r); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unable to determine results type to attest")
+		}
+	}
+
+	return nil
 }
 
 // buildContextProviders initializes the context providers defined in the

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -4,6 +4,10 @@
 package verifier
 
 import (
+	"errors"
+	"fmt"
+	"slices"
+
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/signer/key"
 
@@ -11,6 +15,10 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
+
+var ResultsAttestationFormats = []string{
+	"ampel", // Regular ampel resultSet
+}
 
 type VerificationOptions struct {
 	// Embed the evaluator options
@@ -72,6 +80,16 @@ type VerificationOptions struct {
 	// AllowEmptySetChains prevents the policy from failing if the chain selectors
 	// don't return any mutated subjects.
 	AllowEmptySetChains bool
+}
+
+// Validate checks the options set
+func (opts *VerificationOptions) Validate() error {
+	errs := []error{}
+	if opts.AttestFormat != "" && !slices.Contains(ResultsAttestationFormats, opts.AttestFormat) {
+		errs = append(errs, fmt.Errorf("invalid results attestation format: %q", opts.AttestFormat))
+	}
+
+	return errors.Join(errs...)
 }
 
 var DefaultVerificationOptions = VerificationOptions{

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -36,6 +36,9 @@ type VerificationOptions struct {
 	// AttestResults will generate an attestation of the evaluation results
 	AttestResults bool
 
+	// AttestFormat specifies the format used when AttestResults is true
+	AttestFormat string
+
 	// ResultsAttestationPath stores the path to write the results attestation
 	ResultsAttestationPath string
 
@@ -93,6 +96,9 @@ var DefaultVerificationOptions = VerificationOptions{
 	// AllowEmptySetChains is set to true. This means that if no subjects
 	// result from the selectors, the set passes with the policies softfailed.
 	AllowEmptySetChains: true,
+
+	// By default, we attesta results in the ampel format
+	AttestFormat: "ampel",
 }
 
 func NewVerificationOptions() VerificationOptions {

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -18,6 +18,7 @@ import (
 
 var ResultsAttestationFormats = []string{
 	"ampel", // Regular ampel resultSet
+	"vsa",   // Verification Summary Attestation
 }
 
 type VerificationOptions struct {


### PR DESCRIPTION
This PR adds support to generate VSA attestations when `--attest-results` is set. The verify subcommand now has a new flag `--attest-format` which defaults to `ampel` but now can also take `vsa` as a value.

The VSA is almost complete, it is also bitten by #61 but the rest of the predicate is done:

```jsonc
{
  "predicateType": "https://slsa.dev/verification_summary/v1",
  "predicate": {
    "verifier": {
      "id": "https://carabiner.dev/ampel@v1"
    },
    "timeVerified": "2025-10-02T07:06:12.248324Z",
    "policy": {},
    "inputAttestations": [
      {
        "uri": "internal:vex",
        "digest": {
          "sha256": "d28860ebd3840ff185892934a9459830bc9c4101ed810513f9adeb0d0b2c4549",
          "sha512": "23de3142ec89e867ad05537d13346f3bc6bab724d1cc7bbccd61cbf471a9d92ed6af4ee3e7479d267df1e48eb3367c028cc4f54571b80660fbb4b29e6d36459c"
        }
      }
    ],
    "verificationResult": "PASSED",
    "slsaVersion": "1.1"
  },
  "_type": "https://in-toto.io/Statement/v1",
  "subject": [
    {
      "digest": {
        "gitCommit": "8674a25b7ad73b2ef773391fdbd1c5b61ea770c7",
        "sha1": "8674a25b7ad73b2ef773391fdbd1c5b61ea770c7"
      }
    }
  ]
}

```