### PR TITLE
Coerce context values to defined (simple) types before shipping to eval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.1.1
 	github.com/carabiner-dev/hasher v0.2.2
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.2.1
+	github.com/carabiner-dev/policy v0.2.2-0.20251006203331-d23dccc93823
 	github.com/fatih/color v1.18.0
 	github.com/google/cel-go v0.26.1
 	github.com/in-toto/attestation v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -744,6 +744,8 @@ github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
 github.com/carabiner-dev/policy v0.2.1 h1:AIQzZ+pa6tN9KhmbgY3irNvd9ITQX7FZoxXp8pOJ/oc=
 github.com/carabiner-dev/policy v0.2.1/go.mod h1:7FOMrXNiWBa9ni9l3MzbRmFO61laBtLEGdKuuBg7lNU=
+github.com/carabiner-dev/policy v0.2.2-0.20251006203331-d23dccc93823 h1:jLltaxxAS7Fk7BurQeTbF+wavCqYhz/46AzUClk760U=
+github.com/carabiner-dev/policy v0.2.2-0.20251006203331-d23dccc93823/go.mod h1:7FOMrXNiWBa9ni9l3MzbRmFO61laBtLEGdKuuBg7lNU=
 github.com/carabiner-dev/signer v0.2.1 h1:qNRzDFnG+uLWHPTIC36hrh572bs66hYhBOwkGLcsq1I=
 github.com/carabiner-dev/signer v0.2.1/go.mod h1:VvN+m//2sBUQuZUnVie0WpIy+D9+v8+eJDoMG8nugA8=
 github.com/carabiner-dev/vcslocator v0.3.2 h1:/rfhELG1mvqFq0xi8LQSkfpAVoQDCGlWoL6J5tX9Inw=

--- a/pkg/verifier/context.go
+++ b/pkg/verifier/context.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+)
+
+// ensureContextType makes sure the loaded context values are match the types
+// defined in the context definition. For now we ensure the types of simple
+// types: string, bool, int and convert between them as much as possible.
+func ensureContextType(value any, contextDef *papi.ContextVal) (any, error) {
+	switch contextDef.Type {
+	case papi.ContextTypeString:
+		return convertToString(value), nil
+	case papi.ContextTypeInt:
+		return convertToInt64(value)
+	case papi.ContextTypeBool:
+		return convertToBool(value)
+	default:
+		return value, nil
+	}
+}
+
+// convertToString converts any value to a string representation. If its an
+// unhandled type wel use sptintf("%v") to convert it.
+func convertToString(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case int, int8, int16, int32, int64:
+		return fmt.Sprintf("%d", v)
+	case uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", v)
+	case float32, float64:
+		return fmt.Sprintf("%v", v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// convertToBool converts any of the simple types to their intended type
+func convertToBool(value any) (bool, error) {
+	switch v := value.(type) {
+	case bool:
+		return v, nil
+	case string:
+		if strings.EqualFold(v, "true") {
+			return true, nil
+		} else if strings.EqualFold(v, "false") {
+			return false, nil
+		}
+		// Try to parse as number
+		if num, err := strconv.ParseFloat(v, 64); err == nil {
+			return numToBool(num), nil
+		}
+		return false, fmt.Errorf("convert string %q to bool", v)
+	case int:
+		return numToBool(float64(v)), nil
+	case int8:
+		return numToBool(float64(v)), nil
+	case int16:
+		return numToBool(float64(v)), nil
+	case int32:
+		return numToBool(float64(v)), nil
+	case int64:
+		return numToBool(float64(v)), nil
+	case uint:
+		return numToBool(float64(v)), nil
+	case uint8:
+		return numToBool(float64(v)), nil
+	case uint16:
+		return numToBool(float64(v)), nil
+	case uint32:
+		return numToBool(float64(v)), nil
+	case uint64:
+		return numToBool(float64(v)), nil
+	case float32:
+		return numToBool(float64(v)), nil
+	case float64:
+		return numToBool(v), nil
+	default:
+		return false, fmt.Errorf("cannot convert type %T to bool", v)
+	}
+}
+
+// numToBool converts anything over zero to true.
+func numToBool(n float64) bool {
+	return n > 0
+}
+
+// convertToInt64 converts the simple types to int64
+func convertToInt64(value any) (int64, error) {
+	switch v := value.(type) {
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case uint:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("uint value %d overflows int64", v)
+		}
+		return int64(v), nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("uint64 value %d overflows int64", v)
+		}
+		return int64(v), nil
+	case float32:
+		return int64(math.Round(float64(v))), nil
+	case float64:
+		return int64(math.Round(v)), nil
+	case bool:
+		if v {
+			return 1, nil
+		}
+		return 0, nil
+	case string:
+		// Try to parse as float first (to handle decimals)
+		if f, err := strconv.ParseFloat(v, 64); strings.Contains(v, ".") && err == nil {
+			return int64(math.Round(f)), nil
+		}
+		// If its not a float, then as int64
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return i, nil
+		}
+		return 0, fmt.Errorf("convert string %q to int64", v)
+	default:
+		return 0, fmt.Errorf("cannot convert type %T to int64", v)
+	}
+}

