### PR TITLE
Improve "subject specified twice" error message and usage documentation

### DIFF
--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -56,7 +56,7 @@ type verifyOptions struct {
 func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	o.KeyOptions.AddFlags(cmd)
 	cmd.PersistentFlags().StringVarP(
-		&o.Subject, "subject", "s", "", "subject hash (algo:value) or a path to a files to verify ",
+		&o.Subject, "subject", "s", "", "subject hash (algo:value) or path to file (alternative to positional argument)",
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -274,7 +274,7 @@ using a collector.
 			color.New(color.FgHiWhite).Sprint("The Policy"),
 			color.New(color.FgHiWhite).Sprint("Attested Evidence"),
 		),
-		Use:               "verify",
+		Use:               "verify [subject]",
 		SilenceUsage:      false,
 		SilenceErrors:     false,
 		PersistentPreRunE: initLogging,
@@ -283,7 +283,7 @@ using a collector.
 				if opts.Subject == "" {
 					opts.Subject = args[0]
 				} else if opts.Subject != args[0] {
-					return fmt.Errorf("subject specified twice (as argument and flag)")
+					return fmt.Errorf("subject specified twice: got %q from positional argument and %q from -s flag (use only one)", args[0], opts.Subject)
 				}
 			}
 


### PR DESCRIPTION
This PR improves the verify sub command user experience when "subject specified twice" error occurs. 

- Update Usage to explicitly show [subject] positional argument
`Usage: ampel verify [subject] [flags]`
- Clarify -s/--subject flag help text as alternative to positional arg
`-s, --subject string          subject hash (algo:value) or path to file (alternative to positional argument)`
- Improve error message to display both conflicting values for easier debugging
`Error: subject specified twice: got "sha256:abc" from positional argument and
  "sha256:def" from -s flag (use only one)`

  This addresses user confusion when the "subject specified twice" error occurs
  by making it clear what values were detected and how the subject can be specified.