### PR TITLE
Add ErrOnMissingAttestations eval option

### DIFF
--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -1095,6 +1095,9 @@ func (di *defaultIplementation) VerifySubject(
 				},
 			}
 			skipEval = true
+			if opts.ErrOnMissingAttestations {
+				errs = append(errs, fmt.Errorf("tenet #%d on subject %s: %w", i, subjectToString(subject), ErrMissingAttestations))
+			}
 		}
 
 		if !skipEval {

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -4,6 +4,7 @@
 package verifier
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -633,4 +634,68 @@ func TestFilterAttestationsSkipsNonAdmitted(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, preds, 2, "only admitted envelopes should produce predicates")
+}
+
+// TestVerifySubjectErrOnMissingAttestations covers the ErrOnMissingAttestations
+// option: when off (default) a tenet that requires predicates but receives none
+// produces a failed EvalResult with the sentinel in Error.Message and no
+// top-level error; when on, the same condition additionally returns the
+// sentinel as a Go error so callers can detect it via errors.Is.
+func TestVerifySubjectErrOnMissingAttestations(t *testing.T) {
+	t.Parallel()
+
+	policy := &papi.Policy{
+		Id: "needs-predicate",
+		Tenets: []*papi.Tenet{{
+			Id:   "t1",
+			Code: "true",
+			Predicates: &papi.PredicateSpec{
+				Types: []string{"https://example.com/predicate"},
+			},
+		}},
+	}
+	subject := &gointoto.ResourceDescriptor{
+		Name:   "test-subject",
+		Digest: map[string]string{"sha256": "aaaa0000000000000000000000000000000000000000000000000000000000aa"},
+	}
+	evaluators := map[class.Class]evaluator.Evaluator{}
+
+	for _, tc := range []struct {
+		name             string
+		errOnMissing     bool
+		wantErrIsMissing bool
+	}{
+		{"off-default", false, false},
+		{"on", true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			di := &defaultIplementation{}
+			opts := &VerificationOptions{
+				EvaluatorOptions:         eoptions.Default,
+				DefaultEvaluator:         DefaultVerificationOptions.DefaultEvaluator,
+				ErrOnMissingAttestations: tc.errOnMissing,
+			}
+
+			result, err := di.VerifySubject(
+				context.Background(), opts, evaluators, policy,
+				map[string]any{}, subject, []attestation.Predicate{},
+			)
+
+			if tc.wantErrIsMissing {
+				require.ErrorIs(t, err, ErrMissingAttestations)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Result is populated identically in both cases — the EvalResult
+			// always carries the sentinel string so consumers retain detail.
+			require.NotNil(t, result)
+			require.Len(t, result.EvalResults, 1)
+			require.Equal(t, papi.StatusFAIL, result.EvalResults[0].GetStatus())
+			require.NotNil(t, result.EvalResults[0].GetError())
+			require.Equal(t, ErrMissingAttestations.Error(), result.EvalResults[0].GetError().GetMessage())
+		})
+	}
 }

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -87,6 +87,19 @@ type VerificationOptions struct {
 	// is known. This makes evaluation faster but also means that some policies in
 	// the block may not be evaluated (and missing from the group's resultSet)
 	LazyBlockEval bool
+
+	// ErrOnMissingAttestations causes the verifier to return ErrMissingAttestations
+	// (as a Go error wrapped via errors.Join) the moment any tenet cannot be
+	// evaluated due to missing attestations. The EvalResult is still populated
+	// in Error.Message so callers retain diagnostic detail.
+	//
+	// The default (false) causes the missing attestations error to surface
+	// only as a failed EvalResult, not as a top-level Go error.
+	//
+	// Intended for programmatic callers that want to detect this condition
+	// distinctly from policy violations or signature failures (for example,
+	// to drive a wait+retry loop while attestations land).
+	ErrOnMissingAttestations bool
 }
 
 // Validate checks the options set


### PR DESCRIPTION
This commit adds ErrOnMissingAttestations to the eval options to cause the verifier to throw a go error when it is missing attestations required by the policy tenets.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>