### PR TITLE
Implement attestation signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ This means that results can be used as input attestations for further policies,
 making it simple to check for complex processes further downstream after they
 have been checked once.
 
+Result attestations can be produced as the full Ampel ResultSet, as a SLSA
+[Verification Summary Attestation (VSA)](https://slsa.dev/verification_summary/v1)
+or as an in-toto [Simple Verification Result (SVR)](https://github.com/in-toto/attestation/blob/main/spec/predicates/svr.md),
+and can optionally be signed with sigstore, SPIFFE, or a local key via the
+`--sign` flag. See [Producing Result Attestations](docs/02-ampel-attestations.md#producing-result-attestations)
+for details.
+
 ### Policy Sets
 
 Multiple policies can be specified together in a `PolicySet`. This is a handy way

--- a/docs/02-ampel-attestations.md
+++ b/docs/02-ampel-attestations.md
@@ -118,6 +118,98 @@ But when it comes to the signing identity, AMPEL does not do any assumptions. It
 up to the policy to define who can sign attestations. _Who_ in this context refers
 to a key or sigstore identity, or a mix of both.
 
+## Producing Result Attestations
+
+When AMPEL evaluates a policy, the results can themselves be captured as
+in-toto attestations. This makes them reusable as input evidence for
+downstream policies — verifying once and asserting many times.
+
+### Output Paths
+
+Result attestations can be produced through two channels:
+
+- `--attest-results` writes the attestation to a file. The path is
+  controlled with `--results-path` (defaults to `results.intoto.json`)
+  and the format with `--attest-format`.
+- `--format=attestation|vsa|svr` writes the attestation to standard
+  output in place of the default human-friendly view.
+
+The two channels are independent and can be combined: a single run can
+write a VSA to stdout and an ampel-format attestation to a file.
+
+### Result Attestation Formats
+
+AMPEL supports three result-attestation formats:
+
+| Format | Predicate Type | Description |
+|---|---|---|
+| `ampel` | `https://carabiner.dev/ampel/resultset/v0` | The full ampel ResultSet — every assertion, control and identity. Designed to be re-ingested as evidence for further policies. |
+| `vsa` | `https://slsa.dev/verification_summary/v1` | A SLSA Verification Summary Attestation. Maps the evaluation status to a VerificationResult and lifts SLSA controls to VerifiedLevels. |
+| `svr` | `https://in-toto.io/attestation/svr/v0.1` | A Simple Verification Result. Compact pass/fail summary with property labels. |
+
+The default file format is `ampel`; stdout defaults to the `tty`
+human-friendly view.
+
+### Signing Result Attestations
+
+By default, result attestations are written as raw in-toto Statements.
+Pass `--sign` to wrap the produced attestation in a signed envelope.
+The same `--sign` flag covers both output paths above.
+
+The signing backend is selected with `--signing-backend` and is
+auto-detected from the supplied flags when the explicit value is left
+empty:
+
+- `key` — auto-selected when `--signing-key` is set. Produces a DSSE
+  envelope signed with the supplied private keys (PEM PKCS#8/PKCS#1/SEC1
+  or OpenPGP, repeatable). Encrypted keys can be unlocked via the env
+  var named in `--signing-key-passphrase-env`.
+- `spiffe` — auto-selected when `--spiffe-socket` is set. Produces a
+  sigstore Bundle whose certificate chain comes from a SPIFFE-issued
+  SVID fetched from the Workload API.
+- `sigstore` — fallback when neither of the above is set. Produces a
+  sigstore Bundle via the public-good instance with an interactive
+  OIDC flow; for non-interactive CI use `--sigstore-oidc-token-file`.
+
+The full set of backend-specific flags appears under **Signing Flags**
+in `ampel verify --help`.
+
+### Output Shape
+
+The wire format of the produced attestation depends on the signer:
+
+- **Unsigned** (no `--sign`) — a bare in-toto Statement carrying the
+  selected predicate.
+- **Key backend** (`--sign` + `--signing-key`) — a DSSE envelope
+  whose payload is the base64-encoded Statement.
+- **Sigstore / SPIFFE backend** (`--sign` with sigstore or SPIFFE) — a
+  sigstore Bundle: certificate chain, DSSE envelope, and (when
+  `--signing-timestamp` is on, the default) an RFC 3161 timestamp.
+
+### Examples
+
+```shell
+# Write an ampel-format result attestation to a file (unsigned)
+ampel verify ... --attest-results --results-path=results.intoto.json
+
+# Emit a VSA to stdout
+ampel verify ... --format=vsa
+
+# Sign with a local key, file output (DSSE envelope)
+ampel verify ... \
+  --attest-results --results-path=results.intoto.json \
+  --sign --signing-key=signing.key
+
+# Sign with sigstore, VSA bundle to stdout
+ampel verify ... --format=vsa --sign
+
+# Sign with SPIFFE Workload API, SVR bundle to file
+ampel verify ... \
+  --attest-results --attest-format=svr --results-path=svr.bundle.json \
+  --sign --spiffe-socket=unix:///run/spire/sockets/api.sock \
+  --spiffe-trust-domain=prod.example.org
+```
+
 ## Attestation Tooling
 
 The AMPEL ecosystem includes tools to work with attested data. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,11 @@ contributions are welcome!
     - Collectors
     - Queries and Filters
   - Signatures and Identities
+  - Producing Result Attestations
+    - Output Paths
+    - Result Attestation Formats
+    - Signing Result Attestations
+    - Output Shape
   - Tools
     - bnd
 

--- a/internal/cmd/flaggroups.go
+++ b/internal/cmd/flaggroups.go
@@ -49,6 +49,24 @@ func groupFlags(cmd *cobra.Command, group string, names ...string) {
 	}
 }
 
+// groupFlagsByPrefix tags every persistent flag on cmd whose name starts
+// with one of the given prefixes. Used for flags registered by an
+// external library (e.g. signer's *options.SignerSet) where in-place
+// annotation at registration isn't possible.
+func groupFlagsByPrefix(cmd *cobra.Command, group string, prefixes ...string) {
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		for _, p := range prefixes {
+			if strings.HasPrefix(f.Name, p) {
+				if f.Annotations == nil {
+					f.Annotations = map[string][]string{}
+				}
+				f.Annotations[flagGroupAnnotation] = []string{group}
+				return
+			}
+		}
+	})
+}
+
 // groupedFlagUsages renders cmd's local flags bucketed under the group
 // headings registered for cmd. Mirrors pflag.FlagSet.FlagUsages output
 // per bucket so column alignment matches cobra's default rendering.

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -38,6 +38,25 @@ var (
 	hashRegex    *regexp.Regexp
 )
 
