### PR TITLE
Bump policy fmwk to v0.6.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.4.7-0.20260418052227-a418c4cef5e1
+	github.com/carabiner-dev/policy v0.4.7
 	github.com/carabiner-dev/predicates v0.1.0
 	github.com/fatih/color v1.19.0
 	github.com/google/cel-go v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/carabiner-dev/openeox v1.0.0-pre.1 h1:47Oe0vcH9m8nBFFQCPLNVR2HwiumXst
 github.com/carabiner-dev/openeox v1.0.0-pre.1/go.mod h1:+6i8M7PhtWk2jRtUC1anZnhmOr5cXKMLGYjwFcqPDa0=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.4.7-0.20260418052227-a418c4cef5e1 h1:yOyUDlY89Lnv4KVr3KmVWoIk3JlsVfzm4P07BfGu7oA=
-github.com/carabiner-dev/policy v0.4.7-0.20260418052227-a418c4cef5e1/go.mod h1:A+fnVBXpzx7f/MiLoH1FGTBAOe23ZZwXtGJsT9MCpBM=
+github.com/carabiner-dev/policy v0.4.7 h1:7s2kG1Az1cfD7F/c5ZiQd+OFvNtDZ0n9S2uyge9UDLw=
+github.com/carabiner-dev/policy v0.4.7/go.mod h1:A+fnVBXpzx7f/MiLoH1FGTBAOe23ZZwXtGJsT9MCpBM=
 github.com/carabiner-dev/predicates v0.1.0 h1:t6tQF9gFdr6TIccWtuNk3kFasx8eu88INFVGkCUnjL4=
 github.com/carabiner-dev/predicates v0.1.0/go.mod h1:jL6EAD+LiI6GW/rOdRYAJF4HaA88/V2Q4n7yUGNQ7XM=
 github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTurNaEZs=


### PR DESCRIPTION
This pull request updates the dependency on `github.com/carabiner-dev/policy` in the `go.mod` file to use the stable `v0.4.7` release instead of a pre-release version.

Dependency update:

* Updated `github.com/carabiner-dev/policy` from a pre-release commit to the stable `v0.4.7` version in `go.mod`.