### PR TITLE
Expressions in context values

### DIFF
--- a/docs/03-ampel-policy-guide.md
+++ b/docs/03-ampel-policy-guide.md
@@ -199,6 +199,65 @@ resulting ContextVal would be:
 
 As mentioned above, values can be replaced with another type for now.
 
+### Dynamic Values via Expressions
+
+Context values can be resolved dynamically by an evaluator runtime instead of
+being supplied as a static `value`/`default` or by an external provider. To do
+this, set `expression` (and optionally `runtime`) on the `ContextVal`:
+
+```json
+    "context": {
+        "builderId": {
+            "expression": "subject.name"
+        }
+    }
+```
+
+When `expression` is set, AMPEL invokes the configured runtime at evaluation
+time, resolves the expression and uses the result as the context value. Like
+`value`, an expression is considered burned-in to the policy: it cannot be
+overridden by `default` or by external providers, and is mutually exclusive
+with both `value` and `default` (the policy will fail validation if either is
+combined with `expression`).
+
+The optional `runtime` field selects which evaluator runs the expression. When
+omitted, the policy's default runtime is used (CEL in the default
+distribution). `runtime` is only valid when `expression` is set.
+
+#### Resolution Order
+
+Context values are resolved in two deterministic phases:
+
+1. **Static phase:** every entry that does not define an `expression` is
+   resolved first, in alphabetical key order, by combining `value`, `default`
+   and any external provider override.
+2. **Dynamic phase:** every entry that defines an `expression` is then
+   resolved, also in alphabetical key order, with the static-phase results
+   already populated on the `context.*` object.
+
+Because the static snapshot is captured once before the dynamic phase begins,
+expressions can rely on every static sibling being visible, but they cannot
+observe other expression-resolved siblings. This keeps evaluation order
+irrelevant among expressions and prevents cyclic dependencies.
+
+#### Variables available to context expressions
+
+Expressions evaluated against context values run *before* attestations are
+filtered for a tenet, so they have access to a smaller set of inputs than a
+tenet body. The available variables are:
+
+- `subject` — the subject under evaluation (`name`, `uri`, `digest`).
+- `context` — the already-resolved context values from ancestor scopes
+  (PolicySet → PolicyGroup → Policy) **and** every static sibling at the
+  current scope. Expression-resolved siblings at the current scope are not
+  visible (see "Resolution order" above).
+- Any global variables and functions registered by runtime plugins (for
+  example, the `hasher`, `url`, and `purl` helpers in the CEL runtime).
+
+The following are intentionally *not* available, because they are not yet
+known when context values are assembled: `predicate`, `predicates`, the
+chained subjects produced by selectors, and the policy object itself.
+
 ### Data Sources
 
 Contextual values can get their data from external sources which are not

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.26.2
 
 require (
 	github.com/carabiner-dev/attestation v0.2.1
-	github.com/carabiner-dev/collector v0.3.4
+	github.com/carabiner-dev/collector v0.3.5
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.4.8-0.20260420074232-1f3927cc85fc
-	github.com/carabiner-dev/predicates v0.1.0
+	github.com/carabiner-dev/policy v0.5.0
+	github.com/carabiner-dev/predicates v0.5.0
 	github.com/fatih/color v1.19.0
 	github.com/google/cel-go v0.28.0
 	github.com/in-toto/attestation v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,10 @@ github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oM
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/carabiner-dev/attestation v0.2.1 h1:VhjV5YlO9TsW50Sr/Zd54bdbZhhDAqgxC3kB9z1I+3Q=
 github.com/carabiner-dev/attestation v0.2.1/go.mod h1:O84vF84RZG3pJO/6BYrPs718bZviHF5DKajP1HsrDpw=
-github.com/carabiner-dev/collector v0.3.4 h1:wxW6WZPLm+VpYNmiuEp+50bTyAo8ilAi1FbRbegtY+8=
-github.com/carabiner-dev/collector v0.3.4/go.mod h1:nWnFowFhfqa6dgE6pILXwP80Gi0e99LxG/Nuyspq9qY=
+github.com/carabiner-dev/collector v0.3.5-0.20260421015520-813214e38160 h1:6dmpEwmIjUADv73sIjld5y6hg0hgp71gSSzldtdtQxg=
+github.com/carabiner-dev/collector v0.3.5-0.20260421015520-813214e38160/go.mod h1:WgoEaH6peXynITtICYvoPLRfLYgmWIZbkx8LVgj1wvM=
+github.com/carabiner-dev/collector v0.3.5 h1:D7cKPyjLl69yLqeeQHVwd5fR6YhvudMNEFOmLQgFg1o=
+github.com/carabiner-dev/collector v0.3.5/go.mod h1:WgoEaH6peXynITtICYvoPLRfLYgmWIZbkx8LVgj1wvM=
 github.com/carabiner-dev/command v0.3.1 h1:iBkh+AjwziFZmyihv/izypCV74nkmaslZxb5AgP7GP4=
 github.com/carabiner-dev/command v0.3.1/go.mod h1:0mWfS5BU/krtaI1hgD5wjmLpjWVlf38KY8usA8zfF5c=
 github.com/carabiner-dev/ghrfs v0.3.4 h1:XJoDXkuw+8KQPTC4oI0da8vLpnx7cfQBGgyjzo+Eqrc=
@@ -110,10 +112,10 @@ github.com/carabiner-dev/openeox v1.0.0-pre.1 h1:47Oe0vcH9m8nBFFQCPLNVR2HwiumXst
 github.com/carabiner-dev/openeox v1.0.0-pre.1/go.mod h1:+6i8M7PhtWk2jRtUC1anZnhmOr5cXKMLGYjwFcqPDa0=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.4.8-0.20260420074232-1f3927cc85fc h1:Gy8IbDOcKzk5hzvCcwTm10JdgaJxPSL4reRnUpKj7u4=
-github.com/carabiner-dev/policy v0.4.8-0.20260420074232-1f3927cc85fc/go.mod h1:A+fnVBXpzx7f/MiLoH1FGTBAOe23ZZwXtGJsT9MCpBM=
-github.com/carabiner-dev/predicates v0.1.0 h1:t6tQF9gFdr6TIccWtuNk3kFasx8eu88INFVGkCUnjL4=
-github.com/carabiner-dev/predicates v0.1.0/go.mod h1:jL6EAD+LiI6GW/rOdRYAJF4HaA88/V2Q4n7yUGNQ7XM=
+github.com/carabiner-dev/policy v0.5.0 h1:BBCLtB6PwFB40nTEbI3ooL/54RZCCGFwUCWXS4yJ4DQ=
+github.com/carabiner-dev/policy v0.5.0/go.mod h1:A+fnVBXpzx7f/MiLoH1FGTBAOe23ZZwXtGJsT9MCpBM=
+github.com/carabiner-dev/predicates v0.5.0 h1:CG2xO5xTXWXakjJkAFuS2xSA2olP9Ew25k6CAyL8waI=
+github.com/carabiner-dev/predicates v0.5.0/go.mod h1:EUm2p0CwKoUuc+OLbGkoxLdRqBrg/r957b8iN/ACWSA=
 github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTurNaEZs=
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
 github.com/carabiner-dev/signer v0.4.5 h1:H3XHHqorZw7wvLysbGCc+FM90nSdzFlODj+mIGMsYJc=
@@ -248,6 +250,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
 github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -371,8 +375,8 @@ github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/olareg/olareg v0.2.0 h1:Gr8LKpzQEr3ZP+FE1hEBnFEsN0yAORWMSAmiAoKW5iE=
-github.com/olareg/olareg v0.2.0/go.mod h1:NL7uwkDcjC00kyz9dF9ELn15ggh7ugN5AV/eQzPbHfA=
+github.com/olareg/olareg v0.2.1 h1:RPHGIaqlVWPbKAsOYUj7e2WfEEW5M7F8I6hKMrwd4jU=
+github.com/olareg/olareg v0.2.1/go.mod h1:dhr8QetC7U7jJ2m93oxDhEEOKCRbPgOK1oGyKfB4QNo=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
 github.com/olekukonko/errors v1.2.0 h1:10Zcn4GeV59t/EGqJc8fUjtFT/FuUh5bTMzZ1XwmCRo=

--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -150,6 +150,30 @@ func (e *Evaluator) RegisterPlugin(plugin api.Plugin) error {
 	return nil
 }
 
+// EvalExpression evaluates a standalone CEL expression against the subject
+// carried in the evalcontext and plugin-provided variables, returning its
+// resolved value. It is used to resolve dynamic ContextVal expressions.
+func (e *Evaluator) EvalExpression(
+	ctx context.Context, opts *options.EvaluatorOptions, code string,
+) (any, error) {
+	evalContext, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
+	if !ok {
+		evalContext = evalcontext.EvaluationContext{}
+	}
+
+	vars, err := e.impl.BuildExpressionVariables(opts, e.Plugins, &evalContext)
+	if err != nil {
+		return nil, fmt.Errorf("building expression variable set: %w", err)
+	}
+
+	ast, err := e.impl.CompileCode(e.Environment, code)
+	if err != nil {
+		return nil, fmt.Errorf("compiling expression: %w", err)
+	}
+
+	return e.impl.EvaluateExpression(e.Environment, ast, vars)
+}
+
 func (e *Evaluator) ExecChainedSelector(
 	ctx context.Context, opts *options.EvaluatorOptions, chained *papi.ChainedPredicate, predicate attestation.Predicate,
 ) ([]attestation.Subject, error) {

--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -554,6 +554,8 @@ func (dce *defaulCelEvaluator) BuildSelectorVariables(
 // `subject`, the already-resolved `context` and any plugin-provided globals,
 // but intentionally omits `predicate` and `predicates` since those are not
 // available at context-assembly time.
+//
+//nolint:gocritic // *map return type matches BuildVariables/BuildSelectorVariables
 func (dce *defaulCelEvaluator) BuildExpressionVariables(
 	opts *options.EvaluatorOptions, plugins map[string]Plugin,
 	evalContext *evalcontext.EvaluationContext,

--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -39,6 +39,8 @@ type CelEvaluatorImplementation interface {
 	Assert(*papi.ResultSet) bool
 	BuildSelectorVariables(*options.EvaluatorOptions, map[string]Plugin, *evalcontext.EvaluationContext, *papi.Policy, attestation.Subject, *papi.ChainedPredicate, attestation.Predicate) (*map[string]any, error)
 	EvaluateChainedSelector(*cel.Env, *cel.Ast, *map[string]any) ([]attestation.Subject, error)
+	BuildExpressionVariables(*options.EvaluatorOptions, map[string]Plugin, *evalcontext.EvaluationContext) (*map[string]any, error)
+	EvaluateExpression(*cel.Env, *cel.Ast, *map[string]any) (any, error)
 }
 
 type defaulCelEvaluator struct{}
@@ -545,4 +547,59 @@ func (dce *defaulCelEvaluator) BuildSelectorVariables(
 	}
 
 	return &ret, nil
+}
+
+// BuildExpressionVariables builds the variable set available to standalone
+// expressions (used to resolve dynamic ContextVal expressions). It exposes
+// `subject`, the already-resolved `context` and any plugin-provided globals,
+// but intentionally omits `predicate` and `predicates` since those are not
+// available at context-assembly time.
+func (dce *defaulCelEvaluator) BuildExpressionVariables(
+	opts *options.EvaluatorOptions, plugins map[string]Plugin,
+	evalContext *evalcontext.EvaluationContext,
+) (*map[string]any, error) {
+	ret := map[string]any{}
+
+	subdata, err := extractSubjectData(evalContext.Subject)
+	if err != nil {
+		return nil, fmt.Errorf("loading subject data onto expression runtime: %w", err)
+	}
+	ret[VarNameSubject] = subdata
+
+	s, err := structpb.NewStruct(evalContext.ContextValues)
+	if err != nil {
+		return nil, fmt.Errorf("structuring context data: %w", err)
+	}
+	ret[VarNameContext] = s
+
+	for _, p := range plugins {
+		maps.Copy(ret, p.VarValues(evalContext.Policy, evalContext.Subject, nil))
+	}
+
+	return &ret, nil
+}
+
+// EvaluateExpression runs a compiled standalone expression and returns the
+// resolved Go value (via ref.Val.Value()).
+func (dce *defaulCelEvaluator) EvaluateExpression(
+	//nolint:gocritic // vars is intentionally passed by pointer to match siblings
+	env *cel.Env, ast *cel.Ast, vars *map[string]any,
+) (any, error) {
+	if env == nil {
+		return nil, fmt.Errorf("CEL environment not set")
+	}
+	if vars == nil {
+		return nil, fmt.Errorf("variable set undefined")
+	}
+
+	program, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+	if err != nil {
+		return nil, fmt.Errorf("generating program from AST: %w", err)
+	}
+
+	result, _, err := program.Eval(*vars)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation error: %w", err)
+	}
+	return result.Value(), nil
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -33,4 +33,10 @@ func (f *Factory) Get(opts *options.EvaluatorOptions, c class.Class) (Evaluator,
 type Evaluator interface {
 	ExecTenet(context.Context, *options.EvaluatorOptions, *papi.Tenet, []attestation.Predicate) (*papi.EvalResult, error)
 	ExecChainedSelector(context.Context, *options.EvaluatorOptions, *papi.ChainedPredicate, attestation.Predicate) ([]attestation.Subject, error)
+
+	// EvalExpression evaluates a standalone expression and returns its value.
+	// Used to resolve dynamic ContextVal expressions. The evaluator reads the
+	// subject and any other evaluation-time data from the evalcontext.EvaluationContext
+	// stored in ctx.
+	EvalExpression(context.Context, *options.EvaluatorOptions, string) (any, error)
 }

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -76,7 +76,7 @@ type AmpelVerifier interface {
 	ProcessPolicySetChainedSubjects(context.Context, *VerificationOptions, map[class.Class]evaluator.Evaluator, *collector.Agent, *papi.PolicySet, map[string]any, attestation.Subject, []attestation.Envelope) ([]attestation.Subject, []*papi.ChainedSubject, bool, error)
 
 	// AssembleEvalContextValues builds the policy context values by mixing defaults and defined values
-	AssembleEvalContextValues(context.Context, *VerificationOptions, map[string]*papi.ContextVal) (map[string]any, error)
+	AssembleEvalContextValues(context.Context, *VerificationOptions, map[class.Class]evaluator.Evaluator, map[string]*papi.ContextVal) (map[string]any, error)
 }
 
 type defaultIplementation struct{}
@@ -834,7 +834,9 @@ func newResourceDescriptorFromSubject(s attestation.Subject) *gointoto.ResourceD
 // the context definition starting with its defaults, received values from
 // upstream and context value providers.
 func (di *defaultIplementation) AssembleEvalContextValues(
-	ctx context.Context, opts *VerificationOptions, contextValues map[string]*papi.ContextVal,
+	ctx context.Context, opts *VerificationOptions,
+	evaluators map[class.Class]evaluator.Evaluator,
+	contextValues map[string]*papi.ContextVal,
 ) (map[string]any, error) {
 	errs := []error{}
 
@@ -904,36 +906,96 @@ func (di *defaultIplementation) AssembleEvalContextValues(
 	logrus.Debugf("[CTX] Assembled Context: %+v", assembledContext)
 	logrus.Debugf("[CTX] Context Values: %+v", definitions)
 
-	// Assemble the context by overriding values in order
-	for k, contextDef := range assembledContext {
+	// Resolution is done in two phases over a stable, sorted key order:
+	//
+	//   Phase 1 — resolve every static entry (value, default, provider).
+	//   Snapshot — publish the Phase 1 results onto the evalcontext so they
+	//              are reachable from CEL as `context.<name>`.
+	//   Phase 2 — resolve every expression entry with the static-only
+	//             snapshot in scope. Expression results are NOT added to the
+	//             snapshot, so sibling expressions cannot observe each other.
+	//
+	// Sorting both phases makes ordering deterministic and keeps any errors
+	// reported in a stable order.
+	sortedKeys := slices.Sorted(maps.Keys(assembledContext))
+
+	// Phase 1: static values.
+	for _, k := range sortedKeys {
+		contextDef := assembledContext[k]
+		if contextDef.GetExpression() != "" {
+			continue
+		}
 		var v any
-		// First case: If the policy has a burned in value, that is it.
-		// Burned context values into the policy are signed and cannot
-		// be modified.
+		// Burned-in value wins outright; cannot be overridden by callers.
 		if contextDef.Value != nil {
-			// Potential change:
-			// Here if the defined values attempt to flip a value
-			// burned in the policy code, perhaps we should return
-			// an error instead of ignoring.
 			values[k] = contextDef.Value.AsInterface()
 			continue
 		}
 
-		// Second. The overridable base value is the policy default:
+		// Default is the overridable base.
 		if contextDef.Default != nil {
 			v = contextDef.Default.AsInterface()
 		}
 
-		// Third. If there is a value defined, we override the default:
+		// Provider-supplied values override the default.
 		if _, ok := definitions[k]; ok {
 			v = definitions[k]
 		}
 
 		values[k] = v
 
-		// Fail if the value is required and not set
+		// Required values must end Phase 1 with a non-nil value; expression
+		// values are checked separately in Phase 2.
 		if contextDef.Required != nil && *contextDef.Required && values[k] == nil {
 			errs = append(errs, fmt.Errorf("context value %s is required but not set", k))
+		}
+	}
+
+	// Phase 2: dynamic values resolved by an evaluator runtime. We publish a
+	// snapshot of the Phase 1 results onto the evalcontext so that CEL
+	// expressions see them via `context.<name>`. The snapshot is built once
+	// and never mutated, so expressions cannot depend on each other.
+	hasExpressions := false
+	for _, contextDef := range assembledContext {
+		if contextDef.GetExpression() != "" {
+			hasExpressions = true
+			break
+		}
+	}
+	if hasExpressions {
+		exprCtx := ctx
+		if ec, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext); ok {
+			snapshot := make(map[string]any, len(values))
+			maps.Copy(snapshot, values)
+			ec.ContextValues = snapshot
+			exprCtx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, ec)
+		}
+
+		for _, k := range sortedKeys {
+			contextDef := assembledContext[k]
+			expr := contextDef.GetExpression()
+			if expr == "" {
+				continue
+			}
+			cls := class.Class(contextDef.GetRuntime())
+			if cls == "" {
+				cls = "default"
+			}
+			ev, ok := evaluators[cls]
+			if !ok {
+				errs = append(errs, fmt.Errorf("context value %q: runtime %q not available", k, cls))
+				continue
+			}
+			out, err := ev.EvalExpression(exprCtx, &opts.EvaluatorOptions, expr)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("evaluating expression for context value %q: %w", k, err))
+				continue
+			}
+			values[k] = out
+
+			if contextDef.Required != nil && *contextDef.Required && values[k] == nil {
+				errs = append(errs, fmt.Errorf("context value %s is required but not set", k))
+			}
 		}
 	}
 

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -327,7 +327,10 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 
 	// Publish the subject on the evalcontext so context-value expressions and
 	// the evaluator runtimes can reach it via ctx.
-	ec, _ := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
+	ec, ok := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
+	if !ok {
+		ec = evalcontext.EvaluationContext{}
+	}
 	ec.Subject = subject
 	ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, ec)
 

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -157,9 +157,14 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 	// Load the policyset eval ctx definition into the go contect
 	ctx, evalContext := ampel.loadElementEvalContextDef(ctx, policySet)
 
+	// Publish the subject on the evalcontext so context-value expressions and
+	// the evaluator runtimes can reach it via ctx.
+	evalContext.Subject = subject
+	ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, evalContext)
+
 	// Here we build the context that will be common for all policies as defined
 	// in the policy set.
-	evalContextValues, err := ampel.impl.AssembleEvalContextValues(ctx, &opts, policySet.GetCommon().GetContext())
+	evalContextValues, err := ampel.impl.AssembleEvalContextValues(ctx, &opts, evaluators, policySet.GetCommon().GetContext())
 	if err != nil {
 		return nil, fmt.Errorf("assembling policy context: %w", err)
 	}
@@ -320,7 +325,13 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 		return nil, fmt.Errorf("parsing single attestations: %w", err)
 	}
 
