### PR TITLE
Cli flag groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/protobom/protobom v0.5.5
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -164,7 +165,6 @@ require (
 	github.com/sigstore/sigstore-go v1.1.4 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/spdx/tools-golang v0.5.7 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/internal/cmd/flaggroups.go
+++ b/internal/cmd/flaggroups.go
@@ -49,24 +49,6 @@ func groupFlags(cmd *cobra.Command, group string, names ...string) {
 	}
 }
 
-// groupFlagsByPrefix tags every persistent flag on cmd whose name starts
-// with one of the given prefixes. Used for flags registered by an
-// external library (e.g. signer's *options.SignerSet) where in-place
-// annotation at registration isn't possible.
-func groupFlagsByPrefix(cmd *cobra.Command, group string, prefixes ...string) {
-	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
-		for _, p := range prefixes {
-			if strings.HasPrefix(f.Name, p) {
-				if f.Annotations == nil {
-					f.Annotations = map[string][]string{}
-				}
-				f.Annotations[flagGroupAnnotation] = []string{group}
-				return
-			}
-		}
-	})
-}
-
 // groupedFlagUsages renders cmd's local flags bucketed under the group
 // headings registered for cmd. Mirrors pflag.FlagSet.FlagUsages output
 // per bucket so column alignment matches cobra's default rendering.

