### PR TITLE
Run conformance tests as presubmit

### DIFF
--- a/.github/workflows/go-build-and-test.yaml
+++ b/.github/workflows/go-build-and-test.yaml
@@ -12,8 +12,38 @@ on:
 permissions: {}
 
 jobs:
-  test:
+  conformance:
+    name: Conformance Tests
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: false
+        repository: "carabiner-dev/conformance"
+        path: ./conformance
+
+    - name: Set up Go
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version: '1.24'
+        check-latest: true
+        cache: true
+
+    - id: run-conformance-tests
+      run: |
+        ./conformance/run-tests.sh
+        
+  go-tests:
+    runs-on: ubuntu-latest
+    name: Go Tests
 
     permissions:
       contents: read


### PR DESCRIPTION
This PR adds a new job to the tests workflow to run the conformance tests as a presubmit check

The tests cases are few, but we'll slowly add more and more

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>