-	evalContext, err := ampel.impl.AssembleEvalContextValues(ctx, opts, policy.GetContext())
+	// Publish the subject on the evalcontext so context-value expressions and
+	// the evaluator runtimes can reach it via ctx.
+	ec, _ := ctx.Value(evalcontext.EvaluationContextKey{}).(evalcontext.EvaluationContext)
+	ec.Subject = subject
+	ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, ec)
+
+	evalContext, err := ampel.impl.AssembleEvalContextValues(ctx, opts, evaluators, policy.GetContext())
 	if err != nil {
 		return nil, fmt.Errorf("assembling policy context: %w", err)
 	}
@@ -461,9 +472,14 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 	// Load the policyset eval ctx definition into the go contect
 	ctx, evalContext := ampel.loadElementEvalContextDef(ctx, group)
 
+	// Publish the subject on the evalcontext so context-value expressions and
+	// the evaluator runtimes can reach it via ctx.
+	evalContext.Subject = subject
+	ctx = context.WithValue(ctx, evalcontext.EvaluationContextKey{}, evalContext)
+
 	// Here we build the context that will be common for all policies as defined
 	// in the policy group.
-	evalContextValues, err := ampel.impl.AssembleEvalContextValues(ctx, &opts, group.GetCommon().GetContext())
+	evalContextValues, err := ampel.impl.AssembleEvalContextValues(ctx, &opts, evaluators, group.GetCommon().GetContext())
 	if err != nil {
 		return nil, fmt.Errorf("assembling policy context: %w", err)
 	}


### PR DESCRIPTION
This PR adds the implementation of the expressions evaluator in context values.

Previously, expressions were limited to fixed values. As of v0.5.0 of the policy framework, policies can now define context values from expressions. Context is evaluated early but context expressions have access to some data like the fixed context values, the subject information and (in CEL) any loaded plugins.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>