### PR TITLE
Add semver CEL plugin

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,11 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
+      - name: Check go.mod
+        id: gomodtidy
+        uses: carabiner-dev/actions/go/modtidy@e9aa1ccdf9e93cbd1f8965d6178b85d2b7d3a1f9
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.10
+          version: v2.11

--- a/docs/03-ampel-policy-guide.md
+++ b/docs/03-ampel-policy-guide.md
@@ -252,7 +252,8 @@ tenet body. The available variables are:
   current scope. Expression-resolved siblings at the current scope are not
   visible (see "Resolution order" above).
 - Any global variables and functions registered by runtime plugins (for
-  example, the `hasher`, `url`, and `purl` helpers in the CEL runtime).
+  example, the `hasher`, `url`, `purl`, and `semver` helpers in the CEL
+  runtime).
 
 The following are intentionally *not* available, because they are not yet
 known when context values are assembled: `predicate`, `predicates`, the

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,4 +102,6 @@ contributions are welcome!
 - Appendix A: The AMPEL CEL Runtime
   - The Runtime Environment
   - AMPEL Functions
-  - Plugins
+  - [Plugins](cel-plugins.md) — the runtime globals (`hasher`,
+    `url`, `github`, `protobom`, `purl`, `semver`) available in
+    every CEL expression.

