### PR TITLE
Fix vulnreport initialization in factory

### DIFF
--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -40,7 +40,7 @@ func (tf *Factory) Get(c Class) (Transformer, error) {
 		return protobom.New(), nil
 	case vulnreport.ClassName:
 		logrus.Debugf("Found driver for transformer class %s", s)
-		return protobom.New(), nil
+		return vulnreport.New(), nil
 	case vex.ClassName:
 		logrus.Debugf("Found driver for transformer class %s", s)
 		return vex.New(), nil

--- a/pkg/transformer/vulnreport/vulnreport.go
+++ b/pkg/transformer/vulnreport/vulnreport.go
@@ -21,6 +21,10 @@ var PredicateTypes = []attestation.PredicateType{
 	trivy.PredicateType,
 }
 
+func New() *Transformer {
+	return &Transformer{}
+}
+
 // Transformer implements the normalizer from scanner to vulnv2
 type Transformer struct{}
 


### PR DESCRIPTION
This pull request updates the transformer factory to correctly instantiate the `vulnreport` transformer and adds a constructor for it. These changes ensure that the correct transformer implementation is used when the `vulnreport` class is requested.

Transformer instantiation improvements:

* Modified the `Factory.Get` method in `transformer.go` to return a new `vulnreport.Transformer` instance instead of a `protobom.Transformer` when the `vulnreport` class is requested.
* Added a `New` constructor function to the `vulnreport` package for creating new `Transformer` instances.