### PR TITLE
Normalize alforithm labels in selectors

### DIFF
--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -368,6 +368,22 @@ func decodeValue(val ref.Val) (attestation.Subject, error) {
 			return nil, errors.New("selectror must return a string or cel.Subject struct")
 		}
 
+		// Normalize digest algorithm keys to the canonical intoto casing
+		// (sha1, sha256, gitCommit, ...) and lowercase the hex values so
+		// comparisons match regardless of how the CEL expression built them.
+		canonicalAlgo := make(map[string]string, len(intoto.HashAlgorithms))
+		for name := range intoto.HashAlgorithms {
+			canonicalAlgo[strings.ToLower(name)] = name
+		}
+		normalized := make(map[string]string, len(subj.Digest))
+		for k, h := range subj.Digest {
+			if canonical, ok := canonicalAlgo[strings.ToLower(k)]; ok {
+				k = canonical
+			}
+			normalized[k] = strings.ToLower(h)
+		}
+		subj.Digest = normalized
+
 		// We add here a little hack to copy gitCommit hashes to sha1s (and viceversa)
 		// to ensure maximum matching chances
 


### PR DESCRIPTION
This pull request improves the normalization of digest algorithm keys and values in the CEL evaluator to ensure consistent matching, regardless of input casing or formatting.

**Digest normalization improvements:**

* In `pkg/evaluator/cel/implementation.go`, updated the `decodeValue` function to normalize digest algorithm keys to the canonical intoto casing (e.g., `sha1`, `sha256`, `gitCommit`) and convert all digest hex values to lowercase, ensuring consistent comparisons even if CEL expressions use different casing or formats.