--- a/internal/cmd/flaggroups.go
+++ b/internal/cmd/flaggroups.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const flagGroupAnnotation = "ampel_group"
+
+// flagGroup is a topical bucket of flags rendered under its own heading
+// in --help. Groups are ordered by their position in the slice passed to
+// registerFlagGroups; empty groups are skipped at render time.
+type flagGroup struct {
+	ID    string
+	Title string
+}
+
+// commandGroups holds the per-command ordered group list consulted by
+// the custom usage template. Keyed by *cobra.Command, populated by
+// registerFlagGroups and read by groupedFlagUsages. A global map fits
+// here because cobra commands are constructed once at startup.
+var commandGroups = map[*cobra.Command][]flagGroup{}
+
+// registerFlagGroups records the ordered group list for cmd. Flags
+// without a recognized group fall through to the trailing "Other Flags:"
+// section.
+func registerFlagGroups(cmd *cobra.Command, groups ...flagGroup) {
+	commandGroups[cmd] = groups
+}
+
+// groupFlags tags each named persistent flag on cmd with group. Unknown
+// flag names are skipped silently so the helper stays robust if a flag
+// is later renamed or removed.
+func groupFlags(cmd *cobra.Command, group string, names ...string) {
+	for _, name := range names {
+		f := cmd.PersistentFlags().Lookup(name)
+		if f == nil {
+			continue
+		}
+		if f.Annotations == nil {
+			f.Annotations = map[string][]string{}
+		}
+		f.Annotations[flagGroupAnnotation] = []string{group}
+	}
+}
+
+// groupFlagsByPrefix tags every persistent flag on cmd whose name starts
+// with one of the given prefixes. Used for flags registered by an
+// external library (e.g. signer's *options.SignerSet) where in-place
+// annotation at registration isn't possible.
+func groupFlagsByPrefix(cmd *cobra.Command, group string, prefixes ...string) {
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		for _, p := range prefixes {
+			if strings.HasPrefix(f.Name, p) {
+				if f.Annotations == nil {
+					f.Annotations = map[string][]string{}
+				}
+				f.Annotations[flagGroupAnnotation] = []string{group}
+				return
+			}
+		}
+	})
+}
+
+// groupedFlagUsages renders cmd's local flags bucketed under the group
+// headings registered for cmd. Mirrors pflag.FlagSet.FlagUsages output
+// per bucket so column alignment matches cobra's default rendering.
+func groupedFlagUsages(cmd *cobra.Command) string {
+	groups, ok := commandGroups[cmd]
+	if !ok || len(groups) == 0 {
+		return cmd.LocalFlags().FlagUsages()
+	}
+
+	type bucket struct {
+		title string
+		fs    *pflag.FlagSet
+	}
+	buckets := make(map[string]*bucket, len(groups))
+	for _, g := range groups {
+		buckets[g.ID] = &bucket{
+			title: g.Title,
+			fs:    pflag.NewFlagSet(g.ID, pflag.ContinueOnError),
+		}
+	}
+	other := pflag.NewFlagSet("other", pflag.ContinueOnError)
+
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		if vals, ok := f.Annotations[flagGroupAnnotation]; ok && len(vals) > 0 {
+			if b, ok := buckets[vals[0]]; ok {
+				b.fs.AddFlag(f)
+				return
+			}
+		}
+		other.AddFlag(f)
+	})
+
+	var sb strings.Builder
+	first := true
+	emit := func(title string, fs *pflag.FlagSet) {
+		if !fs.HasFlags() {
+			return
+		}
+		if !first {
+			sb.WriteString("\n")
+		}
+		first = false
+		sb.WriteString(title)
+		sb.WriteString("\n")
+		sb.WriteString(fs.FlagUsages())
+	}
+	for _, g := range groups {
+		emit(g.Title, buckets[g.ID].fs)
+	}
+	emit("Other Flags:", other)
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func init() {
+	cobra.AddTemplateFunc("groupedFlagUsages", groupedFlagUsages)
+}
+
+// usageTemplate is cobra's default usage template with the single
+// "Flags:" block swapped for a {{groupedFlagUsages .}} call, so flags
+// render under topical headings instead of one undifferentiated list.
+// The rest of the template (Usage, Aliases, Examples, subcommand
+// groups, Global Flags, Additional help topics) is unchanged.
+const usageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+{{groupedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command]{{if .HasAvailableInheritedFlags}} [--help]{{end}}" for more information about a command.{{end}}
+`
+
+// applyFlagGroupTemplate installs the grouped-flags usage template on
+// cmd. Call after flags and groups are registered.
+func applyFlagGroupTemplate(cmd *cobra.Command) {
+	cmd.SetUsageTemplate(usageTemplate)
+}

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -35,6 +35,29 @@ var (
 	hashRegex    *regexp.Regexp
 )
 
+const (
+	grpSubject      = "subject"
+	grpPolicy       = "policy"
+	grpEvidence     = "evidence"
+	grpContext      = "context"
+	grpResults      = "results"
+	grpSigning      = "signing"
+	grpVerification = "verification"
+)
+
+// verifyFlagGroups defines the order and headings of the flag sections
+// rendered by `ampel verify --help`. Empty groups are skipped, so the
+// signing section won't appear until signer flags are wired in.
+var verifyFlagGroups = []flagGroup{
+	{ID: grpSubject, Title: "Subject Specification:"},
+	{ID: grpPolicy, Title: "Policy Options & Specification:"},
+	{ID: grpEvidence, Title: "Evidence Collection:"},
+	{ID: grpContext, Title: "Context Definition:"},
+	{ID: grpResults, Title: "Results Attestation & Output:"},
+	{ID: grpSigning, Title: "Signing Flags:"},
+	{ID: grpVerification, Title: "Verification Flags:"},
+}
+
 type verifyOptions struct {
 	verifier.VerificationOptions
 	keyOpts.Options
@@ -152,6 +175,16 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(
 		&o.AllowEmptySetChains, "allow-empty-set-chain", verifier.DefaultVerificationOptions.AllowEmptySetChains, "don't fail PolicySets when chains are empty",
 	)
+
+	groupFlags(cmd, grpSubject, "subject", "subject-file", "subject-hash")
+	groupFlags(cmd, grpPolicy, "policy", "pid", "policy-out", "policy-verify", "policy-key", "policy-signer", "expiration")
+	groupFlags(cmd, grpEvidence, "key", "attestation", "collector", "signer")
+	groupFlags(cmd, grpContext, "context", "context-json", "context-yaml", "context-env")
+	groupFlags(cmd, grpResults, "attest-results", "attest-format", "results-path", "format")
+	groupFlags(cmd, grpVerification, "exit-code", "workers", "allow-empty-set-chain")
+
+	registerFlagGroups(cmd, verifyFlagGroups...)
+	applyFlagGroupTemplate(cmd)
 }
 
 func parseHash(estring string) (algo, value string, err error) {


### PR DESCRIPTION
This PR organizes the "ampel verify" flags in the CLI into easier to comprehend groups:

```
Usage:
  ampel verify [subject] [flags]

Subject Specification:
  -s, --subject string        subject hash (algo:value) or path to file (alternative to positional argument)
      --subject-file string   file to verify
      --subject-hash string   hash to verify

Policy Options & Specification:
      --expiration              enforce policy expiration dates (default true)
      --pid strings             list of policy IDs to evaluate from a set (defaults to all)
  -p, --policy string           policy/policySet (h)json source location (file path, URL, or VCS locator)
      --policy-key strings      path to public keys to verify policies
      --policy-out              render the eval results per policy, more detailed than the set view
      --policy-signer strings   signer identities to verify signed policies
      --policy-verify           verify policy signatures (default true)

Evidence Collection:
  -a, --attestation strings   additional attestations to read
  -c, --collector strings     attestation collectors to initialize
  -k, --key strings           path to public key files
      --signer strings        list of signer identities to verify attestations

Context Definition:
  -x, --context strings       evaluation context value definitions
      --context-env           Support reading context values from env vars (default true)
      --context-json string   JSON struct with the context definition or prefix with @ to read from a file
      --context-yaml string   YAML struct with the context definition or prefix with @ to read from a file

Results Attestation & Output:
      --attest-format string   format used when attest-results is true [ampel vsa svr] (default "ampel")
      --attest-results         write an attestation with the evaluation results to --results-path
  -f, --format string          output format (default "tty")
      --results-path string    path to the evaluation results attestation (default "results.intoto.json")

Verification Flags:
      --allow-empty-set-chain   don't fail PolicySets when chains are empty (default true)
      --exit-code               set a non-zero exit code on policy verification fail (default true)
      --workers int8            number of evaluation threads to run in parallel (default 4)

Other Flags:
  -h, --help   help for verify

Global Flags:
      --log-level string   the logging verbosity, either 'panic', 'fatal', 'error', 'warning', 'info', 'debug', 'trace' (default "info")

```