### PR TITLE
Refactor attesting into new ResultsAttester

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92
-	github.com/carabiner-dev/policy v0.5.0
+	github.com/carabiner-dev/policy v0.5.1-0.20260428221018-836cdae656c0
 	github.com/carabiner-dev/predicates v0.5.0
 	github.com/carabiner-dev/termtable v1.1.0
 	github.com/fatih/color v1.19.0
@@ -41,7 +41,7 @@ require (
 	github.com/carabiner-dev/github v0.2.3 // indirect
 	github.com/carabiner-dev/jsonl v0.2.1 // indirect
 	github.com/carabiner-dev/openeox v1.0.0-pre.1 // indirect
-	github.com/carabiner-dev/signer v0.4.5
+	github.com/carabiner-dev/signer v0.4.6-0.20260428182929-2749e66cbe88
 	github.com/carabiner-dev/vcslocator v0.4.3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
@@ -165,6 +165,7 @@ require (
 	github.com/sigstore/sigstore-go v1.1.4 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.0.6 // indirect
 	github.com/spdx/tools-golang v0.5.7 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,14 +112,14 @@ github.com/carabiner-dev/openeox v1.0.0-pre.1 h1:47Oe0vcH9m8nBFFQCPLNVR2HwiumXst
 github.com/carabiner-dev/openeox v1.0.0-pre.1/go.mod h1:+6i8M7PhtWk2jRtUC1anZnhmOr5cXKMLGYjwFcqPDa0=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92 h1:BJ9+OCNezZGkU8SrGC3oB7Tj+J0JsonwfZztcgUav6c=
 github.com/carabiner-dev/osv v0.0.0-20250124012120-b8ce4531cd92/go.mod h1:o7jXwi/fFZ9mQlvVlog0kcvyEkwQT3eWmVQmrorBGpE=
-github.com/carabiner-dev/policy v0.5.0 h1:BBCLtB6PwFB40nTEbI3ooL/54RZCCGFwUCWXS4yJ4DQ=
-github.com/carabiner-dev/policy v0.5.0/go.mod h1:A+fnVBXpzx7f/MiLoH1FGTBAOe23ZZwXtGJsT9MCpBM=
+github.com/carabiner-dev/policy v0.5.1-0.20260428221018-836cdae656c0 h1:ff1L68jFh1Oo/RmXF9/TqjD7JaDLDXipmWBjQlcyZM4=
+github.com/carabiner-dev/policy v0.5.1-0.20260428221018-836cdae656c0/go.mod h1:iOGhyDNXsGulBRZmMj7zaZcf00rU16+hfq6wI+IT3Fc=
 github.com/carabiner-dev/predicates v0.5.0 h1:CG2xO5xTXWXakjJkAFuS2xSA2olP9Ew25k6CAyL8waI=
 github.com/carabiner-dev/predicates v0.5.0/go.mod h1:EUm2p0CwKoUuc+OLbGkoxLdRqBrg/r957b8iN/ACWSA=
 github.com/carabiner-dev/sbomfs v0.1.0 h1:gEsmn85hod7JTLs2dDr5C1x4Af7FUEhI0lbTurNaEZs=
 github.com/carabiner-dev/sbomfs v0.1.0/go.mod h1:UyPyTSNx9JOLZVgTmM9WXdmgVqDWXCYwr1LK1Ts+7H0=
-github.com/carabiner-dev/signer v0.4.5 h1:H3XHHqorZw7wvLysbGCc+FM90nSdzFlODj+mIGMsYJc=
-github.com/carabiner-dev/signer v0.4.5/go.mod h1:B/53ToJAIgwM+KuDwj52+HwnlA5p8Rmz2OXQdy9x+xs=
+github.com/carabiner-dev/signer v0.4.6-0.20260428182929-2749e66cbe88 h1:9Iij1K4kXYuKKk+2ZkrNR5pJjt/j1q6Yf7gGt7XPQlY=
+github.com/carabiner-dev/signer v0.4.6-0.20260428182929-2749e66cbe88/go.mod h1:lQXabEgyFNLm49T3K3PKmU//H1+hEIOsF+13ZKgXhCs=
 github.com/carabiner-dev/termtable v1.1.0 h1:b/7IqM52Wqwi9njjnAEIDddUYyX23msFkQVihkwarDs=
 github.com/carabiner-dev/termtable v1.1.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.4.3 h1:rXKwVT8N4hS85GEJQGd0ZgOjTcALuCslsqZyg4g6qxA=
@@ -468,6 +468,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
+github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -455,8 +455,10 @@ func (opts *verifyOptions) Run() error {
 	}
 
 	if opts.AttestResults {
-		if err := attest.New(ampel, opts.AttestFormat).
-			AttestToFile(opts.ResultsAttestationPath, results); err != nil {
+		if err := attest.New().AttestToFile(
+			opts.ResultsAttestationPath, results,
+			attest.WithFormat(opts.AttestFormat),
+		); err != nil {
 			return fmt.Errorf("attesting results: %w", err)
 		}
 	}

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/release-utils/helpers"
 
 	"github.com/carabiner-dev/ampel/internal/render"
+	"github.com/carabiner-dev/ampel/pkg/attest"
 	acontext "github.com/carabiner-dev/ampel/pkg/context"
 	"github.com/carabiner-dev/ampel/pkg/verifier"
 )
@@ -453,8 +454,11 @@ func (opts *verifyOptions) Run() error {
 		return fmt.Errorf("running subject verification: %w", err)
 	}
 
-	if err := attestResults(opts, ampel, results); err != nil {
-		return fmt.Errorf("attesting results: %w", err)
+	if opts.AttestResults {
+		if err := attest.New(ampel, opts.AttestFormat).
+			AttestToFile(opts.ResultsAttestationPath, results); err != nil {
+			return fmt.Errorf("attesting results: %w", err)
+		}
 	}
 
 	eng := render.NewEngine()
@@ -490,43 +494,6 @@ func (opts *verifyOptions) Run() error {
 
 	if results.GetStatus() == papi.StatusFAIL && opts.SetExitCode {
 		os.Exit(1)
-	}
-
-	return nil
-}
-
-func attestResults(opts *verifyOptions, ampel *verifier.Ampel, results papi.Results) error {
-	// Generate the results attestation
-	if !opts.AttestResults {
-		return nil
-	}
-	attFile, err := os.Create(opts.ResultsAttestationPath)
-	if err != nil {
-		return fmt.Errorf("unable to open results attestation path")
-	}
-
-	switch opts.AttestFormat {
-	case "ampel", "":
-		if err := ampel.AttestResults(attFile, results); err != nil {
-			return fmt.Errorf("writing results attestation: %w", err)
-		}
-	default:
-		eng := render.NewEngine()
-		if err := eng.SetDriver(opts.AttestFormat); err != nil {
-			return fmt.Errorf("loading VSA attestation driver: %w", err)
-		}
-		switch r := results.(type) {
-		case *papi.Result:
-			if err := eng.RenderResult(attFile, r); err != nil {
-				return err
-			}
-		case *papi.ResultSet:
-			if err := eng.RenderResultSet(attFile, r); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unable to determine results type to attest")
-		}
 	}
 
 	return nil

--- a/internal/drivers/attester/driver.go
+++ b/internal/drivers/attester/driver.go
@@ -1,40 +1,34 @@
-// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
 package attester
 
 import (
-	"fmt"
 	"io"
-	"os"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
 
-	"github.com/carabiner-dev/ampel/pkg/verifier"
+	"github.com/carabiner-dev/ampel/pkg/attest"
 )
 
 func New() *Driver {
-	v, err := verifier.New()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error creating verifier: %v", err)
-	}
 	return &Driver{
-		Ampel: v,
+		Attester: attest.New(),
 	}
 }
 
 type Driver struct {
-	Ampel *verifier.Ampel
+	Attester *attest.ResultsAttester
 }
 
 func (d *Driver) RenderResultSet(w io.Writer, rset *papi.ResultSet) error {
-	return d.Ampel.AttestResults(w, rset)
+	return d.Attester.AttestTo(w, rset)
 }
 
 func (d *Driver) RenderResult(w io.Writer, status *papi.Result) error {
-	return d.Ampel.AttestResults(w, status)
+	return d.Attester.AttestTo(w, status)
 }
 
 func (d *Driver) RenderResultGroup(w io.Writer, status *papi.ResultGroup) error {
-	return d.Ampel.AttestResults(w, status)
+	return d.Attester.AttestTo(w, status)
 }

--- a/internal/drivers/svr/driver.go
+++ b/internal/drivers/svr/driver.go
@@ -1,157 +1,34 @@
-// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
 package svr
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
-	"slices"
-	"strings"
 
-	"github.com/carabiner-dev/attestation"
-	"github.com/carabiner-dev/collector/predicate/generic"
-	"github.com/carabiner-dev/collector/statement/intoto"
 	papi "github.com/carabiner-dev/policy/api/v1"
-	svr "github.com/in-toto/attestation/go/predicates/svr/v01"
-	gointoto "github.com/in-toto/attestation/go/v1"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/types/known/anypb"
-)
 
-const (
-	ampelId       = "https://carabiner.dev/ampel@v1"
-	predicateType = "https://in-toto.io/attestation/svr/v0.1"
+	"github.com/carabiner-dev/ampel/pkg/attest"
 )
 
 func New() *Driver {
-	return &Driver{}
+	return &Driver{
+		Attester: attest.New(),
+	}
 }
 
-type Driver struct{}
-
-func renderAttestation(w io.Writer, subject attestation.Subject, att *svr.SimpleVerificationResult) error {
-	svrJsonData, err := protojson.Marshal(att)
-	if err != nil {
-		return fmt.Errorf("marshaling svr: %w", err)
-	}
-
-	// The anypb.Any wrapper injects a @type field into the policy block
-	// that we don't want in the SVR output. Strip it.
-	var raw map[string]any
-	if err := json.Unmarshal(svrJsonData, &raw); err != nil {
-		return fmt.Errorf("unmarshaling svr json: %w", err)
-	}
-	if verifier, ok := raw["verifier"].(map[string]any); ok {
-		if policy, ok := verifier["policy"].(map[string]any); ok {
-			delete(policy, "@type")
-		}
-	}
-	svrJsonData, err = json.Marshal(raw)
-	if err != nil {
-		return fmt.Errorf("re-marshaling svr json: %w", err)
-	}
-
-	pred := &generic.Predicate{
-		Type:   attestation.PredicateType(predicateType),
-		Parsed: att,
-		Data:   svrJsonData,
-	}
-
-	statement := intoto.NewStatement(
-		intoto.WithPredicate(pred),
-		intoto.WithSubject(&gointoto.ResourceDescriptor{
-			Name:   subject.GetName(),
-			Uri:    subject.GetUri(),
-			Digest: subject.GetDigest(),
-		}),
-	)
-
-	jsonData, err := json.Marshal(statement)
-	if err != nil {
-		return fmt.Errorf("serializing SVR: %w", err)
-	}
-
-	if _, err := w.Write(jsonData); err != nil {
-		return fmt.Errorf("writing SVR data: %w", err)
-	}
-	return nil
+type Driver struct {
+	Attester *attest.ResultsAttester
 }
 
-func policyResourceDescriptor(origin attestation.Subject) (*anypb.Any, error) {
-	rd := &gointoto.ResourceDescriptor{
-		Uri:    origin.GetUri(),
-		Digest: origin.GetDigest(),
-	}
-	return anypb.New(rd)
-}
-
-// RenderResultSet renders a result set as an SVR attestation.
 func (d *Driver) RenderResultSet(w io.Writer, set *papi.ResultSet) error {
-	policyAny, err := policyResourceDescriptor(set.GetMeta().GetOrigin())
-	if err != nil {
-		return fmt.Errorf("wrapping policy descriptor: %w", err)
-	}
-
-	svrData := &svr.SimpleVerificationResult{
-		Verifier: &svr.SimpleVerificationResult_Verifier{
-			Id:     ampelId,
-			Policy: policyAny,
-		},
-		TimeCreated: set.GetDateEnd(),
-		Properties:  []string{},
-	}
-
-	for _, a := range set.Results {
-		if a.GetStatus() != papi.StatusPASS {
-			continue
-		}
-		for _, ctl := range a.GetMeta().GetControls() {
-			if ctl.Id == "" {
-				continue
-			}
-			label := strings.ReplaceAll(ctl.Label(), "-", "_")
-			if !slices.Contains(svrData.Properties, label) {
-				svrData.Properties = append(svrData.Properties, label)
-			}
-		}
-	}
-
-	return renderAttestation(w, set.GetSubject(), svrData)
+	return d.Attester.AttestTo(w, set, attest.WithFormat("svr"))
 }
 
-// RenderResultGroup renders a result group as an SVR attestation.
-func (d *Driver) RenderResultGroup(_ io.Writer, _ *papi.ResultGroup) error {
-	return errors.New("rendering result groups as SVRs is not supported yet")
-}
-
-// RenderResult renders a single policy evaluation result as an SVR attestation.
 func (d *Driver) RenderResult(w io.Writer, result *papi.Result) error {
-	policyAny, err := policyResourceDescriptor(result.GetMeta().GetOrigin())
-	if err != nil {
-		return fmt.Errorf("wrapping policy descriptor: %w", err)
-	}
+	return d.Attester.AttestTo(w, result, attest.WithFormat("svr"))
+}
 
-	svrData := &svr.SimpleVerificationResult{
-		Verifier: &svr.SimpleVerificationResult_Verifier{
-			Id:     ampelId,
-			Policy: policyAny,
-		},
-		TimeCreated: result.GetDateEnd(),
-		Properties:  []string{},
-	}
-
-	for _, ctl := range result.GetMeta().GetControls() {
-		if ctl.Id == "" {
-			continue
-		}
-		label := strings.ReplaceAll(ctl.Label(), "-", "_")
-		if !slices.Contains(svrData.Properties, label) {
-			svrData.Properties = append(svrData.Properties, label)
-		}
-	}
-
-	return renderAttestation(w, result.GetSubject(), svrData)
+func (d *Driver) RenderResultGroup(w io.Writer, group *papi.ResultGroup) error {
+	return d.Attester.AttestTo(w, group, attest.WithFormat("svr"))
 }

--- a/internal/drivers/vsa/driver.go
+++ b/internal/drivers/vsa/driver.go
@@ -1,259 +1,34 @@
-// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
 package vsa
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
-	"slices"
-	"strings"
 
-	"github.com/carabiner-dev/attestation"
-	"github.com/carabiner-dev/collector/predicate/generic"
-	"github.com/carabiner-dev/collector/statement/intoto"
 	papi "github.com/carabiner-dev/policy/api/v1"
-	v1 "github.com/in-toto/attestation/go/predicates/vsa/v1"
-	gointoto "github.com/in-toto/attestation/go/v1"
-	"google.golang.org/protobuf/encoding/protojson"
-)
 
-const (
-	// AMPEL verifier ID
-	ampelId = "https://carabiner.dev/ampel@v1"
-
-	// slsaVersion version used as base to compute the VSA
-	slsaVersion = "1.1"
-
-	// Recognized context keys for the VSA fields
-	vsaContextResourceURIKey = "vsa.resourceUri"
+	"github.com/carabiner-dev/ampel/pkg/attest"
 )
 
 func New() *Driver {
-	return &Driver{}
-}
-
-type Driver struct{}
-
-func renderAttestation(w io.Writer, subject attestation.Subject, att *v1.VerificationSummary) error {
-	vsaJsonData, err := protojson.Marshal(att)
-	if err != nil {
-		return fmt.Errorf("marshaling vsa: %w", err)
-	}
-
-	// Generate the generica predicate
-	pred := &generic.Predicate{
-		Type:   attestation.PredicateType("https://slsa.dev/verification_summary/v1"),
-		Parsed: att,
-		Data:   vsaJsonData,
-	}
-
-	// Add the intoto wrapper
-	statement := intoto.NewStatement(
-		intoto.WithPredicate(pred),
-		intoto.WithSubject(&gointoto.ResourceDescriptor{
-			Name:   subject.GetName(),
-			Uri:    subject.GetUri(),
-			Digest: subject.GetDigest(),
-		}),
-	)
-
-	// Now serialize the attestation
-	jsonData, err := json.Marshal(statement)
-	if err != nil {
-		return fmt.Errorf("serializing VSA: %w", err)
-	}
-
-	if _, err := w.Write(jsonData); err != nil {
-		return fmt.Errorf("writing VSA data: %w", err)
-	}
-	return nil
-}
-
-// resultStringToSLSAResult translates from our policy evalt status strings to SLSA's
-func resultStringToSLSAResult(status string) string {
-	switch status {
-	case papi.StatusPASS, papi.StatusSOFTFAIL:
-		return "PASSED"
-	case papi.StatusFAIL:
-		return "FAILED"
-	default:
-		return ""
+	return &Driver{
+		Attester: attest.New(),
 	}
 }
 
-// RenderResultSet renders a results set in a VSA.
-//
-// We map the result of the VSA (VerificationResult) to the PolicySet
-// assesment result. The SLSA level captured in the the VerifiedLevels
-// field is transferred from the common controls.
-//
-// Dependency levels are computed by extracting the results of policies
-// chained to a different subject. Those policies are expected to have
-// their own controls section, defining the SLSA level they check.
+type Driver struct {
+	Attester *attest.ResultsAttester
+}
+
 func (d *Driver) RenderResultSet(w io.Writer, set *papi.ResultSet) error {
-	vsaData := &v1.VerificationSummary{
-		Verifier: &v1.VerificationSummary_Verifier{
-			Id: ampelId,
-		},
-		TimeVerified: set.GetDateEnd(),
-		// We set the resource URI here to the resource URI of the verified subject
-		// but if the policyset common context defines one, we'll override it later.
-		ResourceUri: set.GetSubject().GetUri(),
-		Policy: &v1.VerificationSummary_Policy{
-			Uri:    set.GetMeta().GetOrigin().GetUri(),
-			Digest: set.GetMeta().GetOrigin().GetDigest(),
-		},
-		InputAttestations:  []*v1.VerificationSummary_InputAttestation{},
-		VerificationResult: resultStringToSLSAResult(set.GetStatus()),
-		VerifiedLevels:     []string{},
-		DependencyLevels:   nil,
-	}
-
-	inputs := []attestation.Subject{}
-	depLevels := map[string]uint64{}
-
-	// Check if the policyset defined a resourceURI for the VSA and replace the
-	// value we got from the subject resource locator.
-	if setContext := set.GetCommon().GetContext(); setContext != nil {
-		if s, ok := setContext.AsMap()[vsaContextResourceURIKey].(string); ok && s != "" {
-			vsaData.ResourceUri = s
-		}
-	}
-
-	var verifiedSomeSlsa bool
-	for _, a := range set.Results {
-		for _, er := range a.EvalResults {
-			for _, stRef := range er.GetStatements() {
-				if !hasSubject(inputs, stRef.GetAttestation()) {
-					inputs = append(inputs, stRef.GetAttestation())
-				}
-			}
-		}
-
-		// Collect any SLSA levels into the dep count
-		if a.GetStatus() != papi.StatusPASS {
-			continue
-		}
-		for _, ctl := range a.GetMeta().GetControls() {
-			// Compute the label from the control
-			if ctl.Id == "" {
-				continue
-			}
-			label := ctl.Label()
-			label = strings.ReplaceAll(label, "-", "_")
-			if !strings.HasPrefix(label, "SLSA_") {
-				continue
-			}
-
-			verifiedSomeSlsa = true
-
-			// Here, we add the level to the verified levels when the result
-			// subject matches the policyset subject. If not, then we assume the
-			// policyset was chained to verify dependencies.
-			if attestation.SubjectsMatch(set.GetSubject(), a.GetSubject()) {
-				if !slices.Contains(vsaData.VerifiedLevels, label) {
-					vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
-				}
-			} else {
-				depLevels[label]++
-			}
-		}
-	}
-	if len(depLevels) > 0 {
-		vsaData.DependencyLevels = depLevels
-	}
-
-	vsaData.InputAttestations = subjectsToSummaryInputs(inputs)
-	if verifiedSomeSlsa {
-		vsaData.SlsaVersion = slsaVersion
-	}
-	return renderAttestation(w, set.GetSubject(), vsaData)
+	return d.Attester.AttestTo(w, set, attest.WithFormat("vsa"))
 }
 
-func (d *Driver) RenderResultGroup(w io.Writer, result *papi.ResultGroup) error {
-	return errors.New("rendering result groups as VSAs is not supported yet")
-}
-
-// RenderResult renders a policy evaluation result into a VSA
 func (d *Driver) RenderResult(w io.Writer, result *papi.Result) error {
-	vsaData := &v1.VerificationSummary{
-		Verifier: &v1.VerificationSummary_Verifier{
-			Id: ampelId,
-		},
-		TimeVerified: result.GetDateEnd(),
-		// We fix the resource URI here to the resource URI of the verification
-		// subject, but if the policy context defines one, we'll override it.
-		ResourceUri: result.GetSubject().GetUri(),
-		Policy: &v1.VerificationSummary_Policy{
-			Uri:    result.GetMeta().GetOrigin().GetUri(),
-			Digest: result.GetMeta().GetOrigin().GetDigest(),
-		},
-		// Populated later
-		InputAttestations:  []*v1.VerificationSummary_InputAttestation{},
-		VerificationResult: resultStringToSLSAResult(result.GetStatus()),
-		VerifiedLevels:     []string{},
-		DependencyLevels:   nil,
-	}
-
-	if resContext := result.GetContext(); resContext != nil {
-		if v, ok := resContext.AsMap()[vsaContextResourceURIKey]; ok && v != nil {
-			if s, ok2 := v.(string); ok2 && s != "" {
-				vsaData.ResourceUri = s
-			}
-		}
-	}
-
-	var verifiedSomeSlsa bool
-	// Add the verified level if its a slsa control
-	for _, ctl := range result.GetMeta().GetControls() {
-		label := strings.ReplaceAll(ctl.Label(), "-", "_")
-		if !strings.HasPrefix(label, "SLSA_") {
-			continue
-		}
-		verifiedSomeSlsa = true
-		vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
-	}
-
-	// Add the input attestations recorded in the result
-	inputs := []attestation.Subject{}
-	for _, er := range result.EvalResults {
-		// Add the statements to the collection
-		for _, stRef := range er.GetStatements() {
-			if !hasSubject(inputs, stRef.GetAttestation()) {
-				inputs = append(inputs, stRef.GetAttestation())
-			}
-		}
-	}
-	vsaData.InputAttestations = subjectsToSummaryInputs(inputs)
-	if verifiedSomeSlsa {
-		vsaData.SlsaVersion = slsaVersion
-	}
-	return renderAttestation(w, result.GetSubject(), vsaData)
+	return d.Attester.AttestTo(w, result, attest.WithFormat("vsa"))
 }
 
-func subjectsToSummaryInputs(inputs []attestation.Subject) []*v1.VerificationSummary_InputAttestation {
-	ret := make([]*v1.VerificationSummary_InputAttestation, 0, len(inputs))
-	for _, s := range inputs {
-		i := &v1.VerificationSummary_InputAttestation{
-			Uri:    s.GetUri(),
-			Digest: s.GetDigest(),
-		}
-		ret = append(ret, i)
-	}
-	if len(ret) == 0 {
-		return nil
-	}
-	return ret
-}
-
-func hasSubject(haystack []attestation.Subject, needle attestation.Subject) bool {
-	for _, sut := range haystack {
-		if attestation.SubjectsMatch(sut, needle) {
-			return true
-		}
-	}
-	return false
+func (d *Driver) RenderResultGroup(w io.Writer, group *papi.ResultGroup) error {
+	return d.Attester.AttestTo(w, group, attest.WithFormat("vsa"))
 }

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -4,8 +4,9 @@
 // Package attest writes attestations capturing evaluation results in
 // the format chosen by the caller. It is the home for the signing
 // pipeline that will turn ampel results into signed attestations —
-// for now it covers the format dispatch only, so call sites that
-// move to it today don't change shape when signing lands.
+// for now it covers the format dispatch and intoto statement
+// construction so call sites that move to it today don't change shape
+// when signing lands.
 package attest
 
 import (
@@ -13,77 +14,209 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"strings"
 
+	"github.com/carabiner-dev/attestation"
+	"github.com/carabiner-dev/collector/statement/intoto"
 	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/predicates"
 
-	"github.com/carabiner-dev/ampel/internal/render"
-	"github.com/carabiner-dev/ampel/pkg/verifier"
+	"github.com/carabiner-dev/ampel/internal/drivers/svr"
+	"github.com/carabiner-dev/ampel/internal/drivers/vsa"
 )
 
-// ResultsAttester writes a results attestation in the configured
-// format. The "ampel" format is rendered by the *verifier.Ampel
-// supplied at construction; non-"ampel" formats route through the
-// render engine.
-type ResultsAttester struct {
-	// Ampel renders the "ampel" format. Required when Format is
-	// "" or "ampel"; may be nil for any other format.
-	Ampel *verifier.Ampel
-
-	// Format selects the results-attestation format. Empty defaults
-	// to "ampel". Must be one of verifier.ResultsAttestationFormats;
-	// callers should rely on VerificationOptions.Validate for
-	// upstream rejection of unknown values.
-	Format string
+// renderDriver is the subset of the render-driver interface that
+// produces an attestation. Declared locally so pkg/attest doesn't
+// have to import internal/render — that would pull internal/drivers/
+// attester back in and create a cycle through this package.
+type renderDriver interface {
+	RenderResult(io.Writer, *papi.Result) error
+	RenderResultSet(io.Writer, *papi.ResultSet) error
 }
 
-// New returns a ResultsAttester wired to ampel for the "ampel" format.
-// Empty format resolves to "ampel" at attest time.
-func New(ampel *verifier.Ampel, format string) *ResultsAttester {
-	return &ResultsAttester{Ampel: ampel, Format: format}
+// ResultsAttester writes a results attestation in the format chosen
+// per call via WithFormat. The "ampel" format produces an in-toto
+// statement carrying a predicates.ResultSet; "vsa" and "svr" route
+// through their format-specific drivers.
+//
+// The struct is a placeholder for instance-level configuration that
+// spans multiple attestation calls — signer credentials, retry
+// behavior, and so on — that will land alongside signing support.
+type ResultsAttester struct{}
+
+// New returns a ready-to-use ResultsAttester.
+func New() *ResultsAttester {
+	return &ResultsAttester{}
+}
+
+// FnOpt configures a single Attest* call.
+type FnOpt func(*attestOptions)
+
+// attestOptions holds the per-call configuration produced by FnOpts.
+type attestOptions struct {
+	format string
+}
+
+// defaultAttestOptions returns the baseline per-call config used when
+// no FnOpts are supplied.
+func defaultAttestOptions() attestOptions {
+	return attestOptions{format: "ampel"}
+}
+
+// WithFormat selects the results-attestation format for the call.
+// Must be one of verifier.ResultsAttestationFormats. Empty resolves
+// to "ampel" at dispatch, so passing through an unset
+// AttestFormat option is safe.
+func WithFormat(format string) FnOpt {
+	return func(o *attestOptions) {
+		o.format = format
+	}
 }
 
 // AttestToFile writes the results attestation for results to path,
 // truncating any existing file. The file handle is closed before
-// the call returns.
-func (a *ResultsAttester) AttestToFile(path string, results *papi.Results) error {
+// the call returns. Format selection is per-call via WithFormat;
+// the default is "ampel".
+func (a *ResultsAttester) AttestToFile(path string, results papi.Results, opts ...FnOpt) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("opening results attestation path: %w", err)
 	}
 	defer f.Close() //nolint:errcheck // best-effort close on a write target; AttestTo's error wins
-	return a.AttestTo(f, results)
+	return a.AttestTo(f, results, opts...)
 }
 
 // AttestTo writes the results attestation for results to w. Splitting
 // the writer- and path-based entry points keeps the dispatch
 // testable without touching the filesystem.
-func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results) error {
-	switch a.Format {
-	case "ampel", "":
-		if a.Ampel == nil {
-			return errors.New("attest: \"ampel\" format requires a configured *verifier.Ampel")
-		}
-		if err := a.Ampel.AttestResults(w, results); err != nil {
-			return fmt.Errorf("writing results attestation: %w", err)
-		}
-		return nil
-	default:
-		eng := render.NewEngine()
-		if err := eng.SetDriver(a.Format); err != nil {
-			return fmt.Errorf("loading attestation driver: %w", err)
-		}
-		switch r := results.(type) {
-		case *papi.Result:
-			if err := eng.RenderResult(w, r); err != nil {
-				return fmt.Errorf("rendering result: %w", err)
-			}
-		case *papi.ResultSet:
-			if err := eng.RenderResultSet(w, r); err != nil {
-				return fmt.Errorf("rendering result set: %w", err)
-			}
-		default:
-			return errors.New("unable to determine results type to attest")
-		}
-		return nil
+func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...FnOpt) error {
+	o := defaultAttestOptions()
+	for _, fn := range opts {
+		fn(&o)
 	}
+	switch o.format {
+	case "ampel", "":
+		return a.attestAmpel(w, results)
+	default:
+		return a.attestRendered(w, results, o.format)
+	}
+}
+
+// attestAmpel writes an "ampel"-format results attestation. Result
+// and ResultGroup inputs are wrapped into a single-entry ResultSet
+// before serialization so every output is the same shape.
+func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results) error {
+	switch r := results.(type) {
+	case *papi.Result:
+		rs := &papi.ResultSet{
+			Results:   []*papi.Result{r},
+			DateStart: r.DateStart,
+			DateEnd:   r.DateEnd,
+		}
+		if err := rs.Assert(); err != nil {
+			return fmt.Errorf("asserting results set: %w", err)
+		}
+		return writeResultSet(w, rs)
+	case *papi.ResultSet:
+		return writeResultSet(w, r)
+	case *papi.ResultGroup:
+		rs := &papi.ResultSet{
+			Groups:    []*papi.ResultGroup{r},
+			DateStart: r.DateStart,
+			DateEnd:   r.DateEnd,
+		}
+		if err := rs.Assert(); err != nil {
+			return fmt.Errorf("asserting results set: %w", err)
+		}
+		return writeResultSet(w, rs)
+	default:
+		return errors.New("results are not Result, ResultSet or ResultGroup")
+	}
+}
+
+// attestRendered writes a non-"ampel" results attestation by
+// dispatching directly to the format-specific driver. Bypasses the
+// render engine on purpose: routing through internal/render would
+// pull internal/drivers/attester (and therefore this package) back
+// in via render's default driver list and break the import graph.
+func (a *ResultsAttester) attestRendered(w io.Writer, results papi.Results, format string) error {
+	var driver renderDriver
+	switch format {
+	case "vsa":
+		driver = vsa.New()
+	case "svr":
+		driver = svr.New()
+	default:
+		return fmt.Errorf("unknown attestation format %q", format)
+	}
+	switch r := results.(type) {
+	case *papi.Result:
+		if err := driver.RenderResult(w, r); err != nil {
+			return fmt.Errorf("rendering result: %w", err)
+		}
+	case *papi.ResultSet:
+		if err := driver.RenderResultSet(w, r); err != nil {
+			return fmt.Errorf("rendering result set: %w", err)
+		}
+	default:
+		return errors.New("unable to determine results type to attest")
+	}
+	return nil
+}
+
+// writeResultSet builds an in-toto statement carrying a
+// predicates.ResultSet and writes it as JSON to w. Subjects are
+// drawn from each Result's first Chain entry when present, with
+// per-digest deduplication so a ResultSet covering many results
+// against the same subject doesn't repeat it.
+func writeResultSet(w io.Writer, resultset *papi.ResultSet) error {
+	if resultset == nil {
+		return errors.New("unable to attest results, set is nil")
+	}
+
+	stmt := intoto.NewStatement()
+
+	// TODO(puerco): This should probably be a method of the results set
+	seen := []string{}
+	for _, result := range resultset.Results {
+		subject := result.Subject
+		if len(result.Chain) > 0 {
+			subject = result.Chain[0].Source
+		}
+
+		// If we already saw it, skip.
+		if slices.Contains(seen, stringifyDigests(subject)) {
+			continue
+		}
+		seen = append(seen, stringifyDigests(subject))
+
+		haveMatching := false
+		for _, s := range stmt.Subject {
+			if attestation.SubjectsMatch(s, subject) {
+				haveMatching = true
+				break
+			}
+		}
+		if !haveMatching {
+			stmt.AddSubject(subject)
+		}
+	}
+
+	stmt.PredicateType = predicates.PredicateTypeResultSet
+	stmt.Predicate = &predicates.ResultSet{Parsed: resultset}
+
+	return stmt.WriteJson(w)
+}
+
+// stringifyDigests returns a canonical algo:value/algo:value... form
+// of subject's digest map suitable for set-membership checks.
+func stringifyDigests(subject attestation.Subject) string {
+	digest := subject.GetDigest()
+	s := make([]string, 0, len(digest))
+	for algo, val := range digest {
+		s = append(s, fmt.Sprintf("%s:%s", algo, val))
+	}
+	slices.Sort(s)
+	return strings.Join(s, "/")
 }

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -10,6 +10,7 @@
 package attest
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -48,13 +49,14 @@ type FnOpt func(*attestOptions)
 
 // attestOptions holds the per-call configuration produced by FnOpts.
 type attestOptions struct {
-	format string
+	format      string
+	prettyPrint bool
 }
 
 // defaultAttestOptions returns the baseline per-call config used when
 // no FnOpts are supplied.
 func defaultAttestOptions() attestOptions {
-	return attestOptions{format: "ampel"}
+	return attestOptions{format: "ampel", prettyPrint: true}
 }
 
 // WithFormat selects the results-attestation format for the call.
@@ -64,6 +66,16 @@ func defaultAttestOptions() attestOptions {
 func WithFormat(format string) FnOpt {
 	return func(o *attestOptions) {
 		o.format = format
+	}
+}
+
+// WithPrettyPrint controls JSON formatting of the produced
+// attestation. The default is true (2-space indented output);
+// pass false for a single-line compact form suitable for piping
+// or one-line-per-record archives.
+func WithPrettyPrint(enabled bool) FnOpt {
+	return func(o *attestOptions) {
+		o.prettyPrint = enabled
 	}
 }
 
@@ -90,11 +102,11 @@ func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...Fn
 	}
 	switch o.format {
 	case "ampel", "":
-		return a.attestAmpel(w, results)
+		return a.attestAmpel(w, results, o)
 	case "vsa":
-		return a.attestVSA(w, results)
+		return a.attestVSA(w, results, o)
 	case "svr":
-		return a.attestSVR(w, results)
+		return a.attestSVR(w, results, o)
 	default:
 		return fmt.Errorf("unknown attestation format %q", o.format)
 	}
@@ -103,7 +115,7 @@ func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...Fn
 // attestAmpel writes an "ampel"-format results attestation. Result
 // and ResultGroup inputs are wrapped into a single-entry ResultSet
 // before serialization so every output is the same shape.
-func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results) error {
+func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results, o attestOptions) error {
 	switch r := results.(type) {
 	case *papi.Result:
 		rs := &papi.ResultSet{
@@ -114,9 +126,9 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results) error {
 		if err := rs.Assert(); err != nil {
 			return fmt.Errorf("asserting results set: %w", err)
 		}
-		return writeResultSet(w, rs)
+		return writeResultSet(w, rs, o)
 	case *papi.ResultSet:
-		return writeResultSet(w, r)
+		return writeResultSet(w, r, o)
 	case *papi.ResultGroup:
 		rs := &papi.ResultSet{
 			Groups:    []*papi.ResultGroup{r},
@@ -126,10 +138,33 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results) error {
 		if err := rs.Assert(); err != nil {
 			return fmt.Errorf("asserting results set: %w", err)
 		}
-		return writeResultSet(w, rs)
+		return writeResultSet(w, rs, o)
 	default:
 		return errors.New("results are not Result, ResultSet or ResultGroup")
 	}
+}
+
+// writeStatementJSON serializes stmt to w in either 2-space indented
+// or compact single-line JSON. Used by every format-specific writer
+// so the WithPrettyPrint behavior stays consistent across ampel, VSA
+// and SVR output.
+func writeStatementJSON(w io.Writer, stmt *intoto.Statement, pretty bool) error {
+	var (
+		data []byte
+		err  error
+	)
+	if pretty {
+		data, err = json.MarshalIndent(stmt, "", "  ")
+	} else {
+		data, err = json.Marshal(stmt)
+	}
+	if err != nil {
+		return fmt.Errorf("serializing statement: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("writing statement: %w", err)
+	}
+	return nil
 }
 
 // writeResultSet builds an in-toto statement carrying a
@@ -137,7 +172,7 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results) error {
 // drawn from each Result's first Chain entry when present, with
 // per-digest deduplication so a ResultSet covering many results
 // against the same subject doesn't repeat it.
-func writeResultSet(w io.Writer, resultset *papi.ResultSet) error {
+func writeResultSet(w io.Writer, resultset *papi.ResultSet, o attestOptions) error {
 	if resultset == nil {
 		return errors.New("unable to attest results, set is nil")
 	}
@@ -173,7 +208,7 @@ func writeResultSet(w io.Writer, resultset *papi.ResultSet) error {
 	stmt.PredicateType = predicates.PredicateTypeResultSet
 	stmt.Predicate = &predicates.ResultSet{Parsed: resultset}
 
-	return stmt.WriteJson(w)
+	return writeStatementJSON(w, stmt, o.prettyPrint)
 }
 
 // stringifyDigests returns a canonical algo:value/algo:value... form

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -21,19 +21,12 @@ import (
 	"github.com/carabiner-dev/collector/statement/intoto"
 	papi "github.com/carabiner-dev/policy/api/v1"
 	"github.com/carabiner-dev/predicates"
-
-	"github.com/carabiner-dev/ampel/internal/drivers/svr"
-	"github.com/carabiner-dev/ampel/internal/drivers/vsa"
 )
 
-// renderDriver is the subset of the render-driver interface that
-// produces an attestation. Declared locally so pkg/attest doesn't
-// have to import internal/render — that would pull internal/drivers/
-// attester back in and create a cycle through this package.
-type renderDriver interface {
-	RenderResult(io.Writer, *papi.Result) error
-	RenderResultSet(io.Writer, *papi.ResultSet) error
-}
+// ampelVerifierID is the verifier identifier embedded in every
+// attestation produced by this package (VSA, SVR, and the ampel
+// resultset format).
+const ampelVerifierID = "https://carabiner.dev/ampel@v1"
 
 // ResultsAttester writes a results attestation in the format chosen
 // per call via WithFormat. The "ampel" format produces an in-toto
@@ -98,8 +91,12 @@ func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...Fn
 	switch o.format {
 	case "ampel", "":
 		return a.attestAmpel(w, results)
+	case "vsa":
+		return a.attestVSA(w, results)
+	case "svr":
+		return a.attestSVR(w, results)
 	default:
-		return a.attestRendered(w, results, o.format)
+		return fmt.Errorf("unknown attestation format %q", o.format)
 	}
 }
 
@@ -133,36 +130,6 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results) error {
 	default:
 		return errors.New("results are not Result, ResultSet or ResultGroup")
 	}
-}
-
-// attestRendered writes a non-"ampel" results attestation by
-// dispatching directly to the format-specific driver. Bypasses the
-// render engine on purpose: routing through internal/render would
-// pull internal/drivers/attester (and therefore this package) back
-// in via render's default driver list and break the import graph.
-func (a *ResultsAttester) attestRendered(w io.Writer, results papi.Results, format string) error {
-	var driver renderDriver
-	switch format {
-	case "vsa":
-		driver = vsa.New()
-	case "svr":
-		driver = svr.New()
-	default:
-		return fmt.Errorf("unknown attestation format %q", format)
-	}
-	switch r := results.(type) {
-	case *papi.Result:
-		if err := driver.RenderResult(w, r); err != nil {
-			return fmt.Errorf("rendering result: %w", err)
-		}
-	case *papi.ResultSet:
-		if err := driver.RenderResultSet(w, r); err != nil {
-			return fmt.Errorf("rendering result set: %w", err)
-		}
-	default:
-		return errors.New("unable to determine results type to attest")
-	}
-	return nil
 }
 
 // writeResultSet builds an in-toto statement carrying a

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package attest writes attestations capturing evaluation results in
+// the format chosen by the caller. It is the home for the signing
+// pipeline that will turn ampel results into signed attestations —
+// for now it covers the format dispatch only, so call sites that
+// move to it today don't change shape when signing lands.
+package attest
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+
+	"github.com/carabiner-dev/ampel/internal/render"
+	"github.com/carabiner-dev/ampel/pkg/verifier"
+)
+
+// ResultsAttester writes a results attestation in the configured
+// format. The "ampel" format is rendered by the *verifier.Ampel
+// supplied at construction; non-"ampel" formats route through the
+// render engine.
+type ResultsAttester struct {
+	// Ampel renders the "ampel" format. Required when Format is
+	// "" or "ampel"; may be nil for any other format.
+	Ampel *verifier.Ampel
+
+	// Format selects the results-attestation format. Empty defaults
+	// to "ampel". Must be one of verifier.ResultsAttestationFormats;
+	// callers should rely on VerificationOptions.Validate for
+	// upstream rejection of unknown values.
+	Format string
+}
+
+// New returns a ResultsAttester wired to ampel for the "ampel" format.
+// Empty format resolves to "ampel" at attest time.
+func New(ampel *verifier.Ampel, format string) *ResultsAttester {
+	return &ResultsAttester{Ampel: ampel, Format: format}
+}
+
+// AttestToFile writes the results attestation for results to path,
+// truncating any existing file. The file handle is closed before
+// the call returns.
+func (a *ResultsAttester) AttestToFile(path string, results *papi.Results) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("opening results attestation path: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // best-effort close on a write target; AttestTo's error wins
+	return a.AttestTo(f, results)
+}
+
+// AttestTo writes the results attestation for results to w. Splitting
+// the writer- and path-based entry points keeps the dispatch
+// testable without touching the filesystem.
+func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results) error {
+	switch a.Format {
+	case "ampel", "":
+		if a.Ampel == nil {
+			return errors.New("attest: \"ampel\" format requires a configured *verifier.Ampel")
+		}
+		if err := a.Ampel.AttestResults(w, results); err != nil {
+			return fmt.Errorf("writing results attestation: %w", err)
+		}
+		return nil
+	default:
+		eng := render.NewEngine()
+		if err := eng.SetDriver(a.Format); err != nil {
+			return fmt.Errorf("loading attestation driver: %w", err)
+		}
+		switch r := results.(type) {
+		case *papi.Result:
+			if err := eng.RenderResult(w, r); err != nil {
+				return fmt.Errorf("rendering result: %w", err)
+			}
+		case *papi.ResultSet:
+			if err := eng.RenderResultSet(w, r); err != nil {
+				return fmt.Errorf("rendering result set: %w", err)
+			}
+		default:
+			return errors.New("unable to determine results type to attest")
+		}
+		return nil
+	}
+}

--- a/pkg/attest/attest_test.go
+++ b/pkg/attest/attest_test.go
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package attest
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// statementShape is a minimal in-toto Statement envelope used by the
+// dispatch tests. Asserting on _type/predicateType/subject is enough
+// to catch dispatch and writer wiring regressions without binding
+// the test suite to any specific predicate schema.
+type statementShape struct {
+	Type          string `json:"_type"`
+	PredicateType string `json:"predicateType"`
+	Subject       []struct {
+		Name   string            `json:"name,omitempty"`
+		Digest map[string]string `json:"digest,omitempty"`
+	} `json:"subject"`
+}
+
+func newSubject(digest string) *gointoto.ResourceDescriptor {
+	return &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": digest},
+	}
+}
+
+// newResultSet builds a minimal *papi.ResultSet carrying one passing
+// Result per provided digest. The first digest also seeds the
+// set-level Subject so VSA/SVR writers (which read set.GetSubject())
+// have something to emit.
+func newResultSet(t *testing.T, digests ...string) *papi.ResultSet {
+	t.Helper()
+	rs := &papi.ResultSet{
+		DateStart: timestamppb.Now(),
+		DateEnd:   timestamppb.Now(),
+		Status:    papi.StatusPASS,
+	}
+	if len(digests) > 0 {
+		rs.Subject = newSubject(digests[0])
+	}
+	for _, d := range digests {
+		rs.Results = append(rs.Results, &papi.Result{
+			Subject: newSubject(d),
+			Status:  papi.StatusPASS,
+		})
+	}
+	return rs
+}
+
+func TestAttestTo_FormatDispatch(t *testing.T) {
+	cases := []struct {
+		format       string
+		wantPredType string
+	}{
+		{"ampel", "https://carabiner.dev/ampel/resultset/v0"},
+		{"vsa", "https://slsa.dev/verification_summary/v1"},
+		{"svr", "https://in-toto.io/attestation/svr/v0.1"},
+	}
+	rs := newResultSet(t, "deadbeef")
+	for _, tc := range cases {
+		t.Run(tc.format, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := New().AttestTo(&buf, rs, WithFormat(tc.format)); err != nil {
+				t.Fatalf("AttestTo: %v", err)
+			}
+			var stmt statementShape
+			if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
+				t.Fatalf("unmarshaling output: %v\nbody: %s", err, buf.String())
+			}
+			if stmt.PredicateType != tc.wantPredType {
+				t.Errorf("predicateType = %q, want %q", stmt.PredicateType, tc.wantPredType)
+			}
+		})
+	}
+}
+
+func TestAttestTo_FormatDefault(t *testing.T) {
+	const wantAmpel = "https://carabiner.dev/ampel/resultset/v0"
+	rs := newResultSet(t, "deadbeef")
+	cases := []struct {
+		name string
+		opts []FnOpt
+	}{
+		{"no option", nil},
+		{"explicit empty", []FnOpt{WithFormat("")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := New().AttestTo(&buf, rs, tc.opts...); err != nil {
+				t.Fatalf("AttestTo: %v", err)
+			}
+			var stmt statementShape
+			if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
+				t.Fatalf("unmarshaling output: %v", err)
+			}
+			if stmt.PredicateType != wantAmpel {
+				t.Errorf("predicateType = %q, want %q", stmt.PredicateType, wantAmpel)
+			}
+		})
+	}
+}
+
+func TestAttestTo_UnknownFormat(t *testing.T) {
+	rs := newResultSet(t, "deadbeef")
+	err := New().AttestTo(&bytes.Buffer{}, rs, WithFormat("bogus"))
+	if err == nil {
+		t.Fatal("expected error for unknown format")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error should mention the format name; got: %v", err)
+	}
+}
+
+func TestAttestTo_PrettyPrint(t *testing.T) {
+	rs := newResultSet(t, "deadbeef")
+
+	var pretty bytes.Buffer
+	if err := New().AttestTo(&pretty, rs); err != nil {
+		t.Fatalf("default AttestTo: %v", err)
+	}
+	if !bytes.Contains(pretty.Bytes(), []byte("\n")) {
+		t.Errorf("default output should be multi-line; got:\n%s", pretty.String())
+	}
+
+	var compact bytes.Buffer
+	if err := New().AttestTo(&compact, rs, WithPrettyPrint(false)); err != nil {
+		t.Fatalf("compact AttestTo: %v", err)
+	}
+	if bytes.Contains(compact.Bytes(), []byte("\n")) {
+		t.Errorf("WithPrettyPrint(false) should produce single-line output; got:\n%s", compact.String())
+	}
+}
+
+func TestAttestAmpel_SubjectDedup(t *testing.T) {
+	// Two results sharing the same digest should yield one subject.
+	rs := newResultSet(t, "deadbeef", "deadbeef")
+	var buf bytes.Buffer
+	if err := New().AttestTo(&buf, rs); err != nil {
+		t.Fatalf("AttestTo: %v", err)
+	}
+	var stmt statementShape
+	if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
+		t.Fatalf("unmarshaling output: %v", err)
+	}
+	if got := len(stmt.Subject); got != 1 {
+		t.Errorf("subject count = %d, want 1 (dedup); subjects: %+v", got, stmt.Subject)
+	}
+}
+
+func TestAttestVSA_ResultGroupNotSupported(t *testing.T) {
+	grp := &papi.ResultGroup{Status: papi.StatusPASS}
+	err := New().AttestTo(&bytes.Buffer{}, grp, WithFormat("vsa"))
+	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
+		t.Errorf("want \"not supported yet\" error; got %v", err)
+	}
+}
+
+func TestAttestSVR_ResultGroupNotSupported(t *testing.T) {
+	grp := &papi.ResultGroup{Status: papi.StatusPASS}
+	err := New().AttestTo(&bytes.Buffer{}, grp, WithFormat("svr"))
+	if err == nil || !strings.Contains(err.Error(), "not supported yet") {
+		t.Errorf("want \"not supported yet\" error; got %v", err)
+	}
+}
+
+func TestStringifyDigests(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest map[string]string
+		want   string
+	}{
+		{"empty", map[string]string{}, ""},
+		{"single", map[string]string{"sha256": "deadbeef"}, "sha256:deadbeef"},
+		{"sorted", map[string]string{"sha512": "ffff", "sha1": "1111"}, "sha1:1111/sha512:ffff"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stringifyDigests(&gointoto.ResourceDescriptor{Digest: tc.digest})
+			if got != tc.want {
+				t.Errorf("stringifyDigests = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStringifyDigests_OrderStability guards against accidental
+// removal of the slices.Sort step: with multiple digest algorithms,
+// map iteration order is randomized, so an unsorted output would
+// flake across calls.
+func TestStringifyDigests_OrderStability(t *testing.T) {
+	sub := &gointoto.ResourceDescriptor{Digest: map[string]string{
+		"sha256": "deadbeef", "sha1": "1111", "sha512": "ffff",
+	}}
+	first := stringifyDigests(sub)
+	for i := range 10 {
+		if got := stringifyDigests(sub); got != first {
+			t.Errorf("iter %d: stringifyDigests = %q, want %q", i, got, first)
+		}
+	}
+}
+
+func TestResultStringToSLSAResult(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{papi.StatusPASS, "PASSED"},
+		{papi.StatusSOFTFAIL, "PASSED"},
+		{papi.StatusFAIL, "FAILED"},
+		{"", ""},
+		{"weird", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := resultStringToSLSAResult(tc.in); got != tc.want {
+				t.Errorf("resultStringToSLSAResult(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/attest/svr.go
+++ b/pkg/attest/svr.go
@@ -24,12 +24,12 @@ import (
 const svrPredicateType = "https://in-toto.io/attestation/svr/v0.1"
 
 // attestSVR writes a Simple Verification Result attestation for results.
-func (a *ResultsAttester) attestSVR(w io.Writer, results papi.Results) error {
+func (a *ResultsAttester) attestSVR(w io.Writer, results papi.Results, o attestOptions) error {
 	switch r := results.(type) {
 	case *papi.Result:
-		return a.writeSVRFromResult(w, r)
+		return a.writeSVRFromResult(w, r, o)
 	case *papi.ResultSet:
-		return a.writeSVRFromResultSet(w, r)
+		return a.writeSVRFromResultSet(w, r, o)
 	case *papi.ResultGroup:
 		return errors.New("rendering result groups as SVRs is not supported yet")
 	default:
@@ -37,7 +37,7 @@ func (a *ResultsAttester) attestSVR(w io.Writer, results papi.Results) error {
 	}
 }
 
-func (a *ResultsAttester) writeSVRFromResultSet(w io.Writer, set *papi.ResultSet) error {
+func (a *ResultsAttester) writeSVRFromResultSet(w io.Writer, set *papi.ResultSet, o attestOptions) error {
 	policyAny, err := svrPolicyResourceDescriptor(set.GetMeta().GetOrigin())
 	if err != nil {
 		return fmt.Errorf("wrapping policy descriptor: %w", err)
@@ -67,10 +67,10 @@ func (a *ResultsAttester) writeSVRFromResultSet(w io.Writer, set *papi.ResultSet
 		}
 	}
 
-	return writeSVRStatement(w, set.GetSubject(), svrData)
+	return writeSVRStatement(w, set.GetSubject(), svrData, o)
 }
 
-func (a *ResultsAttester) writeSVRFromResult(w io.Writer, result *papi.Result) error {
+func (a *ResultsAttester) writeSVRFromResult(w io.Writer, result *papi.Result, o attestOptions) error {
 	policyAny, err := svrPolicyResourceDescriptor(result.GetMeta().GetOrigin())
 	if err != nil {
 		return fmt.Errorf("wrapping policy descriptor: %w", err)
@@ -95,14 +95,14 @@ func (a *ResultsAttester) writeSVRFromResult(w io.Writer, result *papi.Result) e
 		}
 	}
 
-	return writeSVRStatement(w, result.GetSubject(), svrData)
+	return writeSVRStatement(w, result.GetSubject(), svrData, o)
 }
 
 // writeSVRStatement wraps the populated SVR predicate in an in-toto
 // statement and writes it as JSON to w. The protojson Any wrapper
 // injects an "@type" field into the policy block; strip it so the
 // SVR output stays clean.
-func writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.SimpleVerificationResult) error {
+func writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.SimpleVerificationResult, o attestOptions) error {
 	svrJsonData, err := protojson.Marshal(att)
 	if err != nil {
 		return fmt.Errorf("marshaling svr: %w", err)
@@ -137,15 +137,7 @@ func writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.Si
 		}),
 	)
 
-	jsonData, err := json.Marshal(statement)
-	if err != nil {
-		return fmt.Errorf("serializing SVR: %w", err)
-	}
-
-	if _, err := w.Write(jsonData); err != nil {
-		return fmt.Errorf("writing SVR data: %w", err)
-	}
-	return nil
+	return writeStatementJSON(w, statement, o.prettyPrint)
 }
 
 func svrPolicyResourceDescriptor(origin attestation.Subject) (*anypb.Any, error) {

--- a/pkg/attest/svr.go
+++ b/pkg/attest/svr.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package attest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/carabiner-dev/collector/predicate/generic"
+	"github.com/carabiner-dev/collector/statement/intoto"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	svrpred "github.com/in-toto/attestation/go/predicates/svr/v01"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+const svrPredicateType = "https://in-toto.io/attestation/svr/v0.1"
+
+// attestSVR writes a Simple Verification Result attestation for results.
+func (a *ResultsAttester) attestSVR(w io.Writer, results papi.Results) error {
+	switch r := results.(type) {
+	case *papi.Result:
+		return a.writeSVRFromResult(w, r)
+	case *papi.ResultSet:
+		return a.writeSVRFromResultSet(w, r)
+	case *papi.ResultGroup:
+		return errors.New("rendering result groups as SVRs is not supported yet")
+	default:
+		return errors.New("unable to determine results type to attest")
+	}
+}
+
+func (a *ResultsAttester) writeSVRFromResultSet(w io.Writer, set *papi.ResultSet) error {
+	policyAny, err := svrPolicyResourceDescriptor(set.GetMeta().GetOrigin())
+	if err != nil {
+		return fmt.Errorf("wrapping policy descriptor: %w", err)
+	}
+
+	svrData := &svrpred.SimpleVerificationResult{
+		Verifier: &svrpred.SimpleVerificationResult_Verifier{
+			Id:     ampelVerifierID,
+			Policy: policyAny,
+		},
+		TimeCreated: set.GetDateEnd(),
+		Properties:  []string{},
+	}
+
+	for _, r := range set.Results {
+		if r.GetStatus() != papi.StatusPASS {
+			continue
+		}
+		for _, ctl := range r.GetMeta().GetControls() {
+			if ctl.Id == "" {
+				continue
+			}
+			label := strings.ReplaceAll(ctl.Label(), "-", "_")
+			if !slices.Contains(svrData.Properties, label) {
+				svrData.Properties = append(svrData.Properties, label)
+			}
+		}
+	}
+
+	return writeSVRStatement(w, set.GetSubject(), svrData)
+}
+
+func (a *ResultsAttester) writeSVRFromResult(w io.Writer, result *papi.Result) error {
+	policyAny, err := svrPolicyResourceDescriptor(result.GetMeta().GetOrigin())
+	if err != nil {
+		return fmt.Errorf("wrapping policy descriptor: %w", err)
+	}
+
+	svrData := &svrpred.SimpleVerificationResult{
+		Verifier: &svrpred.SimpleVerificationResult_Verifier{
+			Id:     ampelVerifierID,
+			Policy: policyAny,
+		},
+		TimeCreated: result.GetDateEnd(),
+		Properties:  []string{},
+	}
+
+	for _, ctl := range result.GetMeta().GetControls() {
+		if ctl.Id == "" {
+			continue
+		}
+		label := strings.ReplaceAll(ctl.Label(), "-", "_")
+		if !slices.Contains(svrData.Properties, label) {
+			svrData.Properties = append(svrData.Properties, label)
+		}
+	}
+
+	return writeSVRStatement(w, result.GetSubject(), svrData)
+}
+
+// writeSVRStatement wraps the populated SVR predicate in an in-toto
+// statement and writes it as JSON to w. The protojson Any wrapper
+// injects an "@type" field into the policy block; strip it so the
+// SVR output stays clean.
+func writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.SimpleVerificationResult) error {
+	svrJsonData, err := protojson.Marshal(att)
+	if err != nil {
+		return fmt.Errorf("marshaling svr: %w", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(svrJsonData, &raw); err != nil {
+		return fmt.Errorf("unmarshaling svr json: %w", err)
+	}
+	if verifier, ok := raw["verifier"].(map[string]any); ok {
+		if policy, ok := verifier["policy"].(map[string]any); ok {
+			delete(policy, "@type")
+		}
+	}
+	svrJsonData, err = json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("re-marshaling svr json: %w", err)
+	}
+
+	pred := &generic.Predicate{
+		Type:   attestation.PredicateType(svrPredicateType),
+		Parsed: att,
+		Data:   svrJsonData,
+	}
+
+	statement := intoto.NewStatement(
+		intoto.WithPredicate(pred),
+		intoto.WithSubject(&gointoto.ResourceDescriptor{
+			Name:   subject.GetName(),
+			Uri:    subject.GetUri(),
+			Digest: subject.GetDigest(),
+		}),
+	)
+
+	jsonData, err := json.Marshal(statement)
+	if err != nil {
+		return fmt.Errorf("serializing SVR: %w", err)
+	}
+
+	if _, err := w.Write(jsonData); err != nil {
+		return fmt.Errorf("writing SVR data: %w", err)
+	}
+	return nil
+}
+
+func svrPolicyResourceDescriptor(origin attestation.Subject) (*anypb.Any, error) {
+	rd := &gointoto.ResourceDescriptor{
+		Uri:    origin.GetUri(),
+		Digest: origin.GetDigest(),
+	}
+	return anypb.New(rd)
+}

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -4,7 +4,6 @@
 package attest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -37,12 +36,12 @@ const (
 // computed by extracting the results of policies chained to a
 // different subject — those policies are expected to have their own
 // controls section, defining the SLSA level they check.
-func (a *ResultsAttester) attestVSA(w io.Writer, results papi.Results) error {
+func (a *ResultsAttester) attestVSA(w io.Writer, results papi.Results, o attestOptions) error {
 	switch r := results.(type) {
 	case *papi.Result:
-		return a.writeVSAFromResult(w, r)
+		return a.writeVSAFromResult(w, r, o)
 	case *papi.ResultSet:
-		return a.writeVSAFromResultSet(w, r)
+		return a.writeVSAFromResultSet(w, r, o)
 	case *papi.ResultGroup:
 		return errors.New("rendering result groups as VSAs is not supported yet")
 	default:
@@ -50,7 +49,7 @@ func (a *ResultsAttester) attestVSA(w io.Writer, results papi.Results) error {
 	}
 }
 
-func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet) error {
+func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet, o attestOptions) error {
 	vsaData := &v1.VerificationSummary{
 		Verifier: &v1.VerificationSummary_Verifier{
 			Id: ampelVerifierID,
@@ -125,10 +124,10 @@ func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet
 	if verifiedSomeSlsa {
 		vsaData.SlsaVersion = slsaVersion
 	}
-	return writeVSAStatement(w, set.GetSubject(), vsaData)
+	return writeVSAStatement(w, set.GetSubject(), vsaData, o)
 }
 
-func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result) error {
+func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result, o attestOptions) error {
 	vsaData := &v1.VerificationSummary{
 		Verifier: &v1.VerificationSummary_Verifier{
 			Id: ampelVerifierID,
@@ -177,12 +176,12 @@ func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result) e
 	if verifiedSomeSlsa {
 		vsaData.SlsaVersion = slsaVersion
 	}
-	return writeVSAStatement(w, result.GetSubject(), vsaData)
+	return writeVSAStatement(w, result.GetSubject(), vsaData, o)
 }
 
 // writeVSAStatement wraps the populated VSA predicate in an in-toto
 // statement and writes it as JSON to w.
-func writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.VerificationSummary) error {
+func writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.VerificationSummary, o attestOptions) error {
 	vsaJsonData, err := protojson.Marshal(att)
 	if err != nil {
 		return fmt.Errorf("marshaling vsa: %w", err)
@@ -203,15 +202,7 @@ func writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.Verific
 		}),
 	)
 
-	jsonData, err := json.Marshal(statement)
-	if err != nil {
-		return fmt.Errorf("serializing VSA: %w", err)
-	}
-
-	if _, err := w.Write(jsonData); err != nil {
-		return fmt.Errorf("writing VSA data: %w", err)
-	}
-	return nil
+	return writeStatementJSON(w, statement, o.prettyPrint)
 }
 
 // resultStringToSLSAResult translates ampel evaluation status strings

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package attest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/carabiner-dev/collector/predicate/generic"
+	"github.com/carabiner-dev/collector/statement/intoto"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	v1 "github.com/in-toto/attestation/go/predicates/vsa/v1"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	// slsaVersion version used as base to compute the VSA
+	slsaVersion = "1.1"
+
+	// vsaContextResourceURIKey is the policy-context key recognized
+	// for overriding the VSA resource URI.
+	vsaContextResourceURIKey = "vsa.resourceUri"
+)
+
+// attestVSA writes a VSA attestation for results.
+//
+// The VerificationResult on the VSA is mapped from the PolicySet
+// assessment status, and the VerifiedLevels list is taken from the
+// SLSA controls advertised by the policies. Dependency levels are
+// computed by extracting the results of policies chained to a
+// different subject — those policies are expected to have their own
+// controls section, defining the SLSA level they check.
+func (a *ResultsAttester) attestVSA(w io.Writer, results papi.Results) error {
+	switch r := results.(type) {
+	case *papi.Result:
+		return a.writeVSAFromResult(w, r)
+	case *papi.ResultSet:
+		return a.writeVSAFromResultSet(w, r)
+	case *papi.ResultGroup:
+		return errors.New("rendering result groups as VSAs is not supported yet")
+	default:
+		return errors.New("unable to determine results type to attest")
+	}
+}
+
+func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet) error {
+	vsaData := &v1.VerificationSummary{
+		Verifier: &v1.VerificationSummary_Verifier{
+			Id: ampelVerifierID,
+		},
+		TimeVerified: set.GetDateEnd(),
+		// We set the resource URI here to the resource URI of the verified subject
+		// but if the policyset common context defines one, we'll override it later.
+		ResourceUri: set.GetSubject().GetUri(),
+		Policy: &v1.VerificationSummary_Policy{
+			Uri:    set.GetMeta().GetOrigin().GetUri(),
+			Digest: set.GetMeta().GetOrigin().GetDigest(),
+		},
+		InputAttestations:  []*v1.VerificationSummary_InputAttestation{},
+		VerificationResult: resultStringToSLSAResult(set.GetStatus()),
+		VerifiedLevels:     []string{},
+		DependencyLevels:   nil,
+	}
+
+	inputs := []attestation.Subject{}
+	depLevels := map[string]uint64{}
+
+	// Check if the policyset defined a resourceURI for the VSA and replace the
+	// value we got from the subject resource locator.
+	if setContext := set.GetCommon().GetContext(); setContext != nil {
+		if s, ok := setContext.AsMap()[vsaContextResourceURIKey].(string); ok && s != "" {
+			vsaData.ResourceUri = s
+		}
+	}
+
+	var verifiedSomeSlsa bool
+	for _, r := range set.Results {
+		for _, er := range r.EvalResults {
+			for _, stRef := range er.GetStatements() {
+				if !subjectInList(inputs, stRef.GetAttestation()) {
+					inputs = append(inputs, stRef.GetAttestation())
+				}
+			}
+		}
+
+		// Collect any SLSA levels into the dep count
+		if r.GetStatus() != papi.StatusPASS {
+			continue
+		}
+		for _, ctl := range r.GetMeta().GetControls() {
+			if ctl.Id == "" {
+				continue
+			}
+			label := strings.ReplaceAll(ctl.Label(), "-", "_")
+			if !strings.HasPrefix(label, "SLSA_") {
+				continue
+			}
+
+			verifiedSomeSlsa = true
+
+			// Add the level to the verified levels when the result subject
+			// matches the policyset subject. Otherwise treat the policyset as
+			// chained to verify dependencies.
+			if attestation.SubjectsMatch(set.GetSubject(), r.GetSubject()) {
+				if !slices.Contains(vsaData.VerifiedLevels, label) {
+					vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
+				}
+			} else {
+				depLevels[label]++
+			}
+		}
+	}
+	if len(depLevels) > 0 {
+		vsaData.DependencyLevels = depLevels
+	}
+
+	vsaData.InputAttestations = subjectsToSummaryInputs(inputs)
+	if verifiedSomeSlsa {
+		vsaData.SlsaVersion = slsaVersion
+	}
+	return writeVSAStatement(w, set.GetSubject(), vsaData)
+}
+
+func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result) error {
+	vsaData := &v1.VerificationSummary{
+		Verifier: &v1.VerificationSummary_Verifier{
+			Id: ampelVerifierID,
+		},
+		TimeVerified: result.GetDateEnd(),
+		// We fix the resource URI here to the resource URI of the verification
+		// subject, but if the policy context defines one, we'll override it.
+		ResourceUri: result.GetSubject().GetUri(),
+		Policy: &v1.VerificationSummary_Policy{
+			Uri:    result.GetMeta().GetOrigin().GetUri(),
+			Digest: result.GetMeta().GetOrigin().GetDigest(),
+		},
+		InputAttestations:  []*v1.VerificationSummary_InputAttestation{},
+		VerificationResult: resultStringToSLSAResult(result.GetStatus()),
+		VerifiedLevels:     []string{},
+		DependencyLevels:   nil,
+	}
+
+	if resContext := result.GetContext(); resContext != nil {
+		if v, ok := resContext.AsMap()[vsaContextResourceURIKey]; ok && v != nil {
+			if s, ok2 := v.(string); ok2 && s != "" {
+				vsaData.ResourceUri = s
+			}
+		}
+	}
+
+	var verifiedSomeSlsa bool
+	for _, ctl := range result.GetMeta().GetControls() {
+		label := strings.ReplaceAll(ctl.Label(), "-", "_")
+		if !strings.HasPrefix(label, "SLSA_") {
+			continue
+		}
+		verifiedSomeSlsa = true
+		vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
+	}
+
+	inputs := []attestation.Subject{}
+	for _, er := range result.EvalResults {
+		for _, stRef := range er.GetStatements() {
+			if !subjectInList(inputs, stRef.GetAttestation()) {
+				inputs = append(inputs, stRef.GetAttestation())
+			}
+		}
+	}
+	vsaData.InputAttestations = subjectsToSummaryInputs(inputs)
+	if verifiedSomeSlsa {
+		vsaData.SlsaVersion = slsaVersion
+	}
+	return writeVSAStatement(w, result.GetSubject(), vsaData)
+}
+
+// writeVSAStatement wraps the populated VSA predicate in an in-toto
+// statement and writes it as JSON to w.
+func writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.VerificationSummary) error {
+	vsaJsonData, err := protojson.Marshal(att)
+	if err != nil {
+		return fmt.Errorf("marshaling vsa: %w", err)
+	}
+
+	pred := &generic.Predicate{
+		Type:   attestation.PredicateType("https://slsa.dev/verification_summary/v1"),
+		Parsed: att,
+		Data:   vsaJsonData,
+	}
+
+	statement := intoto.NewStatement(
+		intoto.WithPredicate(pred),
+		intoto.WithSubject(&gointoto.ResourceDescriptor{
+			Name:   subject.GetName(),
+			Uri:    subject.GetUri(),
+			Digest: subject.GetDigest(),
+		}),
+	)
+
+	jsonData, err := json.Marshal(statement)
+	if err != nil {
+		return fmt.Errorf("serializing VSA: %w", err)
+	}
+
+	if _, err := w.Write(jsonData); err != nil {
+		return fmt.Errorf("writing VSA data: %w", err)
+	}
+	return nil
+}
+
+// resultStringToSLSAResult translates ampel evaluation status strings
+// to the VerificationResult vocabulary used by SLSA.
+func resultStringToSLSAResult(status string) string {
+	switch status {
+	case papi.StatusPASS, papi.StatusSOFTFAIL:
+		return "PASSED"
+	case papi.StatusFAIL:
+		return "FAILED"
+	default:
+		return ""
+	}
+}
+
+func subjectsToSummaryInputs(inputs []attestation.Subject) []*v1.VerificationSummary_InputAttestation {
+	if len(inputs) == 0 {
+		return nil
+	}
+	ret := make([]*v1.VerificationSummary_InputAttestation, 0, len(inputs))
+	for _, s := range inputs {
+		ret = append(ret, &v1.VerificationSummary_InputAttestation{
+			Uri:    s.GetUri(),
+			Digest: s.GetDigest(),
+		})
+	}
+	return ret
+}
+
+// subjectInList reports whether needle's digests match any subject in
+// haystack. Used to deduplicate input-attestation lists.
+func subjectInList(haystack []attestation.Subject, needle attestation.Subject) bool {
+	for _, sut := range haystack {
+		if attestation.SubjectsMatch(sut, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/evaluator/cel/verification.go
+++ b/pkg/evaluator/cel/verification.go
@@ -198,7 +198,7 @@ var matchIdImpl = func(lhs ref.Val, rhs ref.Val) ref.Val {
 		return types.NewErr("matchesId: argument must be a string")
 	}
 
-	id, err := sapi.NewIdentityFromSlug(slug)
+	id, err := sapi.NewIdentityFromSpec(slug)
 	if err != nil {
 		return types.NewErr("matchesId: invalid identity slug: %v", err)
 	}

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -8,9 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
-	"os"
 	"slices"
 	"strings"
 	"text/template"
@@ -23,7 +21,6 @@ import (
 	"github.com/carabiner-dev/collector/filters"
 	"github.com/carabiner-dev/collector/statement/intoto"
 	papi "github.com/carabiner-dev/policy/api/v1"
-	"github.com/carabiner-dev/predicates"
 	sapi "github.com/carabiner-dev/signer/api/v1"
 	gointoto "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
@@ -56,13 +53,6 @@ type AmpelVerifier interface {
 
 	FilterAttestations(*VerificationOptions, attestation.Subject, []attestation.Envelope, [][]*sapi.Identity) ([]attestation.Predicate, error)
 	AssertResult(*papi.Policy, *papi.Result) error
-	AttestResults(context.Context, *VerificationOptions, papi.Results) error
-
-	// AttestResultToWriter takes an evaluation result and writes an attestation to the supplied io.Writer
-	AttestResultToWriter(io.Writer, *papi.Result) error
-
-	// AttestResultSetToWriter takes an policy resultset and writes an attestation to the supplied io.Writer
-	AttestResultSetToWriter(io.Writer, *papi.ResultSet) error
 
 	// VerifySubject runs the verification process.
 	VerifySubject(context.Context, *VerificationOptions, map[class.Class]evaluator.Evaluator, *papi.Policy, map[string]any, attestation.Subject, []attestation.Predicate) (*papi.Result, error)
@@ -1184,132 +1174,6 @@ func (di *defaultIplementation) VerifySubject(
 	rs.DateEnd = timestamppb.Now()
 
 	return rs, errors.Join(errs...)
-}
-
-// AttestResults writes an attestation captring the evaluation
-// results set.
-func (di *defaultIplementation) AttestResults(
-	ctx context.Context, opts *VerificationOptions, results papi.Results,
-) error {
-	if !opts.AttestResults {
-		return nil
-	}
-
-	logrus.Debugf("writing evaluation attestation to %s", opts.ResultsAttestationPath)
-
-	// Open the file in the options
-	f, err := os.Create(opts.ResultsAttestationPath)
-	if err != nil {
-		return fmt.Errorf("opening results attestation file: %w", err)
-	}
-
-	switch r := results.(type) {
-	case *papi.Result:
-		// Write the statement to json
-		return di.AttestResultToWriter(f, r)
-	case *papi.ResultSet:
-		return di.AttestResultSetToWriter(f, r)
-	default:
-		return fmt.Errorf("unable to cast result")
-	}
-}
-
-// AttestResultToWriter writes an attestation capturing a evaluation
-// result set.
-func (di *defaultIplementation) AttestResultToWriter(
-	w io.Writer, result *papi.Result,
-) error {
-	if result == nil {
-		return fmt.Errorf("unable to attest results, set is nil")
-	}
-
-	subject := result.Subject
-	if result.Chain != nil {
-		if len(result.Chain) > 0 {
-			subject = result.Chain[0].Source
-		}
-	}
-
-	// Create the predicate file
-	pred := &predicates.ResultSet{
-		Parsed: &papi.ResultSet{
-			Results: []*papi.Result{result},
-		},
-	}
-
-	// Create the statement
-	stmt := intoto.NewStatement()
-	stmt.PredicateType = predicates.PredicateTypeResultSet
-	stmt.AddSubject(subject)
-	stmt.Predicate = pred
-
-	// Write the statement to json
-	return stmt.WriteJson(w)
-}
-
-func stringifyDigests(subject attestation.Subject) string {
-	digest := subject.GetDigest()
-	s := make([]string, 0, len(digest))
-	for algo, val := range digest {
-		s = append(s, fmt.Sprintf("%s:%s", algo, val))
-	}
-
-	slices.Sort(s)
-	return strings.Join(s, "/")
-}
-
-// AttestResults writes an attestation captring the evaluation
-// results set.
-func (di *defaultIplementation) AttestResultSetToWriter(
-	w io.Writer, resultset *papi.ResultSet,
-) error {
-	if resultset == nil {
-		return fmt.Errorf("unable to attest results, set is nil")
-	}
-
-	// TODO(puerco): This should probably be a method of the results set
-	seen := []string{}
-
-	// Create the statement
-	stmt := intoto.NewStatement()
-
-	for _, result := range resultset.Results {
-		subject := result.Subject
-		if result.Chain != nil {
-			if len(result.Chain) > 0 {
-				subject = result.Chain[0].Source
-			}
-		}
-
-		// If we already saw it, next:
-		if slices.Contains(seen, stringifyDigests(subject)) {
-			continue
-		}
-
-		// If we havent check if we have a matching pred
-		seen = append(seen, stringifyDigests(subject))
-		haveMatching := false
-		for _, s := range stmt.Subject {
-			if attestation.SubjectsMatch(s, subject) {
-				haveMatching = true
-				break
-			}
-		}
-		if !haveMatching {
-			stmt.AddSubject(subject)
-		}
-	}
-
-	// Create the predicate file
-	pred := &predicates.ResultSet{
-		Parsed: resultset,
-	}
-
-	stmt.PredicateType = predicates.PredicateTypeResultSet
-	stmt.Predicate = pred
-
-	// Write the statement to json
-	return stmt.WriteJson(w)
 }
 
 // ProcessPolicySetChainedSubjects executes a PolicySet's ChainLink and returns

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -478,7 +478,7 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 	if len(opts.IdentityStrings) > 0 && len(policyIdentities) == 0 {
 		logrus.Debugf("Got %d identity strings from options", len(opts.IdentityStrings))
 		for _, idSlug := range opts.IdentityStrings {
-			ident, err := sapi.NewIdentityFromSlug(idSlug)
+			ident, err := sapi.NewIdentityFromSpec(idSlug)
 			if err != nil {
 				return false, nil, nil, fmt.Errorf("invalid identity slug %q: %w", idSlug, err)
 			}
@@ -496,7 +496,7 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 
 	logrus.Debug("Will look for signed attestations from:")
 	for _, i := range allIds {
-		logrus.Debugf("  > %s", i.Slug())
+		logrus.Debugf("  > %s", i.Principal())
 	}
 
 	// The keys to use are the ones in the options...

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -451,7 +451,7 @@ func TestCheckIdentities(t *testing.T) {
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}}},
 			},
 		}, false, true, true},
-		{"no-matching-identities-opts", VerificationOptions{IdentityStrings: []string{idSigstore.Slug()}}, []*sapi.Identity{}, []attestation.Envelope{
+		{"no-matching-identities-opts", VerificationOptions{IdentityStrings: []string{idSigstore.Spec()}}, []*sapi.Identity{}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstoreOther}}},
 			},
@@ -461,7 +461,7 @@ func TestCheckIdentities(t *testing.T) {
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstoreOther}}},
 			},
 		}, false, false, false},
-		{"ids-in-opts", VerificationOptions{IdentityStrings: []string{idSigstore.Slug()}}, []*sapi.Identity{}, []attestation.Envelope{
+		{"ids-in-opts", VerificationOptions{IdentityStrings: []string{idSigstore.Spec()}}, []*sapi.Identity{}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}}},
 			},
@@ -473,14 +473,14 @@ func TestCheckIdentities(t *testing.T) {
 				},
 			},
 		}, false, true, false},
