### PR TITLE
Switch display to term table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
 	github.com/carabiner-dev/policy v0.5.0
 	github.com/carabiner-dev/predicates v0.5.0
+	github.com/carabiner-dev/termtable v1.0.0
 	github.com/fatih/color v1.19.0
 	github.com/google/cel-go v0.28.0
 	github.com/in-toto/attestation v1.2.0
@@ -156,6 +157,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/regclient/regclient v0.11.3 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sigstore/gitsign v0.14.1-0.20260414150136-4638d83b00e1 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.2.1 // indirect
 	github.com/sigstore/sigstore-go v1.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,6 @@ github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oM
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/carabiner-dev/attestation v0.2.1 h1:VhjV5YlO9TsW50Sr/Zd54bdbZhhDAqgxC3kB9z1I+3Q=
 github.com/carabiner-dev/attestation v0.2.1/go.mod h1:O84vF84RZG3pJO/6BYrPs718bZviHF5DKajP1HsrDpw=
-github.com/carabiner-dev/collector v0.3.5-0.20260421015520-813214e38160 h1:6dmpEwmIjUADv73sIjld5y6hg0hgp71gSSzldtdtQxg=
-github.com/carabiner-dev/collector v0.3.5-0.20260421015520-813214e38160/go.mod h1:WgoEaH6peXynITtICYvoPLRfLYgmWIZbkx8LVgj1wvM=
 github.com/carabiner-dev/collector v0.3.5 h1:D7cKPyjLl69yLqeeQHVwd5fR6YhvudMNEFOmLQgFg1o=
 github.com/carabiner-dev/collector v0.3.5/go.mod h1:WgoEaH6peXynITtICYvoPLRfLYgmWIZbkx8LVgj1wvM=
 github.com/carabiner-dev/command v0.3.1 h1:iBkh+AjwziFZmyihv/izypCV74nkmaslZxb5AgP7GP4=
@@ -120,6 +118,8 @@ github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTur
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
 github.com/carabiner-dev/signer v0.4.5 h1:H3XHHqorZw7wvLysbGCc+FM90nSdzFlODj+mIGMsYJc=
 github.com/carabiner-dev/signer v0.4.5/go.mod h1:B/53ToJAIgwM+KuDwj52+HwnlA5p8Rmz2OXQdy9x+xs=
+github.com/carabiner-dev/termtable v1.0.0 h1:z8xZCfOhQQSU58onrE3eVBFWZLCxlU0/D4EySqxW1E0=
+github.com/carabiner-dev/termtable v1.0.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.4.3 h1:rXKwVT8N4hS85GEJQGd0ZgOjTcALuCslsqZyg4g6qxA=
 github.com/carabiner-dev/vcslocator v0.4.3/go.mod h1:o0v3BV06HMg20GaJctA8feu0W/aan+XhHq0i+wr6Jq0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -413,6 +413,8 @@ github.com/protobom/protobom v0.5.5 h1:empsX+5PTBSZr5fcKY2m9QcEblVTk30JhkwCTOZbK
 github.com/protobom/protobom v0.5.5/go.mod h1:BHRle+iMKbIO1jlSseQvhIOgXYkdS4PjN3wfUeByV/0=
 github.com/regclient/regclient v0.11.3 h1:aTnVRsgFaOmezgKp7caL3zINrZKAXsMbzS1oCgD7/cA=
 github.com/regclient/regclient v0.11.3/go.mod h1:a4PDi+VyEbBuV/5hCfMjnYH8jvB7NgD0mdggwNRECy8=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/drivers/tty/driver.go
+++ b/internal/drivers/tty/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
 package tty
@@ -8,52 +8,40 @@ import (
 	"io"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
-
-	"github.com/carabiner-dev/ampel/internal/drivers/gotable"
 )
 
+// New returns the TTY driver, wired to the default Decorator.
 func New() *Driver {
-	return &Driver{
-		TableWriter: gotable.TableBuilder{
-			Decorator: &Decorator{},
-		},
-	}
+	return &Driver{Decorator: &Decorator{}}
 }
 