+// attestFormatFor maps a --format value to its canonical attester
+// format name. Returns ok=false for non-attestation display formats
+// (tty, html, markdown), which should still be rendered through the
+// render engine. The "attestation" alias maps to "ampel" so the
+// stdout output of --format=attestation matches what
+// --attest-format=ampel produces.
+func attestFormatFor(format string) (string, bool) {
+	switch format {
+	case "attestation":
+		return "ampel", true
+	case "vsa":
+		return "vsa", true
+	case "svr":
+		return "svr", true
+	default:
+		return "", false
+	}
+}
+
 const (
 	grpSubject      = "subject"
 	grpPolicy       = "policy"
@@ -182,7 +201,7 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().BoolVar(
-		&o.Sign, "sign", false, "sign the results attestation (requires --attest-results)",
+		&o.Sign, "sign", false, "sign the results attestation",
 	)
 	o.SignerSet.AddFlags(cmd)
 
@@ -286,10 +305,11 @@ func (o *verifyOptions) Validate() error {
 		errs = append(errs, errors.New("no attestation sources specified (collectors or files)"))
 	}
 
-	if o.Sign && !o.AttestResults {
-		errs = append(errs, errors.New("--sign requires --attest-results (nothing to sign without an attestation)"))
-	}
 	if o.Sign {
+		_, stdoutIsAttest := attestFormatFor(o.Format)
+		if !o.AttestResults && !stdoutIsAttest {
+			errs = append(errs, errors.New("--sign requires --attest-results or --format=attestation|vsa|svr (nothing to sign otherwise)"))
+		}
 		if err := o.SignerSet.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("validating signer config: %w", err))
 		}