-		{"ids-in-policy-over-opts-pass", VerificationOptions{IdentityStrings: []string{idSigstoreOther.Slug()}}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
+		{"ids-in-policy-over-opts-pass", VerificationOptions{IdentityStrings: []string{idSigstoreOther.Spec()}}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{
 					Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}},
 				},
 			},
 		}, false, true, false},
-		{"ids-in-policy-over-opts-fail", VerificationOptions{IdentityStrings: []string{idSigstore.Slug()}}, []*sapi.Identity{idSigstoreOther}, []attestation.Envelope{
+		{"ids-in-policy-over-opts-fail", VerificationOptions{IdentityStrings: []string{idSigstore.Spec()}}, []*sapi.Identity{idSigstoreOther}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{
 					Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}},

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/carabiner-dev/ampel/pkg/attest"
 	"github.com/carabiner-dev/ampel/pkg/evaluator"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/evalcontext"
@@ -687,39 +688,17 @@ func subjectToString(subject attestation.Subject) string {
 	return str
 }
 
-// AttestResult writes an attestation capturing an evaluation result
+// AttestResult writes an attestation capturing an evaluation result.
 func (ampel *Ampel) AttestResult(w io.Writer, result *papi.Result) error {
-	return ampel.impl.AttestResultToWriter(w, result)
+	return attest.New().AttestTo(w, result)
 }
 
-// AttestResult writes an attestation capturing an evaluation result
+// AttestResults writes an attestation capturing one or more
+// evaluation results. Result and ResultGroup inputs are wrapped into
+// a single-entry ResultSet by the attester so every output shape is
+// consistent.
 func (ampel *Ampel) AttestResults(w io.Writer, results papi.Results) error {
-	switch r := results.(type) {
-	case *papi.Result:
-		rs := &papi.ResultSet{
-			Results:   []*papi.Result{r},
-			DateStart: r.DateStart,
-			DateEnd:   r.DateEnd,
-		}
-		if err := rs.Assert(); err != nil {
-			return fmt.Errorf("asserting results set: %w", err)
-		}
-		return ampel.impl.AttestResultSetToWriter(w, rs)
-	case *papi.ResultSet:
-		return ampel.impl.AttestResultSetToWriter(w, r)
-	case *papi.ResultGroup:
-		rs := &papi.ResultSet{
-			Groups:    []*papi.ResultGroup{r},
-			DateStart: r.DateStart,
-			DateEnd:   r.DateEnd,
-		}
-		if err := rs.Assert(); err != nil {
-			return fmt.Errorf("asserting results set: %w", err)
-		}
-		return ampel.impl.AttestResultSetToWriter(w, rs)
-	default:
-		return fmt.Errorf("results are not result or resultset")
-	}
+	return attest.New().AttestTo(w, results)
 }
 
 // failPolicySetWithError completes a policy set and sets the specified error


### PR DESCRIPTION
In preparation for results signing, this PR reorganized all the logic that generates the results attestations into a new attest package where the new `ResultsAttester` object handles the generation of the statements.

Both the CLI and the results renderer are ported to use the new attest package.