+// Driver renders Ampel results as ANSI-styled terminal tables using
+// github.com/carabiner-dev/termtable. The tables auto-size to the
+// attached terminal and clip overwide output to the screen.
 type Driver struct {
-	TableWriter gotable.TableBuilder
+	Decorator *Decorator
 }
 
-// RenderResultSet takes a resultset
+// RenderResultSet writes the 4-column policy-set table to w.
 func (d *Driver) RenderResultSet(w io.Writer, rset *papi.ResultSet) error {
-	t, err := d.TableWriter.ResultSetTable(rset)
-	if err != nil {
+	if _, err := d.resultSetTable(rset).WriteTo(w); err != nil {
 		return fmt.Errorf("rendering ResultSet table: %w", err)
 	}
-
-	t.SetOutputMirror(w)
-	t.Render()
 	return nil
 }
 
-// RenderResultSet takes a resultset
+// RenderResultGroup writes the 4-column policy-group table to w.
 func (d *Driver) RenderResultGroup(w io.Writer, rset *papi.ResultGroup) error {
-	t, err := d.TableWriter.ResultGroupTable(rset)
-	if err != nil {
-		return fmt.Errorf("rendering ResultSet table: %w", err)
+	if _, err := d.resultGroupTable(rset).WriteTo(w); err != nil {
+		return fmt.Errorf("rendering ResultGroup table: %w", err)
 	}
-
-	t.SetOutputMirror(w)
-	t.Render()
 	return nil
 }
 
+// RenderResult writes the 3-column single-result table to w.
 func (d *Driver) RenderResult(w io.Writer, result *papi.Result) error {
-	t, err := d.TableWriter.ResultsTable(result)
-	if err != nil {
-		return fmt.Errorf("building table: %w", err)
+	if _, err := d.resultTable(result).WriteTo(w); err != nil {
+		return fmt.Errorf("rendering Result table: %w", err)
 	}
-	t.SetOutputMirror(w)
-	t.Render()
 	return nil
 }

--- a/internal/drivers/tty/table.go
+++ b/internal/drivers/tty/table.go
@@ -1,0 +1,360 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package tty
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/termtable"
+)
+
+// dateFormat is the one-second-resolution layout used for result
+// timestamps. Matches Go's default time.Time stringer minus the
+// fractional seconds.
+const dateFormat = "2006-01-02 15:04:05 -0700 MST"
+
+// localDate renders t in the user's local zone at second resolution.
+func localDate(t time.Time) string {
+	return t.Local().Format(dateFormat)
+}
+
+// resultTable builds the single-result view: a 3-column table with a
+// banner, a metadata block (label/value via a colspan=2 label), and a
+// per-check rundown below.
+func (d *Driver) resultTable(result *papi.Result) *termtable.Table {
+	t := termtable.NewTable()
+
+	d.banner(t, "Evaluation Results", 3)
+
+	// Col 0 holds the Check ID (identifier-style) — bounded the same
+	// way as the identifier columns in the other views.
+	t.Column(0).Style("white-space: nowrap; min-width: 20%; max-width: 25")
+	// Col 1 holds the Status in the per-check section (● PASS /
+	// ● FAIL / ● SOFTFAIL) — same fixed 10-column slot as the other
+	// views so the dot + label never splits and the widest case
+	// (SOFTFAIL = 8 chars + dot + space = 10) fits exactly.
+	t.Column(1).Style("white-space: nowrap; width: 10")
+
+	switch {
+	case result.GetMeta().GetDescription() != "":
+		txt := result.GetMeta().GetDescription()
+		if id := result.GetPolicy().GetId(); id != "" {
+			txt = id + ": " + txt
+		}
+		// Explicitly wrap the description — it anchors at col 0 and
+		// would otherwise inherit col 0's nowrap, clipping long
+		// descriptions on narrow terminals.
+		row := t.AddRow()
+		row.AddCell(
+			termtable.WithContent(txt),
+			termtable.WithColSpan(3),
+			termtable.WithMultiLine(),
+		)
+	case result.GetPolicy().GetId() != "":
+		addLabeledRow(t, "ID", result.GetPolicy().GetId())
+	}
+
+	addLabeledRow(t, "Status",
+		fmt.Sprintf("%s %s", d.Decorator.StatusToDot(result.Status), d.Decorator.Bold(result.Status)))
+	addLabeledRow(t, "Results Date", localDate(result.DateEnd.AsTime()),
+		termtable.WithCellStyle("white-space: nowrap"))
+	addLabeledRow(t, "Execution Time", fmt.Sprint(result.DateEnd.AsTime().Sub(result.DateStart.AsTime())))
+	addLabeledRow(t, "Tenets", d.Decorator.TenetsToString(result))
+	addLabeledRow(t, "Subject", d.Decorator.SubjectToString(result.Subject, result.Chain))
+	if len(result.GetMeta().GetControls()) > 0 {
+		addLabeledRow(t, "Controls", d.Decorator.ControlsToString(result, "", ""))
+	}
+
+	head := t.AddRow()
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Check")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Status")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Message")))
+
+	for i, er := range result.GetEvalResults() {
+		cell := ""
+		if er.GetAssessment() != nil {
+			cell = d.Decorator.AssessmentToString(er.GetAssessment())
+		}
+		if er.Status != papi.StatusPASS {
+			cell = d.Decorator.ErrorToString(er.Error)
+		}
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(
+			d.Decorator.ControlsToString(result, er.Id, fmt.Sprintf("%d", i))))
+		row.AddCell(termtable.WithContent(
+			fmt.Sprintf("%s %s", d.Decorator.StatusToDot(er.Status), er.Status)))
+		row.AddCell(termtable.WithContent(cell))
+	}
+	return t
+}
+
+// resultSetTable builds the 4-column table for a policy-set evaluation:
+// banner, a header line with set ID and date, a subject block, then one
+// row per contained result or group.
+func (d *Driver) resultSetTable(set *papi.ResultSet) *termtable.Table {
+	t := termtable.NewTable()
+
+	d.banner(t, "Evaluation Results", 4)
+
+	// Keep the Policy and Controls columns on a single line — their
+	// contents are identifier-style and wrapping them mid-ID across
+	// multiple rendered lines hurts readability. Bound each to
+	// [20 %, 25 chars] so they claim a visible chunk of the target
+	// even when content is short, and trim with an ellipsis when
+	// content is long.
+	t.Column(0).Style("white-space: nowrap; min-width: 20%; max-width: 25")
+	t.Column(1).Style("white-space: nowrap; min-width: 20%; max-width: 25")
+	// Status is always one of PASS / FAIL / SOFTFAIL, formatted as
+	// "{dot} {STATUS}" — 1 + 1 + 8 = 10 display columns at the widest.
+	// Pin the column so the status dot + label never splits across
+	// lines and the grid stays tidy at any target width.
+	t.Column(2).Style("white-space: nowrap; width: 10")
+
+	idRow := t.AddRow()
+	idRow.AddCell(termtable.WithContent(d.Decorator.Bold("PolicySet")))
+	idRow.AddCell(termtable.WithContent(set.GetPolicySet().GetId()))
+	idRow.AddCell(termtable.WithContent(d.Decorator.Bold("Date")))
+	idRow.AddCell(
+		termtable.WithContent(localDate(set.DateEnd.AsTime())),
+		termtable.WithCellStyle("white-space: nowrap"),
+	)
+
+	if s := set.GetSubject(); s != nil {
+		st := subjectSummary(s)
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(
+			fmt.Sprintf("Status: %s %s",
+				d.Decorator.StatusToDot(set.Status), d.Decorator.Bold(set.Status))))
+		row.AddCell(termtable.WithContent("Subject"))
+		row.AddCell(termtable.WithContent(st), termtable.WithColSpan(2))
+	}
+
+	head := t.AddRow()
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Policy")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Controls")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Status")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Details")))
+
+	for _, r := range set.GetResults() {
+		assessments := collectAssessments(d, r)
+		controls := "-"
+		if len(r.GetMeta().GetControls()) > 0 {
+			controls = d.Decorator.ControlsToString(r, "", "")
+		}
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(r.GetPolicy().GetId()))
+		row.AddCell(termtable.WithContent(controls))
+		row.AddCell(termtable.WithContent(
+			fmt.Sprintf("%s %s", d.Decorator.StatusToDot(r.Status), d.Decorator.Bold(r.Status))))
+		row.AddCell(termtable.WithContent(assessments))
+	}
+
+	for _, grp := range set.GetGroups() {
+		id := grp.GetGroup().GetId()
+		message := groupSummary(d, grp)
+		controls := "-"
+		if len(grp.GetMeta().GetControls()) > 0 {
+			controls = d.Decorator.ControlsToString(&papi.Result{
+				Meta: &papi.Meta{Controls: grp.GetMeta().GetControls()},
+			}, "", "")
+		}
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(id))
+		row.AddCell(termtable.WithContent(controls))
+		row.AddCell(termtable.WithContent(
+			fmt.Sprintf("%s %s", d.Decorator.StatusToDot(grp.GetStatus()), d.Decorator.Bold(grp.GetStatus()))))
+		row.AddCell(termtable.WithContent(message))
+	}
+
+	return t
+}
+
+// resultGroupTable builds the 4-column table for a group evaluation:
+// banner, group ID + date line, subject block, then one row per
+// evaluated policy block.
+func (d *Driver) resultGroupTable(grp *papi.ResultGroup) *termtable.Table {
+	t := termtable.NewTable()
+
+	d.banner(t, "Evaluation Results", 4)
+
+	// Mirror the policy-set layout: cols 0 & 1 are identifier-style
+	// (nowrap, [20 %, 25]), col 2 is the fixed-width status slot
+	// (just wide enough for "● SOFTFAIL"), col 3 (Details) wraps
+	// free-form text.
+	t.Column(0).Style("white-space: nowrap; min-width: 20%; max-width: 25")
+	t.Column(1).Style("white-space: nowrap; min-width: 20%; max-width: 25")
+	t.Column(2).Style("white-space: nowrap; width: 10")
+
+	idRow := t.AddRow()
+	idRow.AddCell(termtable.WithContent(d.Decorator.Bold("PolicyGroup")))
+	idRow.AddCell(termtable.WithContent(grp.GetGroup().GetId()))
+	idRow.AddCell(termtable.WithContent(d.Decorator.Bold("Date")))
+	idRow.AddCell(
+		termtable.WithContent(localDate(grp.DateEnd.AsTime())),
+		termtable.WithCellStyle("white-space: nowrap"),
+	)
+
+	if s := grp.GetSubject(); s != nil {
+		st := subjectSummary(s)
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(
+			d.Decorator.Bold("Status:") +
+				fmt.Sprintf(" %s %s",
+					d.Decorator.StatusToDot(grp.GetStatus()),
+					d.Decorator.Bold(grp.GetStatus()))))
+		row.AddCell(termtable.WithContent(d.Decorator.Bold("Subject")))
+		row.AddCell(termtable.WithContent(st), termtable.WithColSpan(2))
+	}
+
+	head := t.AddRow()
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Policy Block")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Controls")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Status")))
+	head.AddCell(termtable.WithContent(d.Decorator.Bold("Details")))
+
+	for i, r := range grp.GetEvalResults() {
+		id := r.GetId()
+		if id == "" {
+			id = fmt.Sprintf("Block #%d", i)
+		}
+
+		var message string
+		if r.GetStatus() == papi.StatusPASS {
+			message = fmt.Sprintf("(%d policies)", len(r.Results))
+		} else {
+			message = r.GetError().GetMessage()
+			if r.GetError().GetGuidance() != "" {
+				message = "\n" + r.GetError().GetGuidance()
+			}
+		}
+
+		controls := "-"
+		if len(r.GetMeta().GetControls()) > 0 {
+			controls = d.Decorator.ControlsToString(&papi.Result{
+				Meta: &papi.Meta{Controls: r.GetMeta().GetControls()},
+			}, "", "")
+		}
+
+		row := t.AddRow()
+		row.AddCell(termtable.WithContent(id))
+		row.AddCell(termtable.WithContent(controls))
+		row.AddCell(termtable.WithContent(
+			fmt.Sprintf("%s %s", d.Decorator.StatusToDot(r.Status), d.Decorator.Bold(r.Status))))
+		row.AddCell(termtable.WithContent(message))
+	}
+
+	return t
+}
+
+// banner places the Ampel banner as the first row, spanning cols
+// left-aligned.
+func (d *Driver) banner(t *termtable.Table, legend string, cols int) {
+	row := t.AddRow()
+	row.AddCell(
+		termtable.WithContent(d.Decorator.AmpelBanner(legend)),
+		termtable.WithColSpan(cols),
+		termtable.WithAlign(termtable.AlignLeft),
+	)
+}
+
+// addLabeledRow adds a {label (colspan 2), value} row — the metadata
+// shape used by the single-result table. Any cell options passed via
+// valueOpts are applied to the value cell (in addition to its content),
+// so callers can e.g. prevent wrapping on a specific row.
+func addLabeledRow(t *termtable.Table, label, value string, valueOpts ...termtable.CellOption) {
+	row := t.AddRow()
+	row.AddCell(termtable.WithContent(label), termtable.WithColSpan(2))
+	row.AddCell(append([]termtable.CellOption{termtable.WithContent(value)}, valueOpts...)...)
+}
+
+// subjectSummary formats a subject's name + truncated digests. The
+// layout here mirrors the original go-pretty rendering for continuity
+// with the markdown and html drivers.
+func subjectSummary(s interface {
+	GetName() string
+	GetDigest() map[string]string
+},
+) string {
+	var b strings.Builder
+	if s.GetName() != "" {
+		b.WriteString(s.GetName())
+		b.WriteByte('\n')
+	}
+	for algo, val := range s.GetDigest() {
+		cut := int(math.Min(32, float64(len(val))))
+		fmt.Fprintf(&b, "- %s:%s...\n", algo, val[0:cut])
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// collectAssessments concatenates the per-check assessments / errors
+// that should appear in the Details column of a ResultSet row.
+func collectAssessments(d *Driver, r *papi.Result) string {
+	var b strings.Builder
+	for _, er := range r.GetEvalResults() {
+		switch {
+		case er.GetStatus() == papi.StatusPASS && r.GetStatus() == papi.StatusPASS:
+			b.WriteString(er.GetAssessment().GetMessage())
+			b.WriteByte('\n')
+		case er.GetStatus() != papi.StatusPASS && r.GetStatus() != papi.StatusPASS:
+			line := er.GetError().GetMessage() + "\n"
+			if !strings.Contains(b.String(), line) {
+				b.WriteString(d.Decorator.ErrorToString(er.GetError()))
+			}
+		}
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// groupSummary builds the Details-column text for a result-group row
+// inside a ResultSet — pass messages on success, dedup'd error
+// messages on failure.
+func groupSummary(d *Driver, grp *papi.ResultGroup) string {
+	_ = d
+	if grp.GetStatus() == papi.StatusPASS {
+		msgs := []string{}
+		seen := map[string]struct{}{}
+		for _, block := range grp.GetEvalResults() {
+			prefix := ""
+			if ctls := block.GetMeta().GetControls(); len(ctls) > 0 {
+				labels := make([]string, 0, len(ctls))
+				for _, ctl := range ctls {
+					labels = append(labels, ctl.Label())
+				}
+				prefix = "[" + strings.Join(labels, ", ") + "] "
+			}
+			for _, res := range block.GetResults() {
+				for _, er := range res.GetEvalResults() {
+					if msg := er.GetAssessment().GetMessage(); msg != "" {
+						line := prefix + msg
+						if _, ok := seen[line]; !ok {
+							seen[line] = struct{}{}
+							msgs = append(msgs, line)
+						}
+					}
+				}
+			}
+		}
+		return strings.Join(msgs, "\n")
+	}
+
+	msgs := []string{}
+	seen := map[string]struct{}{}
+	for _, block := range grp.GetEvalResults() {
+		if block.GetStatus() != papi.StatusFAIL {
+			continue
+		}
+		if msg := block.GetError().GetMessage(); msg != "" {
+			if _, ok := seen[msg]; !ok {
+				seen[msg] = struct{}{}
+				msgs = append(msgs, msg)
+			}
+		}
+	}
+	return strings.Join(msgs, "\n")
+}


### PR DESCRIPTION
This PR reimplements the tty display driver to use carabiner's termtable module that displays better tables than the previous module we were using.