### PR TITLE
Fix rare concurrency write panic

### DIFF
--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -803,13 +803,22 @@ func failPolicyGroupWithError(p *papi.PolicyGroup, chain []*papi.ChainedSubject,
 // Returns the new go context loaded with the augmented eval ctx definition and the
 // new evaluation context.
 func (ampel *Ampel) loadElementEvalContextDef(ctx context.Context, element papi.CommonProvider) (context.Context, evalcontext.EvaluationContext) {
-	// First, extract any existing evaluation context
-	evalContext, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
-	if !ok {
-		evalContext = evalcontext.EvaluationContext{
-			Context:    map[string]*papi.ContextVal{},
-			Identities: []*sapi.Identity{},
-		}
+	// First, extract any existing evaluation context. The map and slice fields
+	// inside EvaluationContext are reference types, so when this function runs
+	// concurrently across goroutines sharing the same parent ctx we must clone
+	// them before mutating to avoid concurrent map writes / slice races.
+	parent, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
+	evalContext := evalcontext.EvaluationContext{
+		Context:    map[string]*papi.ContextVal{},
+		Identities: []*sapi.Identity{},
+	}
+	if ok {
+		maps.Copy(evalContext.Context, parent.Context)
+		evalContext.Identities = append(evalContext.Identities, parent.Identities...)
+		evalContext.ContextValues = parent.ContextValues
+		evalContext.Subject = parent.Subject
+		evalContext.Policy = parent.Policy
+		evalContext.ChainedSubjects = parent.ChainedSubjects
 	}
 
 	// If the policy material has an eval context definition, then parse it and add


### PR DESCRIPTION
This pull request addresses a concurrency issue in the way evaluation contexts are handled in the `loadElementEvalContextDef` function. Previously, the function could cause data races by sharing reference-type fields (maps and slices) between goroutines. The update ensures that a new, independent copy of the evaluation context is created for each invocation, preventing concurrent map writes and slice races.

Concurrency safety improvements:

* Refactored `loadElementEvalContextDef` in `verifier.go` to always create a new `EvaluationContext` and explicitly clone reference-type fields from the parent context, ensuring thread safety during concurrent execution.