--- a/docs/cel-plugins.md
+++ b/docs/cel-plugins.md
@@ -1,0 +1,204 @@
+# CEL plugins
+
+AMPEL's CEL evaluator ships with a handful of plugins that register
+extra globals in every policy expression. The same environment is
+used by:
+
+- **Tenet code** (`tenets[].code` in a policy)
+- **Chained-subject selectors** (`chain[].predicate.selector`)
+- **Context-value expressions** (`context.<name>.expression` at any
+  scope — PolicySet, PolicyGroup, or Policy common blocks)
+
+So `semver.satisfies(...)`, `hasher.sha256(...)`, `purl.name(...)`,
+etc. all work anywhere CEL runs.
+
+Plugins are registered automatically when `LoadDefaultPlugins: true`
+is set on the evaluator options (the default). Callers embedding
+AMPEL can opt out and register a smaller set themselves via
+`Evaluator.RegisterPlugin`.
+
+- [`hasher`](#hasher) — hash arbitrary strings.
+- [`url`](#url) — parse URLs into components.
+- [`github`](#github) — parse GitHub repo / branch URIs.
+- [`protobom`](#protobom) — query SBOMs attached as predicates.
+- [`purl`](#purl) — parse Package URLs.
+- [`semver`](#semver) — parse and compare semantic-version strings.
+
+---
+
+## `hasher`
+
+Computes cryptographic digests over string content. Useful when a
+tenet needs to confirm that content hashes to an expected value, or
+for building quick digest tables inside a context expression.
+
+| Expression                              | Returns  | Description                                |
+|:----------------------------------------|:---------|:-------------------------------------------|
+| `hasher.sha256("hello")`                | `string` | Hex-encoded SHA-256 digest.                |
+| `hasher.sha1("hello")`                  | `string` | Hex-encoded SHA-1 digest. Legacy use only. |
+| `hasher.sha512("hello")`                | `string` | Hex-encoded SHA-512 digest.                |
+
+Also exposes a read-only `hashAlgorithms` list holding the supported
+algorithm names.
+
+```cel
+hasher.sha256(predicate.data.source) == subject.digest.sha256
+```
+
+---
+
+## `url`
+
+Parses a URL string into its scheme / host / path / fragment parts.
+
+| Expression                       | Returns                | Description                  |
+|:---------------------------------|:-----------------------|:-----------------------------|
+| `url.parse("https://example.com/a#b")` | `map<string, string>` | `{scheme, host, path, fragment}`. |
+
+```cel
+url.parse(predicate.data.source).host.endsWith("apache.org")
+```
+
+Malformed URLs produce a CEL evaluation error.
+
+---
+
+## `github`
+
+Helpers for working with GitHub URIs (as they appear in SLSA
+provenance, source descriptors, etc.).
+
+| Expression                                               | Returns               | Description                                       |
+|:---------------------------------------------------------|:----------------------|:--------------------------------------------------|
+| `github.parseRepo("github.com/owner/repo")`              | `map<string, any>`    | `{org, repo, host, ...}` — legacy helper.         |
+| `github.orgDescriptorFromURI("https://github.com/owner")` | `map<string, any>`    | Organisation descriptor (in-toto subject shape).  |
+| `github.repoDescriptorFromURI("https://github.com/owner/repo")` | `map<string, any>` | Repository descriptor.                            |
+| `github.branchDescriptorFromURI("https://github.com/owner/repo", "main")` | `map<string, any>` | Repo + branch descriptor.                         |
+
+```cel
+github.repoDescriptorFromURI(
+    predicate.data.buildDefinition.resolvedDependencies[0].uri
+).name == "source-tool"
+```
+
+---
+
+## `protobom`
+
+Exposes SBOM helpers when the subject carries SPDX or CycloneDX
+predicates. The plugin delegates to the
+[`protobom/cel` library](https://github.com/protobom/cel), which
+defines the `Document`, `Node`, `NodeList`, etc. receiver types and
+a rich set of filter/map/query methods on them.
+
+| Variable / expression  | Returns    | Description                                                  |
+|:-----------------------|:-----------|:-------------------------------------------------------------|
+| `sboms`                | `list`     | All SBOM documents attached to the subject as predicates.    |
+| `sboms[i].get_root_nodes()` | `list` | Top-level nodes of document `i`.                             |
+| `sboms[i].get_node_list().get_nodes().filter(...)` | `list` | Tree-walk filter over nodes.                                 |
+
+A real policy often looks like this (from the apache-commons
+policyset):
+
+```cel
+cel.bind(
+    root, sboms[0].get_root_nodes()[0],
+    sboms[0].get_node_list()
+        .get_node_descendants(root.id, 1).get_nodes()
+        .filter(n, n.id != root.id)
+        .map(n, {
+            "name":   n.name,
+            "uri":    has(n.identifiers.PURL) ? n.identifiers.PURL : "",
+            "digest": n.hashes,
+        })
+)
+```
+
+See the protobom/cel library README for the full list of methods on
+each type.
+
+---
+
+## `purl`
+
+Parses a [Package URL](https://github.com/package-url/purl-spec) into
+its components.
+
+| Expression                                    | Returns                | Description                                   |
+|:----------------------------------------------|:-----------------------|:----------------------------------------------|
+| `purl.parse("pkg:maven/org.x/lib@1.0")`       | `map<string, any>`     | Full parse — every component at once.         |
+| `purl.packageType("pkg:maven/org.x/lib")`     | `string`               | The `pkg:<type>` portion (e.g. `"maven"`).    |
+| `purl.namespace("pkg:maven/org.x/lib")`       | `string`               | The namespace (e.g. `"org.x"`).               |
+| `purl.name("pkg:maven/org.x/lib")`            | `string`               | The package name.                             |
+| `purl.version("pkg:maven/org.x/lib@1.0")`     | `string`               | The version, if any.                          |
+| `purl.qualifiers("pkg:deb?arch=amd64")`       | `map<string, string>`  | The `?key=value` qualifiers.                  |
+| `purl.subpath("pkg:npm/@scope/x@1#lib/a.js")` | `string`               | The `#subpath` portion.                       |
+
+```cel
+purl.packageType(subject.name) == "maven" &&
+purl.namespace(subject.name) == "org.apache.commons"
+```
+
+Unparseable PURL strings return a CEL evaluation error.
+
+---
+
+## `semver`
+
+Parses and compares [Semantic Versioning 2.0.0](https://semver.org/)
+strings. Accepts versions with or without a leading `v`.
+
+| Expression                                  | Returns  | Description                                                                |
+|:--------------------------------------------|:---------|:---------------------------------------------------------------------------|
+| `semver.major("1.2.3")`                     | `int`    | Major component.                                                           |
+| `semver.minor("1.2.3")`                     | `int`    | Minor component.                                                           |
+| `semver.patch("1.2.3")`                     | `int`    | Patch component.                                                           |
+| `semver.prerelease("1.2.3-alpha.1")`        | `string` | Pre-release label, or `""`.                                                |
+| `semver.build("1.2.3+sha.abc")`             | `string` | Build metadata, or `""`.                                                   |
+| `semver.parse("1.2.3-rc+sha")`              | `map`    | `{major, minor, patch, prerelease, build, original}` as a map.             |
+| `semver.isValid("v1.2.3")`                  | `bool`   | `true` iff the string parses.                                              |
+| `semver.isStable("1.2.3")`                  | `bool`   | `major >= 1` and no pre-release tag.                                       |
+| `semver.compare(a, b)`                      | `int`    | `-1` if `a < b`, `0` if equal, `1` if `a > b`.                             |
+| `semver.isNewer(a, b)`                      | `bool`   | Shorthand for `compare(a, b) > 0`.                                         |
+| `semver.isOlder(a, b)`                      | `bool`   | Shorthand for `compare(a, b) < 0`.                                         |
+| `semver.equal(a, b)`                        | `bool`   | Shorthand for `compare(a, b) == 0`.                                        |
+| `semver.satisfies(v, constraint)`           | `bool`   | npm-style constraint check (`^1.2.3`, `>=1.0.0 <2.0.0`, `~1.2.0`, `||`, …).|
+
+Wrap with `string(...)` when a numeric component is needed as a
+string (e.g. for interpolation):
+
+```cel
+string(semver.major(subject.name)) + "." + string(semver.minor(subject.name))
+```
+
+Common recipes:
+
+```cel
+// Reject builds below a baseline.
+semver.satisfies(predicate.data.version, ">=2.0.0 <3.0.0")
+
+// Block pre-releases from promoting to production.
+semver.isStable(predicate.data.version)
+
+// Only accept patch bumps over a pinned base.
+semver.major(predicate.data.version) == semver.major(context.base) &&
+semver.minor(predicate.data.version) == semver.minor(context.base) &&
+!semver.isOlder(predicate.data.version, context.base)
+```
+
+Invalid version strings (or invalid constraint strings for
+`satisfies`) surface as CEL evaluation errors — guard with
+`semver.isValid(...)` first if a tenet might receive arbitrary
+input.
+
+---
+
+## Adding a plugin
+
+New plugins implement the `Plugin` interface from
+`pkg/api/v1` (`Capabilities`, `CanRegisterFor`, `Library`,
+`VarValues`) and are registered in
+`pkg/evaluator/cel/evaluator.go` alongside the defaults. A minimal
+plugin only needs a single `cel.ObjectType` for its namespace plus
+one or more `cel.Function` registrations — see the `semver` package
+for the smallest working example.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/carabiner-dev/ampel
 go 1.26.2
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/carabiner-dev/attestation v0.2.1
 	github.com/carabiner-dev/collector v0.3.5
 	github.com/carabiner-dev/command v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/CycloneDX/cyclonedx-go v0.10.0 h1:7xyklU7YD+CUyGzSFIARG18NYLsKVn4QFg04qSsu+7Y=
 github.com/CycloneDX/cyclonedx-go v0.10.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/hasher"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/protobom"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/purl"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/semver"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/url"
 )
 
@@ -77,6 +78,7 @@ var (
 	_ Plugin = (*github.Plugin)(nil)
 	_ Plugin = (*protobom.Plugin)(nil)
 	_ Plugin = (*purl.Plugin)(nil)
+	_ Plugin = (*semver.Plugin)(nil)
 )
 
 // rebuildEnvironment builds the environment with the current settings
@@ -96,6 +98,9 @@ func (e *Evaluator) rebuildEnvironment(opts *options.EvaluatorOptions) error {
 		}
 		if err := e.RegisterPlugin(purl.New()); err != nil {
 			return fmt.Errorf("registering purl: %w", err)
+		}
+		if err := e.RegisterPlugin(semver.New()); err != nil {
+			return fmt.Errorf("registering semver: %w", err)
 		}
 	}
 

--- a/pkg/evaluator/plugins/semver/README.md
+++ b/pkg/evaluator/plugins/semver/README.md
@@ -1,0 +1,72 @@
+# `semver` CEL plugin
+
+Exposes a `semver` object inside every CEL tenet so policies can
+parse and compare [Semantic Versioning 2.0.0](https://semver.org/)
+strings without resorting to regex tricks.
+
+Implementation lives in this package; the plugin is registered as a
+default in `pkg/evaluator/cel/evaluator.go`.
+
+## Methods
+
+| Expression                                  | Returns  | Description                                                      |
+|:--------------------------------------------|:---------|:-----------------------------------------------------------------|
+| `semver.major("1.2.3")`                     | `int`    | The major component.                                             |
+| `semver.minor("1.2.3")`                     | `int`    | The minor component.                                             |
+| `semver.patch("1.2.3")`                     | `int`    | The patch component.                                             |
+| `semver.prerelease("1.2.3-alpha.1")`        | `string` | The pre-release label, or `""` if none.                          |
+| `semver.build("1.2.3+sha.abc")`             | `string` | The build metadata, or `""` if none.                             |
+| `semver.parse("1.2.3-alpha+sha")`           | `map`    | All components plus `original`, as a map.                        |
+| `semver.isValid("1.2.3")`                   | `bool`   | True if the argument parses as a semver.                         |
+| `semver.isStable("1.2.3")`                  | `bool`   | True when `major >= 1` and there is no pre-release tag.          |
+| `semver.compare(a, b)`                      | `int`    | `-1` if `a < b`, `0` if equal, `1` if `a > b`.                   |
+| `semver.isNewer(a, b)`                      | `bool`   | Shorthand for `compare(a, b) > 0`.                               |
+| `semver.isOlder(a, b)`                      | `bool`   | Shorthand for `compare(a, b) < 0`.                               |
+| `semver.equal(a, b)`                        | `bool`   | Shorthand for `compare(a, b) == 0`.                              |
+| `semver.satisfies(v, constraint)`           | `bool`   | Evaluates a [Masterminds/semver constraint](https://github.com/Masterminds/semver#checking-version-constraints) (`^1.2.3`, `>=1.0.0 <2.0.0`, `~1.2`, …). |
+
+### Types
+
+`major`, `minor`, and `patch` return `int` so callers can do
+arithmetic directly. Wrap with CEL's `string()` constructor when a
+string is needed:
+
+```cel
+string(semver.major(subject.name))  // -> "1"
+```
+
+### Leading `v`
+
+Version strings with a leading `v` (e.g. `"v1.2.3"`) are accepted
+and produce the same result as the un-prefixed form.
+
+### Validation
+
+Unparseable inputs return a CEL evaluation error. When you need to
+guard an expression, reach for `semver.isValid` first:
+
+```cel
+semver.isValid(subject.name) && semver.major(subject.name) >= 2
+```
+
+## Recipes
+
+Reject artefacts below a baseline:
+
+```cel
+semver.satisfies(predicate.data.version, ">=2.0.0 <3.0.0")
+```
+
+Block pre-release builds from promoting to production:
+
+```cel
+semver.isStable(predicate.data.version)
+```
+
+Only allow patch bumps compared to a pinned base:
+
+```cel
+semver.major(predicate.data.version) == semver.major(context.base) &&
+semver.minor(predicate.data.version) == semver.minor(context.base) &&
+!semver.isOlder(predicate.data.version, context.base)
+```

--- a/pkg/evaluator/plugins/semver/plugin.go
+++ b/pkg/evaluator/plugins/semver/plugin.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package semver provides a CEL-runtime plugin that exposes a
+// `semver` object with helpers for parsing and comparing Semantic
+// Versioning 2.0.0 strings. See docs/03-ampel-policy-guide.md for
+// the list of exposed methods and usage examples.
+package semver
+
+import (
+	"github.com/carabiner-dev/attestation"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/google/cel-go/cel"
+
+	api "github.com/carabiner-dev/ampel/pkg/api/v1"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
+)
+
+// Plugin wires the semver tool into ampel's CEL evaluator.
+type Plugin struct {
+	Tool *SemverTool
+}
+
+// New returns a ready-to-register plugin instance.
+func New() *Plugin {
+	return &Plugin{Tool: &SemverTool{}}
+}
+
+func (p *Plugin) Capabilities() []api.Capability {
+	return []api.Capability{api.CapabilityEvalEnginePlugin}
+}
+
+func (p *Plugin) CanRegisterFor(c class.Class) bool {
+	return c.Name() == "cel"
+}
+
+func (p *Plugin) Library() cel.EnvOption {
+	return cel.Lib(p.Tool)
+}
+
+func (p *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestation.Predicate) map[string]any {
+	return map[string]any{
+		"semver": p.Tool,
+	}
+}

--- a/pkg/evaluator/plugins/semver/semver_test.go
+++ b/pkg/evaluator/plugins/semver/semver_test.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package semver
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+)
+
+// run compiles and evaluates expr against a CEL env preloaded with
+// the semver plugin. Returns the Go value produced by the expression.
+func run(t *testing.T, expr string) any {
+	t.Helper()
+	p := New()
+	env, err := cel.NewEnv(p.Library())
+	require.NoError(t, err)
+
+	ast, iss := env.Compile(expr)
+	require.NoError(t, iss.Err(), "compile %q", expr)
+
+	program, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+	require.NoError(t, err)
+
+	result, _, err := program.Eval(p.VarValues(nil, nil, nil))
+	require.NoError(t, err, "eval %q", expr)
+	return result.Value()
+}
+
+func TestAccessorsReturnComponents(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{"major", `semver.major("1.2.3")`, int64(1)},
+		{"minor", `semver.minor("1.2.3")`, int64(2)},
+		{"patch", `semver.patch("1.2.3")`, int64(3)},
+		{"major-double-digit", `semver.major("10.20.30")`, int64(10)},
+		{"minor-double-digit", `semver.minor("10.20.30")`, int64(20)},
+		{"patch-double-digit", `semver.patch("10.20.30")`, int64(30)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, run(t, tc.expr))
+		})
+	}
+}
+
+func TestMajorToString(t *testing.T) {
+	t.Parallel()
+	// CEL exposes int → string conversion; the "supports returning
+	// string or number" behaviour is achieved by wrapping the int
+	// accessor with the string() constructor.
+	require.Equal(t, "1", run(t, `string(semver.major("1.2.3"))`))
+}
+
+func TestPrereleaseAndBuild(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "alpha.1", run(t, `semver.prerelease("1.2.3-alpha.1")`))
+	require.Empty(t, run(t, `semver.prerelease("1.2.3")`))
+	require.Equal(t, "sha.abc", run(t, `semver.build("1.2.3+sha.abc")`))
+	require.Equal(t, "20130313144700", run(t, `semver.build("1.2.3-beta+20130313144700")`))
+}
+
+func TestComparisonPredicates(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{"isNewer-true", `semver.isNewer("1.2.3", "1.1.3")`, true},
+		{"isNewer-false", `semver.isNewer("1.1.3", "1.2.3")`, false},
+		{"isNewer-equal", `semver.isNewer("1.2.3", "1.2.3")`, false},
+		{"isOlder-true", `semver.isOlder("1.1.3", "1.2.3")`, true},
+		{"isOlder-false", `semver.isOlder("1.2.3", "1.1.3")`, false},
+		{"equal-true", `semver.equal("1.2.3", "1.2.3")`, true},
+		{"equal-false", `semver.equal("1.2.3", "1.2.4")`, false},
+
+		// Prerelease-aware ordering: 1.0.0-alpha < 1.0.0.
+		{"prerelease-older-than-release", `semver.isOlder("1.0.0-alpha", "1.0.0")`, true},
+		{"prerelease-ordering", `semver.isNewer("1.0.0-beta", "1.0.0-alpha")`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, run(t, tc.expr))
+		})
+	}
+}
+
+func TestCompareReturns(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(1), run(t, `semver.compare("1.2.3", "1.1.3")`))
+	require.Equal(t, int64(-1), run(t, `semver.compare("1.1.3", "1.2.3")`))
+	require.Equal(t, int64(0), run(t, `semver.compare("1.2.3", "1.2.3")`))
+}
+
+func TestSatisfiesConstraints(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{"caret-match", `semver.satisfies("1.2.3", "^1.0.0")`, true},
+		{"caret-miss", `semver.satisfies("2.0.0", "^1.0.0")`, false},
+		{"range", `semver.satisfies("1.5.0", ">=1.0.0 <2.0.0")`, true},
+		{"range-upper-exclusive", `semver.satisfies("2.0.0", ">=1.0.0 <2.0.0")`, false},
+		{"tilde", `semver.satisfies("1.2.5", "~1.2.0")`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, run(t, tc.expr))
+		})
+	}
+}
+
+func TestValidationPredicates(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, true, run(t, `semver.isValid("1.2.3")`))
+	require.Equal(t, true, run(t, `semver.isValid("1.2.3-alpha+build")`))
+	require.Equal(t, true, run(t, `semver.isValid("v1.2.3")`)) // leading v accepted
+	require.Equal(t, false, run(t, `semver.isValid("not-a-version")`))
+
+	require.Equal(t, true, run(t, `semver.isStable("1.2.3")`))
+	require.Equal(t, false, run(t, `semver.isStable("0.9.0")`))     // pre-1.0 is not stable
+	require.Equal(t, false, run(t, `semver.isStable("1.2.3-rc1")`)) // prerelease is not stable
+}
+
+func TestParseReturnsMap(t *testing.T) {
+	t.Parallel()
+	got := run(t, `semver.parse("1.2.3-alpha.1+sha.abc")`)
+	m, ok := got.(map[string]any)
+	require.True(t, ok, "parse result should be a map, got %T", got)
+
+	require.Equal(t, int64(1), m["major"])
+	require.Equal(t, int64(2), m["minor"])
+	require.Equal(t, int64(3), m["patch"])
+	require.Equal(t, "alpha.1", m["prerelease"])
+	require.Equal(t, "sha.abc", m["build"])
+	require.Equal(t, "1.2.3-alpha.1+sha.abc", m["original"])
+}
+
+func TestInvalidInputsReturnError(t *testing.T) {
+	t.Parallel()
+	p := New()
+	env, err := cel.NewEnv(p.Library())
+	require.NoError(t, err)
+
+	for _, expr := range []string{
+		`semver.major("not-a-version")`,
+		`semver.compare("1.2.3", "nope")`,
+		`semver.satisfies("1.2.3", "not-a-constraint")`,
+	} {
+		ast, iss := env.Compile(expr)
+		require.NoError(t, iss.Err(), "compile %q", expr)
+		program, err := env.Program(ast)
+		require.NoError(t, err)
+		_, _, err = program.Eval(p.VarValues(nil, nil, nil))
+		require.Error(t, err, "expected error for %q", expr)
+	}
+}