@@ -478,21 +498,40 @@ func (opts *verifyOptions) Run() error {
 		return fmt.Errorf("running subject verification: %w", err)
 	}
 
-	if opts.AttestResults {
-		var attesterOpts []attest.FnOpt
-		if opts.Sign {
-			s, err := signer.NewSignerFromSet(opts.SignerSet)
-			if err != nil {
-				return fmt.Errorf("building signer: %w", err)
-			}
-			attesterOpts = append(attesterOpts, attest.WithSigner(s))
+	stdoutAttestFmt, stdoutIsAttest := attestFormatFor(opts.Format)
+
+	// Build the attester once. The signer (when --sign is set)
+	// applies to both the file output (--attest-results) and the
+	// stdout attestation output (--format=attestation|vsa|svr).
+	var attesterOpts []attest.FnOpt
+	if opts.Sign {
+		s, err := signer.NewSignerFromSet(opts.SignerSet)
+		if err != nil {
+			return fmt.Errorf("building signer: %w", err)
 		}
-		if err := attest.New(attesterOpts...).AttestToFile(
+		attesterOpts = append(attesterOpts, attest.WithSigner(s))
+	}
+	attester := attest.New(attesterOpts...)
+
+	if opts.AttestResults {
+		if err := attester.AttestToFile(
 			opts.ResultsAttestationPath, results,
 			attest.WithFormat(opts.AttestFormat),
 		); err != nil {
 			return fmt.Errorf("attesting results: %w", err)
 		}
+	}
+
+	if stdoutIsAttest {
+		if err := attester.AttestTo(
+			os.Stdout, results, attest.WithFormat(stdoutAttestFmt),
+		); err != nil {
+			return fmt.Errorf("rendering attestation to stdout: %w", err)
+		}
+		if results.GetStatus() == papi.StatusFAIL && opts.SetExitCode {
+			os.Exit(1)
+		}
+		return nil
 	}
 
 	eng := render.NewEngine()

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -19,7 +19,9 @@ import (
 	"github.com/carabiner-dev/policy"
 	papi "github.com/carabiner-dev/policy/api/v1"
 	"github.com/carabiner-dev/policy/options"
+	"github.com/carabiner-dev/signer"
 	"github.com/carabiner-dev/signer/key"
+	signerOpts "github.com/carabiner-dev/signer/options"
 	"github.com/fatih/color"
 	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/spf13/cobra"
@@ -76,6 +78,8 @@ type verifyOptions struct {
 	PolicyIdentityStrings []string
 	PolicyVerify          bool
 	PolicyKeyPaths        []string
+	Sign                  bool
+	SignerSet             *signerOpts.SignerSet
 }
 
 // AddFlags adds the flags
@@ -177,12 +181,22 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 		&o.AllowEmptySetChains, "allow-empty-set-chain", verifier.DefaultVerificationOptions.AllowEmptySetChains, "don't fail PolicySets when chains are empty",
 	)
 
+	cmd.PersistentFlags().BoolVar(
+		&o.Sign, "sign", false, "sign the results attestation (requires --attest-results)",
+	)
+	o.SignerSet.AddFlags(cmd)
+
 	groupFlags(cmd, grpSubject, "subject", "subject-file", "subject-hash")
 	groupFlags(cmd, grpPolicy, "policy", "pid", "policy-out", "policy-verify", "policy-key", "policy-signer", "expiration")
 	groupFlags(cmd, grpEvidence, "key", "attestation", "collector", "signer")
 	groupFlags(cmd, grpContext, "context", "context-json", "context-yaml", "context-env")
 	groupFlags(cmd, grpResults, "attest-results", "attest-format", "results-path", "format")
 	groupFlags(cmd, grpVerification, "exit-code", "workers", "allow-empty-set-chain")
+	groupFlags(cmd, grpSigning, "sign")
+	// Sweep every flag the SignerSet just registered into the
+	// Signing section. Doing it post-hoc keeps the signer library's
+	// AddFlags surface untouched.
+	groupFlagsByPrefix(cmd, grpSigning, "signing-", "sigstore-", "spiffe-")
 
 	registerFlagGroups(cmd, verifyFlagGroups...)
 	applyFlagGroupTemplate(cmd)
@@ -272,12 +286,22 @@ func (o *verifyOptions) Validate() error {
 		errs = append(errs, errors.New("no attestation sources specified (collectors or files)"))
 	}
 
+	if o.Sign && !o.AttestResults {
+		errs = append(errs, errors.New("--sign requires --attest-results (nothing to sign without an attestation)"))
+	}
+	if o.Sign {
+		if err := o.SignerSet.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("validating signer config: %w", err))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
 func addVerify(parentCmd *cobra.Command) {
 	opts := verifyOptions{
 		VerificationOptions: verifier.NewVerificationOptions(),
+		SignerSet:           signerOpts.DefaultSignerSet(),
 	}
 	evalCmd := &cobra.Command{
 		Short: "check artifacts against a policy",
@@ -455,7 +479,15 @@ func (opts *verifyOptions) Run() error {
 	}
 
 	if opts.AttestResults {
-		if err := attest.New().AttestToFile(
+		var attesterOpts []attest.FnOpt
+		if opts.Sign {
+			s, err := signer.NewSignerFromSet(opts.SignerSet)
+			if err != nil {
+				return fmt.Errorf("building signer: %w", err)
+			}
+			attesterOpts = append(attesterOpts, attest.WithSigner(s))
+		}
+		if err := attest.New(attesterOpts...).AttestToFile(
 			opts.ResultsAttestationPath, results,
 			attest.WithFormat(opts.AttestFormat),
 		); err != nil {

--- a/internal/cmd/verify_test.go
+++ b/internal/cmd/verify_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	signerOpts "github.com/carabiner-dev/signer/options"
+
+	"github.com/carabiner-dev/ampel/pkg/verifier"
+)
+
+// TestVerifyOptions_SignGate locks in the rule that --sign is valid
+// only when there is somewhere to write the produced attestation:
+// either --attest-results (file output) or --format=attestation|
+// vsa|svr (stdout output). Catches regressions of the gap where
+// --sign was wired only to --attest-results.
+func TestVerifyOptions_SignGate(t *testing.T) {
+	const wantSignSubstr = "--sign requires --attest-results"
+
+	base := func() verifyOptions {
+		o := verifyOptions{
+			VerificationOptions: verifier.NewVerificationOptions(),
+			SignerSet:           signerOpts.DefaultSignerSet(),
+			SubjectHash:         "sha256:abc123",
+			PolicyLocation:      "/tmp/policy.json",
+			Format:              "tty",
+		}
+		// Satisfy the unrelated "no attestation sources" check so
+		// Validate doesn't short-circuit before the --sign gate.
+		o.AttestationFiles = []string{"x"}
+		return o
+	}
+
+	cases := []struct {
+		name          string
+		sign          bool
+		attestResults bool
+		format        string
+		wantSignError bool
+	}{
+		{"no sign no gate", false, false, "tty", false},
+		{"sign without target", true, false, "tty", true},
+		{"sign with attest-results", true, true, "tty", false},
+		{"sign with format=attestation", true, false, "attestation", false},
+		{"sign with format=vsa", true, false, "vsa", false},
+		{"sign with format=svr", true, false, "svr", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := base()
+			o.Sign = tc.sign
+			o.AttestResults = tc.attestResults
+			o.Format = tc.format
+			err := o.Validate()
+			// Validate may surface unrelated errors (e.g. nonexistent
+			// policy path); we only care about the --sign gate
+			// message here.
+			haveSignError := err != nil && strings.Contains(err.Error(), wantSignSubstr)
+			if haveSignError != tc.wantSignError {
+				t.Errorf("haveSignError=%v want=%v; full err=%v", haveSignError, tc.wantSignError, err)
+			}
+		})
+	}
+}

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/carabiner-dev/collector/statement/intoto"
 	papi "github.com/carabiner-dev/policy/api/v1"
 	"github.com/carabiner-dev/predicates"
+	"github.com/carabiner-dev/signer"
 )
 
 // ampelVerifierID is the verifier identifier embedded in every
@@ -34,27 +35,41 @@ const ampelVerifierID = "https://carabiner.dev/ampel@v1"
 // statement carrying a predicates.ResultSet; "vsa" and "svr" route
 // through their format-specific drivers.
 //
-// The struct is a placeholder for instance-level configuration that
-// spans multiple attestation calls — signer credentials, retry
-// behavior, and so on — that will land alongside signing support.
-type ResultsAttester struct{}
-
-// New returns a ready-to-use ResultsAttester.
-func New() *ResultsAttester {
-	return &ResultsAttester{}
+// FnOpts passed to New populate the attester's defaults; the same
+// FnOpts passed to AttestTo / AttestToFile override those defaults
+// for one call. A typical CLI configures once via New (e.g. with a
+// pre-built *signer.Signer) and never overrides; library callers
+// can stay stateless and pass options per call instead.
+type ResultsAttester struct {
+	defaults attestOptions
 }
 
-// FnOpt configures a single Attest* call.
+// New returns a ResultsAttester with optional instance-level
+// defaults. Pass FnOpts here when the same configuration applies to
+// every call (typical CLI use); otherwise leave empty and pass
+// options per call.
+func New(opts ...FnOpt) *ResultsAttester {
+	a := &ResultsAttester{defaults: defaultAttestOptions()}
+	for _, fn := range opts {
+		fn(&a.defaults)
+	}
+	return a
+}
+
+// FnOpt configures a ResultsAttester. Passed to New, it sets
+// instance-wide defaults; passed to AttestTo / AttestToFile, it
+// overrides those defaults for that one call.
 type FnOpt func(*attestOptions)
 
-// attestOptions holds the per-call configuration produced by FnOpts.
+// attestOptions is the resolved configuration for one Attest* call.
 type attestOptions struct {
 	format      string
 	prettyPrint bool
+	signer      *signer.Signer
 }
 
-// defaultAttestOptions returns the baseline per-call config used when
-// no FnOpts are supplied.
+// defaultAttestOptions returns the baseline config used when no
+// FnOpts are supplied at construction or call time.
 func defaultAttestOptions() attestOptions {
 	return attestOptions{format: "ampel", prettyPrint: true}
 }
@@ -69,20 +84,38 @@ func WithFormat(format string) FnOpt {
 	}
 }
 
-// WithPrettyPrint controls JSON formatting of the produced
-// attestation. The default is true (2-space indented output);
-// pass false for a single-line compact form suitable for piping
-// or one-line-per-record archives.
+// WithPrettyPrint controls JSON formatting of the unsigned
+// attestation. The default is true (2-space indented output); pass
+// false for a single-line compact form.
+//
+// When a signer is configured via WithSigner this option is a
+// no-op — the produced *signer.SignedArtifact serializes with the
+// formatting dictated by its kind (sigstore Bundle: compact;
+// DSSE envelope: indented).
 func WithPrettyPrint(enabled bool) FnOpt {
 	return func(o *attestOptions) {
 		o.prettyPrint = enabled
 	}
 }
 
+// WithSigner configures the attester to sign the produced
+// attestation instead of writing the raw in-toto Statement. The
+// output shape becomes the *signer.SignedArtifact's canonical JSON
+// form (sigstore Bundle for the sigstore/SPIFFE backends, DSSE
+// envelope for the key backend).
+//
+// nil resets to the unsigned path — useful per-call to override an
+// instance-level default set at New time.
+func WithSigner(s *signer.Signer) FnOpt {
+	return func(o *attestOptions) {
+		o.signer = s
+	}
+}
+
 // AttestToFile writes the results attestation for results to path,
 // truncating any existing file. The file handle is closed before
-// the call returns. Format selection is per-call via WithFormat;
-// the default is "ampel".
+// the call returns. Per-call FnOpts override any defaults set at
+// New time.
 func (a *ResultsAttester) AttestToFile(path string, results papi.Results, opts ...FnOpt) error {
 	f, err := os.Create(path)
 	if err != nil {
@@ -92,11 +125,12 @@ func (a *ResultsAttester) AttestToFile(path string, results papi.Results, opts .
 	return a.AttestTo(f, results, opts...)
 }
 
-// AttestTo writes the results attestation for results to w. Splitting
-// the writer- and path-based entry points keeps the dispatch
-// testable without touching the filesystem.
+// AttestTo writes the results attestation for results to w. The
+// effective configuration is the attester's defaults overlaid with
+// any per-call FnOpts. Splitting the writer- and path-based entry
+// points keeps the dispatch testable without touching the filesystem.
 func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...FnOpt) error {
-	o := defaultAttestOptions()
+	o := a.defaults
 	for _, fn := range opts {
 		fn(&o)
 	}
@@ -110,6 +144,29 @@ func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...Fn
 	default:
 		return fmt.Errorf("unknown attestation format %q", o.format)
 	}
+}
+
+// writeStatement writes stmt to w in either its raw in-toto JSON
+// form (when no signer is configured) or as a signer.SignedArtifact
+// (sigstore Bundle or DSSE envelope, depending on the backend).
+// All format-specific writers funnel through this method so the
+// signing dispatch lives in exactly one place.
+func (a *ResultsAttester) writeStatement(w io.Writer, stmt *intoto.Statement, o attestOptions) error {
+	if o.signer == nil {
+		return writeStatementJSON(w, stmt, o.prettyPrint)
+	}
+	data, err := json.Marshal(stmt)
+	if err != nil {
+		return fmt.Errorf("serializing statement for signing: %w", err)
+	}
+	artifact, err := o.signer.SignStatement(data)
+	if err != nil {
+		return fmt.Errorf("signing statement: %w", err)
+	}
+	if _, err := artifact.WriteTo(w); err != nil {
+		return fmt.Errorf("writing signed artifact: %w", err)
+	}
+	return nil
 }
 
 // attestAmpel writes an "ampel"-format results attestation. Result
@@ -126,9 +183,9 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results, o attes
 		if err := rs.Assert(); err != nil {
 			return fmt.Errorf("asserting results set: %w", err)
 		}
-		return writeResultSet(w, rs, o)
+		return a.writeResultSet(w, rs, o)
 	case *papi.ResultSet:
-		return writeResultSet(w, r, o)
+		return a.writeResultSet(w, r, o)
 	case *papi.ResultGroup:
 		rs := &papi.ResultSet{
 			Groups:    []*papi.ResultGroup{r},
@@ -138,7 +195,7 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results, o attes
 		if err := rs.Assert(); err != nil {
 			return fmt.Errorf("asserting results set: %w", err)
 		}
-		return writeResultSet(w, rs, o)
+		return a.writeResultSet(w, rs, o)
 	default:
 		return errors.New("results are not Result, ResultSet or ResultGroup")
 	}
@@ -168,11 +225,11 @@ func writeStatementJSON(w io.Writer, stmt *intoto.Statement, pretty bool) error 
 }
 
 // writeResultSet builds an in-toto statement carrying a
-// predicates.ResultSet and writes it as JSON to w. Subjects are
-// drawn from each Result's first Chain entry when present, with
+// predicates.ResultSet and writes it via a.writeStatement. Subjects
+// are drawn from each Result's first Chain entry when present, with
 // per-digest deduplication so a ResultSet covering many results
 // against the same subject doesn't repeat it.
-func writeResultSet(w io.Writer, resultset *papi.ResultSet, o attestOptions) error {
+func (a *ResultsAttester) writeResultSet(w io.Writer, resultset *papi.ResultSet, o attestOptions) error {
 	if resultset == nil {
 		return errors.New("unable to attest results, set is nil")
 	}
@@ -208,7 +265,7 @@ func writeResultSet(w io.Writer, resultset *papi.ResultSet, o attestOptions) err
 	stmt.PredicateType = predicates.PredicateTypeResultSet
 	stmt.Predicate = &predicates.ResultSet{Parsed: resultset}
 
-	return writeStatementJSON(w, stmt, o.prettyPrint)
+	return a.writeStatement(w, stmt, o)
 }
 
 // stringifyDigests returns a canonical algo:value/algo:value... form

--- a/pkg/attest/attest_test.go
+++ b/pkg/attest/attest_test.go
@@ -5,11 +5,15 @@ package attest
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/signer"
+	"github.com/carabiner-dev/signer/key"
+	"github.com/carabiner-dev/signer/options"
 	gointoto "github.com/in-toto/attestation/go/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -206,6 +210,120 @@ func TestStringifyDigests_OrderStability(t *testing.T) {
 		if got := stringifyDigests(sub); got != first {
 			t.Errorf("iter %d: stringifyDigests = %q, want %q", i, got, first)
 		}
+	}
+}
+
+// newKeySigner returns a *signer.Signer wired to the key backend
+// using a freshly generated keypair. Suitable for exercising the
+// signed-output path without an OIDC popup or external dependency.
+func newKeySigner(t *testing.T) *signer.Signer {
+	t.Helper()
+	priv, err := key.NewGenerator().GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generating signing key: %v", err)
+	}
+	s := signer.NewSigner()
+	s.Options.Backend = options.BackendKey
+	s.Options.Keys = []key.PrivateKeyProvider{priv}
+	return s
+}
+
+// dsseEnvelope is the on-the-wire shape of a key-backend signed
+// artifact, used to assert that the signed-path output is a DSSE
+// envelope rather than a raw Statement.
+type dsseEnvelope struct {
+	PayloadType string `json:"payloadType"`
+	Payload     string `json:"payload"`
+	Signatures  []struct {
+		KeyID string `json:"keyid"`
+		Sig   string `json:"sig"`
+	} `json:"signatures"`
+}
+
+// TestAttestTo_Signed_ConstructorSigner exercises the typical CLI
+// path: signer is bound at New time and AttestTo emits a DSSE
+// envelope (key backend) carrying the in-toto Statement as payload.
+func TestAttestTo_Signed_ConstructorSigner(t *testing.T) {
+	s := newKeySigner(t)
+	rs := newResultSet(t, "deadbeef")
+
+	var buf bytes.Buffer
+	if err := New(WithSigner(s)).AttestTo(&buf, rs); err != nil {
+		t.Fatalf("AttestTo: %v", err)
+	}
+
+	var env dsseEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("output is not a DSSE envelope: %v\nbody: %s", err, buf.String())
+	}
+	if env.Payload == "" {
+		t.Fatal("envelope payload is empty")
+	}
+	if len(env.Signatures) == 0 {
+		t.Fatal("envelope has no signatures")
+	}
+
+	// The base64-decoded payload should be the in-toto Statement
+	// carrying the ampel resultset predicateType.
+	decoded, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatalf("decoding payload: %v", err)
+	}
+	var stmt statementShape
+	if err := json.Unmarshal(decoded, &stmt); err != nil {
+		t.Fatalf("payload is not a Statement: %v\npayload: %s", err, decoded)
+	}
+	if stmt.PredicateType != "https://carabiner.dev/ampel/resultset/v0" {
+		t.Errorf("payload predicateType = %q, want ampel resultset", stmt.PredicateType)
+	}
+}
+
+// TestAttestTo_Signed_PerCallOverride exercises the library-caller
+// path: attester is constructed with no signer, but a per-call
+// WithSigner enables signing for one AttestTo invocation.
+func TestAttestTo_Signed_PerCallOverride(t *testing.T) {
+	s := newKeySigner(t)
+	rs := newResultSet(t, "deadbeef")
+
+	a := New() // no constructor signer
+	var buf bytes.Buffer
+	if err := a.AttestTo(&buf, rs, WithSigner(s)); err != nil {
+		t.Fatalf("AttestTo: %v", err)
+	}
+	var env dsseEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("output is not a DSSE envelope: %v\nbody: %s", err, buf.String())
+	}
+	if env.Payload == "" || len(env.Signatures) == 0 {
+		t.Errorf("envelope missing payload or signatures: %+v", env)
+	}
+}
+
+// TestAttestTo_Signed_PerCallNilOverride confirms that passing
+// WithSigner(nil) at call time disables signing even when a signer
+// was bound at New time. Useful for callers that want to selectively
+// emit unsigned attestations from a signing-default attester.
+func TestAttestTo_Signed_PerCallNilOverride(t *testing.T) {
+	s := newKeySigner(t)
+	rs := newResultSet(t, "deadbeef")
+
+	a := New(WithSigner(s))
+	var buf bytes.Buffer
+	if err := a.AttestTo(&buf, rs, WithSigner(nil)); err != nil {
+		t.Fatalf("AttestTo: %v", err)
+	}
+	// Output is the raw in-toto Statement, not a DSSE envelope.
+	var stmt statementShape
+	if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
+		t.Fatalf("output should be a Statement: %v", err)
+	}
+	if stmt.PredicateType != "https://carabiner.dev/ampel/resultset/v0" {
+		t.Errorf("predicateType = %q, want ampel resultset", stmt.PredicateType)
+	}
+	// Sanity: ensure no DSSE shape leaked through.
+	var env dsseEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err == nil && env.Payload != "" {
+		t.Errorf("expected unsigned output; got DSSE-shaped payload field")
 	}
 }
 

