### PR TITLE
Support for transformer configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,6 @@ jobs:
             tejolote attest --artifacts github://${{github.repository}}/${{ steps.tag.outputs.tag_name }} github://${{github.repository}}/"${GITHUB_RUN_ID}" --output provenance.json
             bnd statement provenance.json -o ampel-${{ steps.tag.outputs.tag_name }}.provenance.json
             gh release upload ${{ steps.tag.outputs.tag_name }} ampel-${{ steps.tag.outputs.tag_name }}.provenance.json
-            bnd push github ${{github.repository}} ampel-${{ steps.tag.outputs.tag_name }}.provenance.json
 
       - name: Generate SBOM
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.4.6
+	github.com/carabiner-dev/policy v0.4.7-0.20260418052227-a418c4cef5e1
 	github.com/carabiner-dev/predicates v0.1.0
 	github.com/fatih/color v1.19.0
 	github.com/google/cel-go v0.28.0
@@ -112,6 +112,7 @@ require (
 )
 
 require (
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 // indirect
 	cel.dev/expr v0.25.1 // indirect
 	github.com/CycloneDX/cyclonedx-go v0.10.0 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 h1:s6hzCXtND/ICdGPTMGk7C+/BFlr2Jg5GyH0NKf4XGXg=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
@@ -108,8 +110,8 @@ github.com/carabiner-dev/openeox v1.0.0-pre.1 h1:47Oe0vcH9m8nBFFQCPLNVR2HwiumXst
 github.com/carabiner-dev/openeox v1.0.0-pre.1/go.mod h1:+6i8M7PhtWk2jRtUC1anZnhmOr5cXKMLGYjwFcqPDa0=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.4.6 h1:JfWUPDtBNiC+TtNudcpLwHtlRQqRR580cb4m19cXYFo=
-github.com/carabiner-dev/policy v0.4.6/go.mod h1:DKCL2EEEN0l6mnTcGk2fnOfqv8dZJ1w+r8BTTxEw5Y8=
+github.com/carabiner-dev/policy v0.4.7-0.20260418052227-a418c4cef5e1 h1:yOyUDlY89Lnv4KVr3KmVWoIk3JlsVfzm4P07BfGu7oA=
+github.com/carabiner-dev/policy v0.4.7-0.20260418052227-a418c4cef5e1/go.mod h1:A+fnVBXpzx7f/MiLoH1FGTBAOe23ZZwXtGJsT9MCpBM=
 github.com/carabiner-dev/predicates v0.1.0 h1:t6tQF9gFdr6TIccWtuNk3kFasx8eu88INFVGkCUnjL4=
 github.com/carabiner-dev/predicates v0.1.0/go.mod h1:jL6EAD+LiI6GW/rOdRYAJF4HaA88/V2Q4n7yUGNQ7XM=
 github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTurNaEZs=

--- a/pkg/transformer/protobom/protobom.go
+++ b/pkg/transformer/protobom/protobom.go
@@ -16,6 +16,7 @@ import (
 	"github.com/carabiner-dev/collector/predicate/spdx"
 	"github.com/protobom/protobom/pkg/reader"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type Transformer struct{}
@@ -24,6 +25,11 @@ var ClassName = "protobom"
 
 func New() *Transformer {
 	return &Transformer{}
+}
+
+// Init satisfies the transformer interface. The protobom transformer takes no config.
+func (p *Transformer) Init(_ *structpb.Struct) error {
+	return nil
 }
 
 // PredicateTypes

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -22,6 +22,7 @@ import (
 var (
 	_ Transformer = (*protobom.Transformer)(nil)
 	_ Transformer = (*vulnreport.Transformer)(nil)
+	_ Transformer = (*vex.Transformer)(nil)
 )
 
 // Factory returns a list of transformers from

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/carabiner-dev/ampel/pkg/transformer/protobom"
 	"github.com/carabiner-dev/ampel/pkg/transformer/vex"
@@ -27,30 +28,38 @@ var (
 // a list of string identifiers
 type Factory struct{}
 
-// Get returns
-func (tf *Factory) Get(c Class) (Transformer, error) {
+// Get returns a transformer for the given class, initialized with the
+// supplied config. Pass nil config when the policy declared none; each
+// transformer applies its own defaults.
+func (tf *Factory) Get(c Class, config *structpb.Struct) (Transformer, error) {
 	if !strings.HasPrefix(c.Name(), "internal:") {
 		return nil, errors.New("only internal transformers are supported for now")
 	}
 
 	s := strings.TrimPrefix(c.Name(), "internal:")
+	var t Transformer
 	switch s {
 	case protobom.ClassName:
-		logrus.Debugf("Found driver for transformer class %s", s)
-		return protobom.New(), nil
+		t = protobom.New()
 	case vulnreport.ClassName:
-		logrus.Debugf("Found driver for transformer class %s", s)
-		return vulnreport.New(), nil
+		t = vulnreport.New()
 	case vex.ClassName:
-		logrus.Debugf("Found driver for transformer class %s", s)
-		return vex.New(), nil
+		t = vex.New()
 	default:
 		return nil, fmt.Errorf("unknown transformer %q", s)
 	}
+	logrus.Debugf("Found driver for transformer class %s", s)
+	if err := t.Init(config); err != nil {
+		return nil, fmt.Errorf("initializing transformer %q: %w", s, err)
+	}
+	return t, nil
 }
 
 // Transformer is an interface that models a predicate transformer
 type Transformer interface {
+	// Init configures the transformer from policy-supplied config. Implementations
+	// must tolerate a nil config and apply defaults.
+	Init(*structpb.Struct) error
 	Mutate(attestation.Subject, []attestation.Predicate) (attestation.Subject, []attestation.Predicate, error)
 }
 

--- a/pkg/transformer/vex/transformer.go
+++ b/pkg/transformer/vex/transformer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/carabiner-dev/ampel/internal/index"
 )
@@ -36,6 +37,11 @@ func New() *Transformer {
 
 // Transformer implements the VEX interface
 type Transformer struct{}
+
+// Init satisfies the transformer interface. The VEX transformer takes no config today.
+func (t *Transformer) Init(_ *structpb.Struct) error {
+	return nil
+}
 
 // Mutate applies the VEX documents in the input to the received
 // vulnerability reports.

--- a/pkg/transformer/vulnreport/trivy.go
+++ b/pkg/transformer/vulnreport/trivy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/carabiner-dev/collector/predicate/osv"
 	"github.com/carabiner-dev/collector/predicate/trivy"
 	posv "github.com/carabiner-dev/osv/go/osv"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -160,8 +161,14 @@ func (t *Transformer) TrivyToOSV(original attestation.Predicate) (attestation.Pr
 		osvResults.Results[0].Packages = append(osvResults.Results[0].Packages, pkg)
 	}
 
+	data, err := protojson.Marshal(osvResults)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling OSV predicate: %w", err)
+	}
+
 	return &generic.Predicate{
 		Type:   osv.PredicateType,
 		Parsed: osvResults,
+		Data:   data,
 	}, nil
 }

--- a/pkg/transformer/vulnreport/trivy_test.go
+++ b/pkg/transformer/vulnreport/trivy_test.go
@@ -10,44 +10,101 @@ import (
 	"github.com/carabiner-dev/attestation"
 	posv "github.com/carabiner-dev/collector/predicate/osv"
 	"github.com/carabiner-dev/collector/predicate/trivy"
+	"github.com/carabiner-dev/collector/predicate/vulns"
+	v02 "github.com/in-toto/attestation/go/predicates/vulns/v02"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestTrivyToOSV(t *testing.T) {
+func TestMutate(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name          string
 		trivyPath     string
+		config        *structpb.Struct
 		expectedLen   int
 		mustErr       bool
-		validatePreds func([]attestation.Predicate)
+		validatePreds func(*testing.T, []attestation.Predicate)
 	}{
-		{"one-trivy-go", "testdata/trivy.json", 1, false, func(preds []attestation.Predicate) {
-			require.Len(t, preds, 1)
-			require.Equal(t, preds[0].GetType(), posv.PredicateType)
-		}},
+		{
+			name:        "default-output-is-osv",
+			trivyPath:   "testdata/trivy.json",
+			config:      nil,
+			expectedLen: 1,
+			validatePreds: func(t *testing.T, preds []attestation.Predicate) {
+				t.Helper()
+				require.Equal(t, posv.PredicateType, preds[0].GetType())
+			},
+		},
+		{
+			name:      "explicit-osv-output",
+			trivyPath: "testdata/trivy.json",
+			config: mustStruct(t, map[string]any{
+				"output": OutputOSV,
+			}),
+			expectedLen: 1,
+			validatePreds: func(t *testing.T, preds []attestation.Predicate) {
+				t.Helper()
+				require.Equal(t, posv.PredicateType, preds[0].GetType())
+			},
+		},
+		{
+			name:      "vulnreport-output",
+			trivyPath: "testdata/trivy.json",
+			config: mustStruct(t, map[string]any{
+				"output": OutputVulnReport,
+			}),
+			expectedLen: 1,
+			validatePreds: func(t *testing.T, preds []attestation.Predicate) {
+				t.Helper()
+				require.Equal(t, vulns.PredicateType, preds[0].GetType())
+				report, ok := preds[0].GetParsed().(*v02.Vulns)
+				require.True(t, ok, "parsed predicate must be *v02.Vulns")
+				require.Equal(t, trivyScannerURI, report.GetScanner().GetUri())
+				require.NotNil(t, report.GetMetadata().GetScanStartedOn())
+				require.NotEmpty(t, report.GetScanner().GetResult(), "must emit at least one result")
+				first := report.GetScanner().GetResult()[0]
+				require.NotEmpty(t, first.GetId())
+				require.NotEmpty(t, first.GetAnnotations(), "results must carry package annotations")
+				require.NotEmpty(t, preds[0].GetData(), "predicate data must be marshaled")
+			},
+		},
+		{
+			name:      "unknown-output-rejected",
+			trivyPath: "testdata/trivy.json",
+			config: mustStruct(t, map[string]any{
+				"output": "totally-bogus",
+			}),
+			mustErr: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			xformer := Transformer{}
-
-			// Read the data
-			data, err := os.ReadFile(tc.trivyPath)
-			require.NoError(t, err)
-			pred, err := trivy.New().Parse(data)
-			require.NoError(t, err)
-			_, ret, err := xformer.Mutate(nil, []attestation.Predicate{
-				pred,
-			})
+			xformer := New()
+			err := xformer.Init(tc.config)
 			if tc.mustErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
+
+			data, err := os.ReadFile(tc.trivyPath)
+			require.NoError(t, err)
+			pred, err := trivy.New().Parse(data)
+			require.NoError(t, err)
+			_, ret, err := xformer.Mutate(nil, []attestation.Predicate{pred})
+			require.NoError(t, err)
 			require.Len(t, ret, tc.expectedLen)
 			if tc.validatePreds != nil {
-				tc.validatePreds(ret)
+				tc.validatePreds(t, ret)
 			}
 		})
 	}
+}
+
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	require.NoError(t, err)
+	return s
 }

--- a/pkg/transformer/vulnreport/vulnreport.go
+++ b/pkg/transformer/vulnreport/vulnreport.go
@@ -7,15 +7,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/collector/predicate/generic"
 	"github.com/carabiner-dev/collector/predicate/trivy"
+	"github.com/carabiner-dev/collector/predicate/vulns"
 	v02 "github.com/in-toto/attestation/go/predicates/vulns/v02"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// trivyScannerURI identifies the Trivy scanner in vulns/v0.2 Scanner.uri.
+const trivyScannerURI = "https://trivy.dev"
 
 var ClassName = "vulnreport"
 
@@ -103,19 +108,22 @@ func trivyToVulnsV2(original attestation.Predicate) (attestation.Predicate, erro
 
 	oParsed, ok := original.GetParsed().(*trivy.TrivyReport)
 	if !ok {
-		return nil, fmt.Errorf("unable to parse predicate payload as v02.Vulns")
+		return nil, fmt.Errorf("unable to parse predicate payload as trivy report")
+	}
+
+	scanTime := time.Now()
+	if oParsed.CreatedAt != nil {
+		scanTime = *oParsed.CreatedAt
 	}
 
 	newReport := &v02.Vulns{
 		Scanner: &v02.Scanner{
-			Uri:     "",
-			Version: new(string),
-			Db:      &v02.VulnDatabase{},
-			Result:  []*v02.Result{},
+			Uri:    trivyScannerURI,
+			Result: []*v02.Result{},
 		},
 		Metadata: &v02.ScanMetadata{
-			ScanStartedOn:  timestamppb.New(*oParsed.CreatedAt),
-			ScanFinishedOn: timestamppb.New(*oParsed.CreatedAt),
+			ScanStartedOn:  timestamppb.New(scanTime),
+			ScanFinishedOn: timestamppb.New(scanTime),
 		},
 	}
 
@@ -126,18 +134,39 @@ func trivyToVulnsV2(original attestation.Predicate) (attestation.Predicate, erro
 				Severity:    []*v02.Result_Severity{},
 				Annotations: []*structpb.Struct{},
 			}
-			newResult.Severity = append(newResult.Severity, &v02.Result_Severity{
-				Method: "",
-				Score:  "",
+
+			for _, cvss := range vuln.CVSS {
+				newResult.Severity = append(newResult.Severity, &v02.Result_Severity{
+					Method: "CVSS_V3",
+					Score:  fmt.Sprintf("%.1f", cvss.V3Score),
+				})
+			}
+
+			ann, err := structpb.NewStruct(map[string]any{
+				"package":           vuln.PkgName,
+				"installed_version": vuln.InstalledVersion,
+				"fixed_version":     vuln.FixedVersion,
+				"purl":              vuln.PkgIdentifier["PURL"],
+				"severity":          vuln.Severity,
+				"title":             vuln.Title,
 			})
+			if err != nil {
+				return nil, fmt.Errorf("building result annotation: %w", err)
+			}
+			newResult.Annotations = append(newResult.Annotations, ann)
 
 			newReport.Scanner.Result = append(newReport.Scanner.Result, newResult)
 		}
 	}
 
+	data, err := protojson.Marshal(newReport)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling vulns/v0.2 predicate: %w", err)
+	}
+
 	return &generic.Predicate{
-		Type:   trivy.PredicateType,
+		Type:   vulns.PredicateType,
 		Parsed: newReport,
-		Data:   []byte{},
+		Data:   data,
 	}, nil
 }

--- a/pkg/transformer/vulnreport/vulnreport.go
+++ b/pkg/transformer/vulnreport/vulnreport.go
@@ -4,6 +4,7 @@
 package vulnreport
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/carabiner-dev/collector/predicate/generic"
 	"github.com/carabiner-dev/collector/predicate/trivy"
 	v02 "github.com/in-toto/attestation/go/predicates/vulns/v02"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -21,12 +23,51 @@ var PredicateTypes = []attestation.PredicateType{
 	trivy.PredicateType,
 }
 
+// Output formats the vulnreport transformer can emit.
+const (
+	OutputOSV        = "osv"
+	OutputVulnReport = "vulnreport"
+)
+
+// Config is the user-facing configuration for the vulnreport transformer.
+type Config struct {
+	// Output selects the predicate format emitted by Mutate.
+	// Defaults to "osv". "vulnreport" emits an in-toto vulns/v0.2 predicate.
+	Output string `json:"output"`
+}
+
 func New() *Transformer {
 	return &Transformer{}
 }
 
 // Transformer implements the normalizer from scanner to vulnv2
-type Transformer struct{}
+type Transformer struct {
+	config Config
+}
+
+// Init parses the policy-supplied config and applies defaults.
+func (t *Transformer) Init(raw *structpb.Struct) error {
+	t.config = Config{Output: OutputOSV}
+	if raw == nil {
+		return nil
+	}
+	data, err := protojson.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshaling config struct: %w", err)
+	}
+	if err := json.Unmarshal(data, &t.config); err != nil {
+		return fmt.Errorf("decoding vulnreport config: %w", err)
+	}
+	if t.config.Output == "" {
+		t.config.Output = OutputOSV
+	}
+	switch t.config.Output {
+	case OutputOSV, OutputVulnReport:
+	default:
+		return fmt.Errorf("unsupported output %q (want %q or %q)", t.config.Output, OutputOSV, OutputVulnReport)
+	}
+	return nil
+}
 
 func (t *Transformer) Mutate(
 	_ attestation.Subject, preds []attestation.Predicate,
@@ -36,9 +77,18 @@ func (t *Transformer) Mutate(
 		//nolint:gocritic // This will take more types at some point
 		switch original.GetType() {
 		case trivy.PredicateType:
-			newPred, err := t.TrivyToOSV(original)
+			var (
+				newPred attestation.Predicate
+				err     error
+			)
+			switch t.config.Output {
+			case OutputVulnReport:
+				newPred, err = trivyToVulnsV2(original)
+			default:
+				newPred, err = t.TrivyToOSV(original)
+			}
 			if err != nil {
-				return nil, nil, fmt.Errorf("converting trivy predicate to OSV: %w", err)
+				return nil, nil, fmt.Errorf("converting trivy predicate to %s: %w", t.config.Output, err)
 			}
 			newPreds = append(newPreds, newPred)
 		}
@@ -46,7 +96,6 @@ func (t *Transformer) Mutate(
 	return nil, newPreds, nil
 }
 
-//nolint:unused
 func trivyToVulnsV2(original attestation.Predicate) (attestation.Predicate, error) {
 	if original == nil {
 		return nil, errors.New("original predicate undefined")

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -418,13 +418,18 @@ func (di *defaultIplementation) BuildEvaluators(opts *VerificationOptions, p *pa
 func (di *defaultIplementation) BuildTransformers(opts *VerificationOptions, policy *papi.Policy) (map[transformer.Class]transformer.Transformer, error) {
 	factory := transformer.Factory{}
 	transformers := map[transformer.Class]transformer.Transformer{}
-	for _, classString := range policy.Transformers {
-		t, err := factory.Get(transformer.Class(classString.Id))
+
+	// Here we should have logic to support loading the latest version. So if
+	// a policy defined v1 and we have v1.1 and v1.2 load v1.2. Also, no version
+	// will load the latest version.
+	for _, trDef := range policy.Transformers {
+		t, err := factory.Get(transformer.Class(trDef.GetId()), trDef.GetConfig())
 		if err != nil {
-			return nil, fmt.Errorf("building tranformer for class %q: %w", classString, err)
+			return nil, fmt.Errorf("building tranformer for class %q: %w", t, err)
 		}
-		transformers[transformer.Class(classString.Id)] = t
+		transformers[transformer.Class(trDef.GetId())] = t
 	}
+
 	logrus.Debugf("Loaded %d transformers defined in the policy", len(transformers))
 	return transformers, nil
 }


### PR DESCRIPTION
This PR adds support for passing the transformer configuration from the policy to the tranformer initialization. The latest policy spec defines a configration struct which is now fed into the tranformer via a new Init() method in the interface at poplicy load time.

The built in tranfomers are now updated to the new interface and we've resusiteated the vulnreport transfer to attest to the neutral report which was dead code until now.