--- a/pkg/evaluator/plugins/semver/tool.go
+++ b/pkg/evaluator/plugins/semver/tool.go
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package semver
+
+import (
+	"errors"
+	"reflect"
+
+	msemver "github.com/Masterminds/semver/v3"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// SemverTool is the host object for the `semver.*` methods in CEL.
+type SemverTool struct{}
+
+// SemverType is the CEL object type registered for the `semver`
+// global. Like the other plugin tools, it is an opaque handle the
+// CEL compiler uses to dispatch method calls.
+var SemverType = cel.ObjectType("semver", traits.ReceiverType)
+
+// Functions registers the member overloads exposed on the semver
+// object. Every accessor accepts a string and either returns a
+// numeric/string component or a bool — the failure mode for an
+// unparseable input is a CEL error that surfaces at evaluation
+// time.
+func (st *SemverTool) Functions() []cel.EnvOption {
+	return []cel.EnvOption{
+		// Accessors returning ints.
+		memberIntFn("major", majorFn),
+		memberIntFn("minor", minorFn),
+		memberIntFn("patch", patchFn),
+
+		// Accessors returning strings.
+		memberStringFn("prerelease", prereleaseFn),
+		memberStringFn("build", buildFn),
+
+		// Validation predicates.
+		memberBoolFn("isValid", isValidFn),
+		memberBoolFn("isStable", isStableFn),
+
+		// Binary comparisons (two version strings).
+		memberBinaryBoolFn("isNewer", isNewerFn),
+		memberBinaryBoolFn("isOlder", isOlderFn),
+		memberBinaryBoolFn("equal", equalFn),
+		cel.Function(
+			"compare",
+			cel.MemberOverload(
+				"semver_compare_binding",
+				[]*cel.Type{SemverType, cel.StringType, cel.StringType}, cel.IntType,
+				cel.FunctionBinding(compareFn),
+			),
+		),
+
+		// Constraint matching (npm/composer-style expressions).
+		cel.Function(
+			"satisfies",
+			cel.MemberOverload(
+				"semver_satisfies_binding",
+				[]*cel.Type{SemverType, cel.StringType, cel.StringType}, cel.BoolType,
+				cel.FunctionBinding(satisfiesFn),
+			),
+		),
+
+		// Full parse — returns a map mirroring the other plugins'
+		// parse() convention.
+		cel.Function(
+			"parse",
+			cel.MemberOverload(
+				"semver_parse_binding",
+				[]*cel.Type{SemverType, cel.StringType}, cel.MapType(cel.StringType, cel.AnyType),
+				cel.BinaryBinding(parseFn),
+			),
+		),
+	}
+}
+
+// memberIntFn is shorthand for the "member(semver, string) → int"
+// shape used by major/minor/patch.
+func memberIntFn(name string, fn func(string) (int64, error)) cel.EnvOption {
+	return cel.Function(
+		name,
+		cel.MemberOverload(
+			"semver_"+name+"_binding",
+			[]*cel.Type{SemverType, cel.StringType}, cel.IntType,
+			cel.BinaryBinding(stringToIntAdapter(fn)),
+		),
+	)
+}
+
+// memberStringFn is the "(semver, string) → string" helper.
+func memberStringFn(name string, fn func(string) (string, error)) cel.EnvOption {
+	return cel.Function(
+		name,
+		cel.MemberOverload(
+			"semver_"+name+"_binding",
+			[]*cel.Type{SemverType, cel.StringType}, cel.StringType,
+			cel.BinaryBinding(stringToStringAdapter(fn)),
+		),
+	)
+}
+
+// memberBoolFn is the "(semver, string) → bool" helper.
+func memberBoolFn(name string, fn func(string) (bool, error)) cel.EnvOption {
+	return cel.Function(
+		name,
+		cel.MemberOverload(
+			"semver_"+name+"_binding",
+			[]*cel.Type{SemverType, cel.StringType}, cel.BoolType,
+			cel.BinaryBinding(stringToBoolAdapter(fn)),
+		),
+	)
+}
+
+// memberBinaryBoolFn is the "(semver, string, string) → bool"
+// helper used by the pairwise comparison predicates.
+func memberBinaryBoolFn(name string, fn func(a, b string) (bool, error)) cel.EnvOption {
+	return cel.Function(
+		name,
+		cel.MemberOverload(
+			"semver_"+name+"_binding",
+			[]*cel.Type{SemverType, cel.StringType, cel.StringType}, cel.BoolType,
+			cel.FunctionBinding(twoStringsToBoolAdapter(fn)),
+		),
+	)
+}
+
+// ---- CEL adapter glue ---------------------------------------------------
+
+func stringToIntAdapter(fn func(string) (int64, error)) func(lhs, rhs ref.Val) ref.Val {
+	return func(_, rhs ref.Val) ref.Val {
+		s, err := asString(rhs, "int accessor")
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		v, err := fn(s)
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		return types.Int(v)
+	}
+}
+
+func stringToStringAdapter(fn func(string) (string, error)) func(lhs, rhs ref.Val) ref.Val {
+	return func(_, rhs ref.Val) ref.Val {
+		s, err := asString(rhs, "string accessor")
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		v, err := fn(s)
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		return types.String(v)
+	}
+}
+
+func stringToBoolAdapter(fn func(string) (bool, error)) func(lhs, rhs ref.Val) ref.Val {
+	return func(_, rhs ref.Val) ref.Val {
+		s, err := asString(rhs, "bool accessor")
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		v, err := fn(s)
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		return types.Bool(v)
+	}
+}
+
+func twoStringsToBoolAdapter(fn func(a, b string) (bool, error)) func(args ...ref.Val) ref.Val {
+	return func(args ...ref.Val) ref.Val {
+		if len(args) != 3 {
+			return types.NewErrFromString("semver comparison needs two string args")
+		}
+		a, err := asString(args[1], "first version")
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		b, err := asString(args[2], "second version")
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		v, err := fn(a, b)
+		if err != nil {
+			return types.NewErrFromString(err.Error())
+		}
+		return types.Bool(v)
+	}
+}
+
+// compareFn is not a predicate — it returns Int — so it has its
+// own adapter.
+func compareFn(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErrFromString("semver.compare needs two string args")
+	}
+	a, err := asString(args[1], "first version")
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	b, err := asString(args[2], "second version")
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	av, err := msemver.NewVersion(a)
+	if err != nil {
+		return types.NewErrFromString("invalid semver: " + a)
+	}
+	bv, err := msemver.NewVersion(b)
+	if err != nil {
+		return types.NewErrFromString("invalid semver: " + b)
+	}
+	return types.Int(av.Compare(bv))
+}
+
+func satisfiesFn(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErrFromString("semver.satisfies needs a version and a constraint")
+	}
+	v, err := asString(args[1], "version")
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	constraint, err := asString(args[2], "constraint")
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	parsed, err := msemver.NewVersion(v)
+	if err != nil {
+		return types.NewErrFromString("invalid semver: " + v)
+	}
+	c, err := msemver.NewConstraint(constraint)
+	if err != nil {
+		return types.NewErrFromString("invalid constraint: " + constraint)
+	}
+	return types.Bool(c.Check(parsed))
+}
+
+func parseFn(_, rhs ref.Val) ref.Val {
+	s, err := asString(rhs, "version")
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	parsed, err := msemver.NewVersion(s)
+	if err != nil {
+		return types.NewErrFromString("invalid semver: " + s)
+	}
+	reg, err := types.NewRegistry()
+	if err != nil {
+		return types.NewErrFromString(err.Error())
+	}
+	return types.NewDynamicMap(reg, map[string]any{
+		//nolint:gosec // semver components are always small (major/minor/patch), overflow is not a real risk
+		"major": int64(parsed.Major()),
+		//nolint:gosec // semver components are always small (major/minor/patch), overflow is not a real risk
+		"minor": int64(parsed.Minor()),
+		//nolint:gosec // semver components are always small (major/minor/patch), overflow is not a real risk
+		"patch":      int64(parsed.Patch()),
+		"prerelease": parsed.Prerelease(),
+		"build":      parsed.Metadata(),
+		"original":   parsed.Original(),
+	})
+}
+
+// ---- Business logic -----------------------------------------------------
+
+func majorFn(s string) (int64, error) {
+	v, err := msemver.NewVersion(s)
+	if err != nil {
+		return 0, err
+	}
+	return int64(v.Major()), nil //nolint:gosec // semver major never overflows int64
+}
+
+func minorFn(s string) (int64, error) {
+	v, err := msemver.NewVersion(s)
+	if err != nil {
+		return 0, err
+	}
+	return int64(v.Minor()), nil //nolint:gosec // semver minor never overflows int64
+}
+
+func patchFn(s string) (int64, error) {
+	v, err := msemver.NewVersion(s)
+	if err != nil {
+		return 0, err
+	}
+	return int64(v.Patch()), nil //nolint:gosec // semver patch never overflows int64
+}
+
+func prereleaseFn(s string) (string, error) {
+	v, err := msemver.NewVersion(s)
+	if err != nil {
+		return "", err
+	}
+	return v.Prerelease(), nil
+}
+
+func buildFn(s string) (string, error) {
+	v, err := msemver.NewVersion(s)
+	if err != nil {
+		return "", err
+	}
+	return v.Metadata(), nil
+}
+
+func isValidFn(s string) (bool, error) {
+	_, err := msemver.NewVersion(s)
+	return err == nil, nil
+}
+
+func isStableFn(s string) (bool, error) {
+	v, err := msemver.NewVersion(s)
+	if err != nil {
+		return false, err
+	}
+	return v.Major() >= 1 && v.Prerelease() == "", nil
+}
+
+func isNewerFn(a, b string) (bool, error) {
+	av, err := msemver.NewVersion(a)
+	if err != nil {
+		return false, err
+	}
+	bv, err := msemver.NewVersion(b)
+	if err != nil {
+		return false, err
+	}
+	return av.GreaterThan(bv), nil
+}
+
+func isOlderFn(a, b string) (bool, error) {
+	av, err := msemver.NewVersion(a)
+	if err != nil {
+		return false, err
+	}
+	bv, err := msemver.NewVersion(b)
+	if err != nil {
+		return false, err
+	}
+	return av.LessThan(bv), nil
+}
+
+func equalFn(a, b string) (bool, error) {
+	av, err := msemver.NewVersion(a)
+	if err != nil {
+		return false, err
+	}
+	bv, err := msemver.NewVersion(b)
+	if err != nil {
+		return false, err
+	}
+	return av.Equal(bv), nil
+}
+
+// asString unwraps a CEL ref.Val into a Go string or a descriptive
+// error identifying which argument slot was bad.
+func asString(v ref.Val, slot string) (string, error) {
+	switch x := v.Value().(type) {
+	case string:
+		return x, nil
+	default:
+		return "", errors.New("expected string for " + slot)
+	}
+}
+
+// ---- cel.Library / ref.Val boilerplate ----------------------------------
+
+func (st *SemverTool) ConvertToType(typeVal ref.Type) ref.Val {
+	if typeVal == types.TypeType {
+		return SemverType
+	}
+	return types.NewErr("type conversion not allowed for semver")
+}
+
+func (*SemverTool) Type() ref.Type { return SemverType }
+
+func (*SemverTool) Equal(_ ref.Val) ref.Val {
+	return types.NewErr("objects cannot be compared")
+}
+
+func (st *SemverTool) Value() any { return st }
+
+func (*SemverTool) ConvertToNative(_ reflect.Type) (any, error) {
+	return nil, errors.New("semver cannot be converted to native")
+}
+
+// TypeAdapter registers SemverTool with CEL's runtime type system.
+type TypeAdapter struct{}
+
+func (TypeAdapter) NativeToValue(value any) ref.Val {
+	if val, ok := value.(SemverTool); ok {
+		return &val
+	}
+	return types.DefaultTypeAdapter.NativeToValue(value)
+}
+
+func (st *SemverTool) CompileOptions() []cel.EnvOption {
+	funcs := st.Functions()
+	ret := make([]cel.EnvOption, 0, 3+len(funcs))
+	ret = append(ret,
+		cel.Types(SemverType),
+		cel.CustomTypeAdapter(&TypeAdapter{}),
+		cel.Variable("semver", SemverType),
+	)
+	ret = append(ret, funcs...)
+	return ret
+}
+
+func (*SemverTool) ProgramOptions() []cel.ProgramOption { return nil }


### PR DESCRIPTION
This PR adds a new plugin to the CEL environment: `semver`. This plugin essentially exposes Masterminds/semver on the CEL runtime to enable policies to compare versions.

I'm piggy backing an update to CI (to check go.mod) and updates to the documentation.