--- a/pkg/verifier/context_test.go
+++ b/pkg/verifier/context_test.go
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"math"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		// String preservation
+		{"string preserved", "hello", "hello"},
+		{"empty string", "", ""},
+
+		// Bool to string
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+
+		// Integers to string
+		{"int", 42, "42"},
+		{"int8", int8(-128), "-128"},
+		{"int16", int16(1000), "1000"},
+		{"int32", int32(-50000), "-50000"},
+		{"int64", int64(9223372036854775807), "9223372036854775807"},
+		{"negative int", -42, "-42"},
+
+		// Unsigned integers to string
+		{"uint", uint(42), "42"},
+		{"uint8", uint8(255), "255"},
+		{"uint16", uint16(65535), "65535"},
+		{"uint32", uint32(4294967295), "4294967295"},
+		{"uint64", uint64(18446744073709551615), "18446744073709551615"},
+
+		// Floats to string
+		{"float32", float32(3.14), "3.14"},
+		{"float64", float64(2.718281828), "2.718281828"},
+		{"negative float", float64(-1.5), "-1.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ensureContextType(tt.input, &papi.ContextVal{Type: "string"})
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("got %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertToBool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     any
+		expected  bool
+		shouldErr bool
+	}{
+		// Bool preservation
+		{"bool true preserved", true, true, false},
+		{"bool false preserved", false, false, false},
+
+		// String to bool
+		{"string true", "true", true, false},
+		{"string false", "false", false, false},
+		{"string number 1", "1", true, false},
+		{"string number 0", "0", false, false},
+		{"invalid string", "maybe", false, true},
+
+		// Numbers to bool
+		{"int_1", 1, true, false},
+		{"int_0", 0, false, false},
+		{"int_other", 42, true, false},
+		{"int_negative", -1, false, false},
+		{"int8_1", int8(1), true, false},
+		{"int16_0", int16(0), false, false},
+		{"int32_1", int32(1), true, false},
+		{"int64_0", int64(0), false, false},
+		{"uint_1", uint(1), true, false},
+		{"uint_0", uint(0), false, false},
+		{"uint8_1", uint8(1), true, false},
+		{"uint16_0", uint16(0), false, false},
+		{"uint32_1", uint32(1), true, false},
+		{"uint64_0", uint64(0), false, false},
+		{"float32_1.0", float32(1.0), true, false},
+		{"float32_0.0", float32(0.0), false, false},
+		{"float64_1.0", float64(1.0), true, false},
+		{"float64_0.0", float64(0.0), false, false},
+		{"float64_0.9", float64(0.9), true, false},
+		{"float64_1.1", float64(1.1), true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := ensureContextType(tt.input, &papi.ContextVal{Type: "bool"})
+			if tt.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertToInt64(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     any
+		expected  int64
+		shouldErr bool
+	}{
+		// Integer preservation
+		{"int64 preserved", int64(42), 42, false},
+		{"int", 100, 100, false},
+		{"int8", int8(-128), -128, false},
+		{"int16", int16(1000), 1000, false},
+		{"int32", int32(-50000), -50000, false},
+		{"negative int64", int64(-9223372036854775808), -9223372036854775808, false},
+
+		// Unsigned integers
+		{"uint", uint(42), 42, false},
+		{"uint8", uint8(255), 255, false},
+		{"uint16", uint16(65535), 65535, false},
+		{"uint32", uint32(4294967295), 4294967295, false},
+		{"uint64 valid", uint64(100), 100, false},
+		{"uint64 max valid", uint64(math.MaxInt64), math.MaxInt64, false},
+		{"uint64 overflow", uint64(math.MaxUint64), 0, true},
+		{"uint overflow", uint(math.MaxUint64), 0, true},
+
+		// Float rounding
+		{"float32_round_down", float32(3.4), 3, false},
+		{"float32_round_up", float32(3.5), 4, false},
+		{"float64_round_down", float64(2.4), 2, false},
+		{"float64_round_up", float64(2.5), 3, false},
+		{"float64_negative_round", float64(-2.5), -3, false},
+		{"float64_exact_half_up", float64(0.5), 1, false},
+		{"float64_exact_half_down", float64(-0.5), -1, false},
+
+		// Bool to int64
+		{"bool true", true, 1, false},
+		{"bool false", false, 0, false},
+
+		// String to int64
+		{"string int", "42", 42, false},
+		{"string negative", "-100", -100, false},
+		{"string float", "3.7", 4, false},
+		{"string float negative", "-3.7", -4, false},
+		{"string invalid", "not a number", 0, true},
+		{"string empty", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ensureContextType(tt.input, &papi.ContextVal{Type: "int"})
+			if tt.shouldErr {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("got %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// Test edge cases of the different type conversions
+func TestEdgeCases(t *testing.T) {
+	t.Run("zero_values", func(t *testing.T) {
+		// Zero int to string
+		s, _ := ensureContextType(0, &papi.ContextVal{Type: "string"}) //nolint:errcheck // Not checking errors
+		if s != "0" {
+			t.Errorf("zero int to string: got %v, want '0'", s)
+		}
+
+		// Zero float to string
+		s2, _ := ensureContextType(0.0, &papi.ContextVal{Type: "string"}) //nolint:errcheck // Not checking errors
+		if s2 != "0" {
+			t.Errorf("zero float to string: got %v, want '0'", s2)
+		}
+
+		// Zero string to int64
+		i, _ := ensureContextType("0", &papi.ContextVal{Type: "int"}) //nolint:errcheck // Not checking errors
+		if i.(int64) != 0 {                                           //nolint:errcheck,forcetypeassert
+			t.Errorf("zero string to int64 huh: got %v, want 0", i)
+		}
+	})
+
+	t.Run("max_values", func(t *testing.T) {
+		// MaxInt64 conversions
+		i := int64(math.MaxInt64) - 1
+		s, _ := ensureContextType(i, &papi.ContextVal{Type: "string"}) //nolint:errcheck // Not checking errors
+		if s != "9223372036854775806" {
+			t.Errorf("MaxInt64 to string failed: %v", s)
+		}
+
+		// String back to int64
+		i2, _ := ensureContextType(s, &papi.ContextVal{Type: "int"}) //nolint:errcheck // Not checking errors
+		if i2 != i {
+			t.Errorf("MaxInt64 round trip failed: got %v, want %v", i2, i)
+		}
+	})
+
+	t.Run("float_precision", func(t *testing.T) {
+		// Test rounding at .5 boundary
+		tests := []struct {
+			input    float64
+			expected int64
+		}{
+			{1.5, 2},
+			{2.5, 3},
+			{-1.5, -2},
+			{-2.5, -3},
+		}
+
+		for _, tt := range tests {
+			result, _ := ensureContextType(tt.input, &papi.ContextVal{Type: "int"}) //nolint:errcheck // Not checking errors
+			if result != tt.expected {
+				t.Errorf("rounding %v: got %v, want %v", tt.input, result, tt.expected)
+			}
+		}
+	})
+}
+
+// Benchmark tests
+func BenchmarkConvertToString(b *testing.B) {
+	for b.Loop() {
+		ensureContextType(42, &papi.ContextVal{Type: "string"}) //nolint:errcheck,gosec // Not checking errors
+	}
+}
+
+func BenchmarkConvertToBool(b *testing.B) {
+	for b.Loop() {
+		ensureContextType("true", &papi.ContextVal{Type: "bool"}) //nolint:errcheck,gosec // Not checking errors
+	}
+}
+
+func BenchmarkConvertToInt64(b *testing.B) {
+	for b.Loop() {
+		ensureContextType(3.14, &papi.ContextVal{Type: "int"}) //nolint:errcheck,gosec // Not checking errors
+	}
+}

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -796,6 +796,27 @@ func (di *defaultIplementation) AssembleEvalContextValues(ctx context.Context, o
 		}
 	}
 
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+
+	// Ensure context values are in the correct type when typed. For now, we
+	// enforce and cross convert simple types: string, int and bool and
+	// force-convert between them. This means that if a value is typed in
+	// the context definition, the evaluator is guaranteed to get it in
+	// that type or ampel will return an error before evaluating.
+	//
+	// Ideally, context providers will return these in their correct types
+	// but we ensure they are correct here to guarantee evaluators get the
+	// context values in the right types.
+	for k, contextDef := range assembledContext {
+		typedVal, err := ensureContextType(values[k], contextDef)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		values[k] = typedVal
+	}
+
 	return values, errors.Join(errs...)
 }
 


### PR DESCRIPTION
This PR adds a change to AMPEL where context values received from the different providers will be coerced into the types defined in their definitions.

For the initial AMPEL release, we check and coerce the [recognized simple types](https://github.com/carabiner-dev/policy/blob/d23dccc938237e0ad6299af195c0701477097e61/api/v1/context.go#L11-L21): `int`, `string` and `bool` 

If a context definition is marked as any of them, AMPEL will force-convert the value from whatever type it has into Go's `int64`, `string` and `bool` types, respectively. If conversion is not possible, the evaluation will not occur, and an error will be thrown.

Closes https://github.com/carabiner-dev/ampel/issues/128 


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>