--- a/pkg/attest/svr.go
+++ b/pkg/attest/svr.go
@@ -67,7 +67,7 @@ func (a *ResultsAttester) writeSVRFromResultSet(w io.Writer, set *papi.ResultSet
 		}
 	}
 
-	return writeSVRStatement(w, set.GetSubject(), svrData, o)
+	return a.writeSVRStatement(w, set.GetSubject(), svrData, o)
 }
 
 func (a *ResultsAttester) writeSVRFromResult(w io.Writer, result *papi.Result, o attestOptions) error {
@@ -95,14 +95,15 @@ func (a *ResultsAttester) writeSVRFromResult(w io.Writer, result *papi.Result, o
 		}
 	}
 
-	return writeSVRStatement(w, result.GetSubject(), svrData, o)
+	return a.writeSVRStatement(w, result.GetSubject(), svrData, o)
 }
 
 // writeSVRStatement wraps the populated SVR predicate in an in-toto
-// statement and writes it as JSON to w. The protojson Any wrapper
+// statement and routes it through a.writeStatement so signing and
+// pretty-print dispatch stay centralized. The protojson Any wrapper
 // injects an "@type" field into the policy block; strip it so the
 // SVR output stays clean.
-func writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.SimpleVerificationResult, o attestOptions) error {
+func (a *ResultsAttester) writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.SimpleVerificationResult, o attestOptions) error {
 	svrJsonData, err := protojson.Marshal(att)
 	if err != nil {
 		return fmt.Errorf("marshaling svr: %w", err)
@@ -137,7 +138,7 @@ func writeSVRStatement(w io.Writer, subject attestation.Subject, att *svrpred.Si
 		}),
 	)
 
-	return writeStatementJSON(w, statement, o.prettyPrint)
+	return a.writeStatement(w, statement, o)
 }
 
 func svrPolicyResourceDescriptor(origin attestation.Subject) (*anypb.Any, error) {

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -124,7 +124,7 @@ func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet
 	if verifiedSomeSlsa {
 		vsaData.SlsaVersion = slsaVersion
 	}
-	return writeVSAStatement(w, set.GetSubject(), vsaData, o)
+	return a.writeVSAStatement(w, set.GetSubject(), vsaData, o)
 }
 
 func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result, o attestOptions) error {
@@ -176,12 +176,13 @@ func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result, o
 	if verifiedSomeSlsa {
 		vsaData.SlsaVersion = slsaVersion
 	}
-	return writeVSAStatement(w, result.GetSubject(), vsaData, o)
+	return a.writeVSAStatement(w, result.GetSubject(), vsaData, o)
 }
 
 // writeVSAStatement wraps the populated VSA predicate in an in-toto
-// statement and writes it as JSON to w.
-func writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.VerificationSummary, o attestOptions) error {
+// statement and routes it through a.writeStatement so signing and
+// pretty-print dispatch stay centralized.
+func (a *ResultsAttester) writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.VerificationSummary, o attestOptions) error {
 	vsaJsonData, err := protojson.Marshal(att)
 	if err != nil {
 		return fmt.Errorf("marshaling vsa: %w", err)
@@ -202,7 +203,7 @@ func writeVSAStatement(w io.Writer, subject attestation.Subject, att *v1.Verific
 		}),
 	)
 
-	return writeStatementJSON(w, statement, o.prettyPrint)
+	return a.writeStatement(w, statement, o)
 }
 
 // resultStringToSLSAResult translates ampel evaluation status strings


### PR DESCRIPTION
This PR introduces the first implementation of the results attestation signing using the v0.5 prerelease of the carabiner signer. 

All attesting and signing operations in the ampel CLI are now delegated to the new attester package. Clients using ampel as a library can opt to use the attester and optionally sign the attestations their way.

By pulling the v0.5 prerelease, AMPEL gains the capability to sign not only with sigstore but also with keys and SPIFFE SVIDs.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>