### PR TITLE
Add support for eval results publishers

### DIFF
--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -91,6 +91,7 @@ type verifyOptions struct {
 	ContextYAML           string
 	ContextStringVals     []string
 	Collectors            []string
+	Publishers            []string
 	Subject               string
 	SubjectFile           string
 	SubjectHash           string
@@ -158,6 +159,10 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringSliceVarP(
 		&o.Collectors, "collector", "c", []string{}, "attestation collectors to initialize",
+	)
+
+	cmd.PersistentFlags().StringSliceVar(
+		&o.Publishers, "publish", []string{}, "publishers to emit evaluation results to, as \"driver:spec\"",
 	)
 
 	cmd.PersistentFlags().BoolVar(
@@ -434,6 +439,7 @@ func (opts *verifyOptions) Run() error {
 
 	ampel, err := verifier.New(
 		verifier.WithCollectorInits(opts.Collectors),
+		verifier.WithPublisherInits(opts.Publishers),
 		verifier.WithKeys(opts.Keys...),
 	)
 	if err != nil {

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -214,7 +214,7 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	groupFlags(cmd, grpPolicy, "policy", "pid", "policy-out", "policy-verify", "policy-key", "policy-signer", "expiration")
 	groupFlags(cmd, grpEvidence, "key", "attestation", "collector", "signer")
 	groupFlags(cmd, grpContext, "context", "context-json", "context-yaml", "context-env")
-	groupFlags(cmd, grpResults, "attest-results", "attest-format", "results-path", "format")
+	groupFlags(cmd, grpResults, "attest-results", "attest-format", "results-path", "format", "publish")
 	groupFlags(cmd, grpVerification, "exit-code", "workers", "allow-empty-set-chain")
 	groupFlags(cmd, grpSigning, "sign")
 	// Sweep every flag the SignerSet just registered into the

--- a/pkg/publisher/drivers/drivers.go
+++ b/pkg/publisher/drivers/drivers.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package drivers wires the built-in emitter drivers into the publisher
+// registry. It is kept separate from the publisher package so that the emitter
+// packages can import the publisher interface without creating an import cycle
+// (mirroring how the collector keeps its repository drivers separate).
+package drivers
+
+import (
+	"errors"
+
+	"github.com/carabiner-dev/ampel/pkg/publisher"
+	"github.com/carabiner-dev/ampel/pkg/publisher/webhook"
+)
+
+// LoadDefaultEmitterTypes loads the default emitter types into the registry to
+// get them ready for instantiation. It is idempotent: types that are already
+// registered are skipped.
+func LoadDefaultEmitterTypes() error {
+	errs := []error{}
+	for t, factory := range map[string]publisher.EmitterFactory{
+		webhook.TypeMoniker: webhook.Build,
+	} {
+		if err := publisher.RegisterEmitterType(t, factory); err != nil {
+			if !errors.Is(err, publisher.ErrTypeAlreadyRegistered) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package publisher defines the interface and registry for the AMPEL results
+// publishers. A publisher emits the results of a policy evaluation to an
+// external system: a webhook, a gRPC API, an eventing system, etc.
+// For now, publishing is best effort: The AMPEL verifier calls the configured
+// publishers once an evaluation completes but never queues, retries or fails
+// an evaluation because a publisher returned an error. Any drivers that need
+// a retry mechanism implement it themselves.
+//
+// Publishers are pluggable like other ampel subsystems. Each driver registers a
+// builder under a driver id and is selected through an initstring of the form
+// "driver:spec". The scheme picks the driver from the registry; the spec is
+// interpreted into the configuration struct passed to the driver's Init method.
+package publisher
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Publisher is the interface implemented by all publisher drivers.
+type Publisher interface {
+	// Init configures the driver. The configuration struct is built by the
+	// registry from the spec portion of the publisher's initstring.
+	Init(*structpb.Struct) error
+
+	// Publish emits the evaluation results. It is called once per evaluation
+	// with the results of the verified policy material. The papi.Results
+	// interface is satisfied by all of the material kinds the verifier can
+	// produce (*papi.Result, *papi.ResultGroup and *papi.ResultSet). Publish is
+	// best-effort: a returned error is logged by the verifier but never fails
+	// the evaluation.
+	Publish(context.Context, papi.Results, ...PublishOpt) error
+}
+
+// BuilderFunc returns a new, unconfigured instance of a driver.
+type BuilderFunc func() Publisher
+
+// PublishOpt is a functional option modifying a single Publish call.
+type PublishOpt func(*PublishOptions)
+
+// PublishOptions carries cross-driver options for a Publish call. It is
+// currently empty but reserved so the Publish signature is stable as options
+// are added.
+type PublishOptions struct{}
+
+var (
+	registryMtx sync.RWMutex
+	registry    = map[string]BuilderFunc{}
+)
+
+// Register adds a driver builder to the registry under its driver id. It is
+// meant to be called from a driver package's init() function.
+func Register(driver string, fn BuilderFunc) {
+	registryMtx.Lock()
+	defer registryMtx.Unlock()
+	registry[driver] = fn
+}
+
+// New builds and initializes a single publisher from an initstring of the form
+// "driver:spec". The scheme (everything before the first colon) selects the
+// driver from the registry and the spec is interpreted into the configuration
+// struct passed to the driver's Init method.
+func New(initString string) (Publisher, error) {
+	driver, spec, ok := strings.Cut(initString, ":")
+	if !ok || driver == "" {
+		return nil, fmt.Errorf("invalid publisher initstring %q (expected \"driver:spec\")", initString)
+	}
+
+	registryMtx.RLock()
+	build, ok := registry[driver]
+	registryMtx.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("no publisher driver registered for %q", driver)
+	}
+
+	cfg, err := specToStruct(spec)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q publisher spec: %w", driver, err)
+	}
+
+	p := build()
+	if err := p.Init(cfg); err != nil {
+		return nil, fmt.Errorf("initializing %q publisher: %w", driver, err)
+	}
+	return p, nil
+}
+
+// NewSet builds a list of publishers from a list of initstrings. It fails on
+// the first initstring that cannot be parsed or initialized.
+func NewSet(initStrings []string) ([]Publisher, error) {
+	pubs := make([]Publisher, 0, len(initStrings))
+	for _, s := range initStrings {
+		p, err := New(s)
+		if err != nil {
+			return nil, err
+		}
+		pubs = append(pubs, p)
+	}
+	return pubs, nil
+}
+
+// specToStruct interprets the spec portion of a publisher initstring into the
+// configuration struct handed to a driver's Init method. The spec is parsed as
+// URL query syntax (key=value&key=value). As a convenience, a non-empty spec
+// that contains no "=" is stored whole under the "spec" key so simple drivers
+// can take a bare value (eg "webhook:https://example.com/hook").
+func specToStruct(spec string) (*structpb.Struct, error) {
+	fields := map[string]any{}
+	switch {
+	case spec == "":
+		// No configuration.
+	case !strings.Contains(spec, "="):
+		fields["spec"] = spec
+	default:
+		values, err := url.ParseQuery(spec)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range values {
+			if len(v) == 1 {
+				fields[k] = v[0]
+				continue
+			}
+			anys := make([]any, len(v))
+			for i := range v {
+				anys[i] = v[i]
+			}
+			fields[k] = anys
+		}
+	}
+	return structpb.NewStruct(fields)
+}

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -1,141 +1,160 @@
 // SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
-// Package publisher defines the interface and registry for the AMPEL results
-// publishers. A publisher emits the results of a policy evaluation to an
-// external system: a webhook, a gRPC API, an eventing system, etc.
-// For now, publishing is best effort: The AMPEL verifier calls the configured
-// publishers once an evaluation completes but never queues, retries or fails
-// an evaluation because a publisher returned an error. Any drivers that need
-// a retry mechanism implement it themselves.
+// Package publisher emits the results of an AMPEL policy evaluation to external
+// systems. The Publisher object aggregates a set of configured emitters (the
+// drivers: a webhook, a gRPC API, an eventing system, etc) and fans a single
+// PublishResults call out to all of them.
 //
-// Publishers are pluggable like other ampel subsystems. Each driver registers a
-// builder under a driver id and is selected through an initstring of the form
-// "driver:spec". The scheme picks the driver from the registry; the spec is
-// interpreted into the configuration struct passed to the driver's Init method.
+// For now, publishing is best effort: PublishResults invokes every emitter but
+// never queues, retries or fails because an emitter returned an error. Any
+// emitter that needs a retry mechanism implements it itself.
+//
+// Emitters are pluggable and follow the same registration model as the
+// collector's repository drivers: each emitter registers a factory under a
+// moniker and is selected through an initstring of the form "moniker:spec". The
+// factory receives the spec (everything after the first colon) and parses it
+// however the emitter sees fit. The built-in emitters are wired into the
+// registry by the publisher/drivers package's LoadDefaultEmitterTypes.
 package publisher
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 	"sync"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// Publisher is the interface implemented by all publisher drivers.
-type Publisher interface {
-	// Init configures the driver. The configuration struct is built by the
-	// registry from the spec portion of the publisher's initstring.
-	Init(*structpb.Struct) error
-
-	// Publish emits the evaluation results. It is called once per evaluation
-	// with the results of the verified policy material. The papi.Results
-	// interface is satisfied by all of the material kinds the verifier can
-	// produce (*papi.Result, *papi.ResultGroup and *papi.ResultSet). Publish is
-	// best-effort: a returned error is logged by the verifier but never fails
-	// the evaluation.
-	Publish(context.Context, papi.Results, ...PublishOpt) error
+// Emitter is the interface implemented by all publisher drivers.
+type Emitter interface {
+	// Emit sends the evaluation results to the emitter's destination. It is
+	// called once per evaluation with the results of the verified policy
+	// material. The papi.Results interface is satisfied by all of the material
+	// kinds the verifier can produce (*papi.Result, *papi.ResultGroup and
+	// *papi.ResultSet). Emit is best-effort: a returned error is logged by the
+	// Publisher but never fails the evaluation.
+	Emit(context.Context, papi.Results, ...EmitOpt) error
 }
 
-// BuilderFunc returns a new, unconfigured instance of a driver.
-type BuilderFunc func() Publisher
+// EmitOpt is a functional option modifying a single Emit call.
+type EmitOpt func(*EmitOptions)
 
-// PublishOpt is a functional option modifying a single Publish call.
-type PublishOpt func(*PublishOptions)
+// EmitOptions carries cross-emitter options for an Emit call. It is currently
+// empty but reserved so the Emit signature is stable as options are added.
+type EmitOptions struct{}
 
-// PublishOptions carries cross-driver options for a Publish call. It is
-// currently empty but reserved so the Publish signature is stable as options
-// are added.
-type PublishOptions struct{}
+// EmitterFactory builds a configured emitter from the spec portion of an
+// initstring (everything after the "moniker:" prefix). Each emitter parses its
+// own spec.
+type EmitterFactory func(string) (Emitter, error)
 
 var (
-	registryMtx sync.RWMutex
-	registry    = map[string]BuilderFunc{}
+	emitterTypes             = map[string]EmitterFactory{}
+	ErrTypeAlreadyRegistered = errors.New("emitter type already registered")
+	mtx                      sync.RWMutex
 )
 
-// Register adds a driver builder to the registry under its driver id. It is
-// meant to be called from a driver package's init() function.
-func Register(driver string, fn BuilderFunc) {
-	registryMtx.Lock()
-	defer registryMtx.Unlock()
-	registry[driver] = fn
+// EmitterFromString builds an emitter from an initstring of the form
+// "moniker:spec". The string is split on the first colon: the first half
+// selects the emitter factory from the registry and the remainder is handed to
+// it verbatim.
+func EmitterFromString(init string) (Emitter, error) {
+	t, init, _ := strings.Cut(init, ":")
+	mtx.RLock()
+	b, ok := emitterTypes[t]
+	mtx.RUnlock()
+	if ok {
+		return b(init)
+	}
+	return nil, fmt.Errorf("emitter type unknown: %q", t)
 }
 
-// New builds and initializes a single publisher from an initstring of the form
-// "driver:spec". The scheme (everything before the first colon) selects the
-// driver from the registry and the spec is interpreted into the configuration
-// struct passed to the driver's Init method.
-func New(initString string) (Publisher, error) {
-	driver, spec, ok := strings.Cut(initString, ":")
-	if !ok || driver == "" {
-		return nil, fmt.Errorf("invalid publisher initstring %q (expected \"driver:spec\")", initString)
+// RegisterEmitterType registers a new type of emitter.
+func RegisterEmitterType(moniker string, factory EmitterFactory) error {
+	mtx.Lock()
+	defer mtx.Unlock()
+	if _, ok := emitterTypes[moniker]; ok {
+		return ErrTypeAlreadyRegistered
 	}
-
-	registryMtx.RLock()
-	build, ok := registry[driver]
-	registryMtx.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("no publisher driver registered for %q", driver)
-	}
-
-	cfg, err := specToStruct(spec)
-	if err != nil {
-		return nil, fmt.Errorf("parsing %q publisher spec: %w", driver, err)
-	}
-
-	p := build()
-	if err := p.Init(cfg); err != nil {
-		return nil, fmt.Errorf("initializing %q publisher: %w", driver, err)
-	}
-	return p, nil
+	emitterTypes[moniker] = factory
+	return nil
 }
 
-// NewSet builds a list of publishers from a list of initstrings. It fails on
-// the first initstring that cannot be parsed or initialized.
-func NewSet(initStrings []string) ([]Publisher, error) {
-	pubs := make([]Publisher, 0, len(initStrings))
-	for _, s := range initStrings {
-		p, err := New(s)
+// UnregisterEmitterType removes an emitter type from the registry.
+func UnregisterEmitterType(moniker string) {
+	mtx.Lock()
+	delete(emitterTypes, moniker)
+	mtx.Unlock()
+}
+
+// Publisher fans an evaluation's results out to a set of configured emitters.
+type Publisher struct {
+	Emitters []Emitter
+
+	// inits holds the emitter initstrings queued via AddEmitterInit, built into
+	// Emitters by Build once the required emitter types are registered.
+	inits []string
+
+	// loadDefaults reports whether the default emitter types should be
+	// registered before Build runs. It defaults to true.
+	loadDefaults bool
+}
+
+// New returns an empty Publisher with default emitter loading enabled.
+func New() *Publisher {
+	return &Publisher{loadDefaults: true}
+}
+
+// AddEmitter adds already-built emitters to the publisher.
+func (p *Publisher) AddEmitter(emitters ...Emitter) {
+	p.Emitters = append(p.Emitters, emitters...)
+}
+
+// AddEmitterInit queues an emitter initstring ("moniker:spec"). The emitter is
+// constructed when Build is called, after the required types are registered.
+func (p *Publisher) AddEmitterInit(inits ...string) {
+	p.inits = append(p.inits, inits...)
+}
+
+// SetLoadDefaults controls whether Build expects the default emitter types to
+// be registered. It is enabled by default.
+func (p *Publisher) SetLoadDefaults(load bool) { p.loadDefaults = load }
+
+// LoadsDefaults reports whether the default emitter types should be registered
+// before the queued emitters are built.
+func (p *Publisher) LoadsDefaults() bool { return p.loadDefaults }
+
+// Build constructs the queued emitter initstrings into emitters. It must be
+// called after the required emitter types are registered (see the
+// publisher/drivers package's LoadDefaultEmitterTypes).
+func (p *Publisher) Build() error {
+	for _, init := range p.inits {
+		e, err := EmitterFromString(init)
 		if err != nil {
-			return nil, err
+			return fmt.Errorf("building emitter %q: %w", init, err)
 		}
-		pubs = append(pubs, p)
+		p.Emitters = append(p.Emitters, e)
 	}
-	return pubs, nil
+	p.inits = nil
+	return nil
 }
 
-// specToStruct interprets the spec portion of a publisher initstring into the
-// configuration struct handed to a driver's Init method. The spec is parsed as
-// URL query syntax (key=value&key=value). As a convenience, a non-empty spec
-// that contains no "=" is stored whole under the "spec" key so simple drivers
-// can take a bare value (eg "webhook:https://example.com/hook").
-func specToStruct(spec string) (*structpb.Struct, error) {
-	fields := map[string]any{}
-	switch {
-	case spec == "":
-		// No configuration.
-	case !strings.Contains(spec, "="):
-		fields["spec"] = spec
-	default:
-		values, err := url.ParseQuery(spec)
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range values {
-			if len(v) == 1 {
-				fields[k] = v[0]
-				continue
-			}
-			anys := make([]any, len(v))
-			for i := range v {
-				anys[i] = v[i]
-			}
-			fields[k] = anys
+// PublishResults emits the results through all configured emitters and returns
+// the joined emitter errors. Every emitter is always invoked; a failing one
+// does not stop the others. The verifier treats publishing as best-effort and
+// ignores the returned error.
+func (p *Publisher) PublishResults(ctx context.Context, results papi.Results) error {
+	if p == nil || results == nil {
+		return nil
+	}
+	errs := []error{}
+	for _, e := range p.Emitters {
+		if err := e.Emit(ctx, results); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	return structpb.NewStruct(fields)
+	return errors.Join(errs...)
 }

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -66,6 +66,7 @@ func TestNew(t *testing.T) {
 		{name: "unknown-driver", init: "does-not-exist:x", mustErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			p, err := New(tc.init)
 			if tc.mustErr {
 				require.Error(t, err)

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -5,88 +5,133 @@ package publisher
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// capture is a minimal Publisher used to assert registry/initstring behavior.
+// capture is a minimal Emitter that records what it was given and can be made
+// to fail on demand.
 type capture struct {
-	cfg       *structpb.Struct
-	published papi.Results
+	emitted papi.Results
+	err     error
 }
 
-func (c *capture) Init(cfg *structpb.Struct) error { c.cfg = cfg; return nil }
-
-func (c *capture) Publish(_ context.Context, rs papi.Results, _ ...PublishOpt) error {
-	c.published = rs
-	return nil
+func (c *capture) Emit(_ context.Context, r papi.Results, _ ...EmitOpt) error {
+	c.emitted = r
+	return c.err
 }
 
-func TestNew(t *testing.T) {
+func TestEmitterFromString(t *testing.T) {
 	t.Parallel()
-	last := &capture{}
-	Register("test-capture", func() Publisher { last = &capture{}; return last })
+	var gotSpec string
+	require.NoError(t, RegisterEmitterType("test-from-string", func(spec string) (Emitter, error) {
+		gotSpec = spec
+		return &capture{}, nil
+	}))
+	t.Cleanup(func() { UnregisterEmitterType("test-from-string") })
 
 	for _, tc := range []struct {
-		name      string
-		init      string
-		mustErr   bool
-		assertCfg func(*testing.T, *structpb.Struct)
+		name     string
+		init     string
+		mustErr  bool
+		wantSpec string
 	}{
+		{name: "no-spec", init: "test-from-string:", wantSpec: ""},
+		{name: "plain-uri", init: "test-from-string:https://example.com/hook", wantSpec: "https://example.com/hook"},
 		{
-			name: "no-spec",
-			init: "test-capture:",
-			assertCfg: func(t *testing.T, s *structpb.Struct) {
-				t.Helper()
-				require.Empty(t, s.GetFields())
-			},
+			// The spec reaches the factory verbatim: a query string must
+			// survive, never split into key=value config.
+			name:     "uri-with-query",
+			init:     "test-from-string:https://host/hook?token=abc",
+			wantSpec: "https://host/hook?token=abc",
 		},
-		{
-			name: "bare-spec-under-spec-key",
-			init: "test-capture:https://example.com/hook",
-			assertCfg: func(t *testing.T, s *structpb.Struct) {
-				t.Helper()
-				require.Equal(t, "https://example.com/hook", s.GetFields()["spec"].GetStringValue())
-			},
-		},
-		{
-			name: "query-spec",
-			init: "test-capture:url=https://example.com&timeout=5s",
-			assertCfg: func(t *testing.T, s *structpb.Struct) {
-				t.Helper()
-				require.Equal(t, "https://example.com", s.GetFields()["url"].GetStringValue())
-				require.Equal(t, "5s", s.GetFields()["timeout"].GetStringValue())
-			},
-		},
-		{name: "no-scheme", init: "no-colon", mustErr: true},
-		{name: "empty-driver", init: ":spec", mustErr: true},
-		{name: "unknown-driver", init: "does-not-exist:x", mustErr: true},
+		{name: "no-colon", init: "no-colon", mustErr: true},
+		{name: "empty-moniker", init: ":https://example.com", mustErr: true},
+		{name: "unknown-moniker", init: "does-not-exist:https://example.com", mustErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			p, err := New(tc.init)
+			e, err := EmitterFromString(tc.init)
 			if tc.mustErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.NotNil(t, p)
-			tc.assertCfg(t, last.cfg)
+			require.NotNil(t, e)
+			require.Equal(t, tc.wantSpec, gotSpec)
 		})
 	}
 }
 
-func TestNewSet(t *testing.T) {
+func TestRegisterEmitterType(t *testing.T) {
 	t.Parallel()
-	Register("test-set", func() Publisher { return &capture{} })
+	factory := func(string) (Emitter, error) { return &capture{}, nil }
+	require.NoError(t, RegisterEmitterType("test-register", factory))
+	t.Cleanup(func() { UnregisterEmitterType("test-register") })
 
-	pubs, err := NewSet([]string{"test-set:a=1", "test-set:b=2"})
-	require.NoError(t, err)
-	require.Len(t, pubs, 2)
+	// A second registration of the same moniker is rejected.
+	require.ErrorIs(t, RegisterEmitterType("test-register", factory), ErrTypeAlreadyRegistered)
 
-	_, err = NewSet([]string{"test-set:a=1", "bad-driver:x"})
-	require.Error(t, err)
+	// After unregistering, it can be registered again.
+	UnregisterEmitterType("test-register")
+	require.NoError(t, RegisterEmitterType("test-register", factory))
+}
+
+func TestPublisherBuild(t *testing.T) {
+	t.Parallel()
+	var gotSpec string
+	require.NoError(t, RegisterEmitterType("test-build", func(spec string) (Emitter, error) {
+		gotSpec = spec
+		return &capture{}, nil
+	}))
+	t.Cleanup(func() { UnregisterEmitterType("test-build") })
+
+	p := New()
+	p.AddEmitterInit("test-build:https://host/x?token=abc")
+	require.NoError(t, p.Build())
+	require.Len(t, p.Emitters, 1)
+	require.Equal(t, "https://host/x?token=abc", gotSpec)
+
+	// The init queue is consumed: a second Build adds nothing.
+	require.NoError(t, p.Build())
+	require.Len(t, p.Emitters, 1)
+}
+
+func TestPublisherBuildUnknownType(t *testing.T) {
+	t.Parallel()
+	p := New()
+	p.AddEmitterInit("does-not-exist:spec")
+	require.Error(t, p.Build())
+}
+
+func TestPublishResults(t *testing.T) {
+	t.Parallel()
+	good := &capture{}
+	bad := &capture{err: errors.New("boom")}
+	p := New()
+	p.AddEmitter(good, bad)
+
+	rs := &papi.ResultSet{Status: papi.StatusPASS}
+	err := p.PublishResults(context.Background(), rs)
+	require.ErrorContains(t, err, "boom")
+	// Every emitter is invoked even though one failed.
+	require.NotNil(t, good.emitted)
+	require.NotNil(t, bad.emitted)
+}
+
+func TestPublishResultsNil(t *testing.T) {
+	t.Parallel()
+	p := New()
+	p.AddEmitter(&capture{})
+	require.NoError(t, p.PublishResults(context.Background(), nil))
+}
+
+func TestLoadsDefaults(t *testing.T) {
+	t.Parallel()
+	p := New()
+	require.True(t, p.LoadsDefaults())
+	p.SetLoadDefaults(false)
+	require.False(t, p.LoadsDefaults())
 }

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package publisher
+
+import (
+	"context"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// capture is a minimal Publisher used to assert registry/initstring behavior.
+type capture struct {
+	cfg       *structpb.Struct
+	published papi.Results
+}
+
+func (c *capture) Init(cfg *structpb.Struct) error { c.cfg = cfg; return nil }
+
+func (c *capture) Publish(_ context.Context, rs papi.Results, _ ...PublishOpt) error {
+	c.published = rs
+	return nil
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	last := &capture{}
+	Register("test-capture", func() Publisher { last = &capture{}; return last })
+
+	for _, tc := range []struct {
+		name      string
+		init      string
+		mustErr   bool
+		assertCfg func(*testing.T, *structpb.Struct)
+	}{
+		{
+			name: "no-spec",
+			init: "test-capture:",
+			assertCfg: func(t *testing.T, s *structpb.Struct) {
+				t.Helper()
+				require.Empty(t, s.GetFields())
+			},
+		},
+		{
+			name: "bare-spec-under-spec-key",
+			init: "test-capture:https://example.com/hook",
+			assertCfg: func(t *testing.T, s *structpb.Struct) {
+				t.Helper()
+				require.Equal(t, "https://example.com/hook", s.GetFields()["spec"].GetStringValue())
+			},
+		},
+		{
+			name: "query-spec",
+			init: "test-capture:url=https://example.com&timeout=5s",
+			assertCfg: func(t *testing.T, s *structpb.Struct) {
+				t.Helper()
+				require.Equal(t, "https://example.com", s.GetFields()["url"].GetStringValue())
+				require.Equal(t, "5s", s.GetFields()["timeout"].GetStringValue())
+			},
+		},
+		{name: "no-scheme", init: "no-colon", mustErr: true},
+		{name: "empty-driver", init: ":spec", mustErr: true},
+		{name: "unknown-driver", init: "does-not-exist:x", mustErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(tc.init)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, p)
+			tc.assertCfg(t, last.cfg)
+		})
+	}
+}
+
+func TestNewSet(t *testing.T) {
+	t.Parallel()
+	Register("test-set", func() Publisher { return &capture{} })
+
+	pubs, err := NewSet([]string{"test-set:a=1", "test-set:b=2"})
+	require.NoError(t, err)
+	require.Len(t, pubs, 2)
+
+	_, err = NewSet([]string{"test-set:a=1", "bad-driver:x"})
+	require.Error(t, err)
+}

--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -15,6 +15,7 @@ import (
 // capture is a minimal Emitter that records what it was given and can be made
 // to fail on demand.
 type capture struct {
+	spec    string
 	emitted papi.Results
 	err     error
 }
@@ -26,10 +27,8 @@ func (c *capture) Emit(_ context.Context, r papi.Results, _ ...EmitOpt) error {
 
 func TestEmitterFromString(t *testing.T) {
 	t.Parallel()
-	var gotSpec string
 	require.NoError(t, RegisterEmitterType("test-from-string", func(spec string) (Emitter, error) {
-		gotSpec = spec
-		return &capture{}, nil
+		return &capture{spec: spec}, nil
 	}))
 	t.Cleanup(func() { UnregisterEmitterType("test-from-string") })
 
@@ -53,14 +52,16 @@ func TestEmitterFromString(t *testing.T) {
 		{name: "unknown-moniker", init: "does-not-exist:https://example.com", mustErr: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			e, err := EmitterFromString(tc.init)
 			if tc.mustErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.NotNil(t, e)
-			require.Equal(t, tc.wantSpec, gotSpec)
+			c, ok := e.(*capture)
+			require.True(t, ok)
+			require.Equal(t, tc.wantSpec, c.spec)
 		})
 	}
 }

--- a/pkg/publisher/stdout/stdout.go
+++ b/pkg/publisher/stdout/stdout.go
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
 // SPDX-License-Identifier: Apache-2.0
 
-// Package stdout implements a mock publisher that writes the evaluation results
+// Package stdout implements a mock emitter that writes the evaluation results
 // as JSON to a writer (os.Stdout by default). It is mainly useful for tests and
-// for manually inspecting what would be published.
+// for manually inspecting what would be published. It is not wired into
+// LoadDefaultEmitterTypes; tests that need it register it explicitly.
 package stdout
 
 import (
@@ -14,34 +15,32 @@ import (
 	"os"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/carabiner-dev/ampel/pkg/publisher"
 )
 
-// DriverName is the id used to select this publisher in an initstring.
-const DriverName = "stdout"
+// TypeMoniker is the moniker used to select this emitter in an initstring.
+const TypeMoniker = "stdout"
 
-func init() {
-	publisher.Register(DriverName, func() publisher.Publisher { return New() })
+// Build constructs a stdout emitter. The init string is ignored; results are
+// written to os.Stdout.
+func Build(string) (publisher.Emitter, error) {
+	return New(), nil
 }
 
-// Publisher writes the result set as indented JSON to Writer.
-type Publisher struct {
+// Emitter writes the results as indented JSON to Writer.
+type Emitter struct {
 	Writer io.Writer
 }
 
-// New returns a stdout publisher writing to os.Stdout.
-func New() *Publisher {
-	return &Publisher{Writer: os.Stdout}
+// New returns a stdout emitter writing to os.Stdout.
+func New() *Emitter {
+	return &Emitter{Writer: os.Stdout}
 }
 
-// Init takes no configuration.
-func (p *Publisher) Init(*structpb.Struct) error { return nil }
-
-// Publish writes the results to the configured writer as indented JSON.
-func (p *Publisher) Publish(_ context.Context, results papi.Results, _ ...publisher.PublishOpt) error {
-	w := p.Writer
+// Emit writes the results to the configured writer as indented JSON.
+func (e *Emitter) Emit(_ context.Context, results papi.Results, _ ...publisher.EmitOpt) error {
+	w := e.Writer
 	if w == nil {
 		w = os.Stdout
 	}

--- a/pkg/publisher/stdout/stdout.go
+++ b/pkg/publisher/stdout/stdout.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stdout implements a mock publisher that writes the evaluation results
+// as JSON to a writer (os.Stdout by default). It is mainly useful for tests and
+// for manually inspecting what would be published.
+package stdout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/carabiner-dev/ampel/pkg/publisher"
+)
+
+// DriverName is the id used to select this publisher in an initstring.
+const DriverName = "stdout"
+
+func init() {
+	publisher.Register(DriverName, func() publisher.Publisher { return New() })
+}
+
+// Publisher writes the result set as indented JSON to Writer.
+type Publisher struct {
+	Writer io.Writer
+}
+
+// New returns a stdout publisher writing to os.Stdout.
+func New() *Publisher {
+	return &Publisher{Writer: os.Stdout}
+}
+
+// Init takes no configuration.
+func (p *Publisher) Init(*structpb.Struct) error { return nil }
+
+// Publish writes the results to the configured writer as indented JSON.
+func (p *Publisher) Publish(_ context.Context, results papi.Results, _ ...publisher.PublishOpt) error {
+	w := p.Writer
+	if w == nil {
+		w = os.Stdout
+	}
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling results: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, string(data)); err != nil {
+		return fmt.Errorf("writing results: %w", err)
+	}
+	return nil
+}

--- a/pkg/publisher/stdout/stdout_test.go
+++ b/pkg/publisher/stdout/stdout_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package stdout
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/ampel/pkg/publisher"
+)
+
+func TestRegistered(t *testing.T) {
+	t.Parallel()
+	p, err := publisher.New(DriverName + ":")
+	require.NoError(t, err)
+	require.IsType(t, &Publisher{}, p)
+}
+
+func TestPublish(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	p := &Publisher{Writer: &buf}
+
+	rs := &papi.ResultSet{
+		PolicySet: &papi.PolicyRef{Id: "test-set"},
+		Status:    papi.StatusPASS,
+	}
+	require.NoError(t, p.Publish(context.Background(), rs))
+	require.Contains(t, buf.String(), "test-set")
+}

--- a/pkg/publisher/stdout/stdout_test.go
+++ b/pkg/publisher/stdout/stdout_test.go
@@ -14,22 +14,25 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/publisher"
 )
 
-func TestRegistered(t *testing.T) {
+func TestRegisterAndFromString(t *testing.T) {
 	t.Parallel()
-	p, err := publisher.New(DriverName + ":")
+	require.NoError(t, publisher.RegisterEmitterType(TypeMoniker, Build))
+	t.Cleanup(func() { publisher.UnregisterEmitterType(TypeMoniker) })
+
+	e, err := publisher.EmitterFromString(TypeMoniker + ":")
 	require.NoError(t, err)
-	require.IsType(t, &Publisher{}, p)
+	require.IsType(t, &Emitter{}, e)
 }
 
-func TestPublish(t *testing.T) {
+func TestEmit(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	p := &Publisher{Writer: &buf}
+	e := &Emitter{Writer: &buf}
 
 	rs := &papi.ResultSet{
 		PolicySet: &papi.PolicyRef{Id: "test-set"},
 		Status:    papi.StatusPASS,
 	}
-	require.NoError(t, p.Publish(context.Background(), rs))
+	require.NoError(t, e.Emit(context.Background(), rs))
 	require.Contains(t, buf.String(), "test-set")
 }

--- a/pkg/publisher/webhook/webhook.go
+++ b/pkg/publisher/webhook/webhook.go
@@ -79,9 +79,9 @@ func (e *Emitter) Emit(ctx context.Context, results papi.Results, _ ...publisher
 	if err != nil {
 		return fmt.Errorf("posting to webhook: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // best-effort: nothing to do on a close failure
 	// Drain the body so the connection can be reused.
-	_, _ = io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck // best-effort drain
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("webhook returned non-success status %s", resp.Status)

--- a/pkg/publisher/webhook/webhook.go
+++ b/pkg/publisher/webhook/webhook.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package webhook implements an emitter that POSTs the evaluation results as
+// JSON to an HTTP(S) endpoint. It is configured with a single value, the
+// webhook URL, taken from its initstring (eg "webhook:https://example.com/hook").
+//
+// Emitting is best-effort: a single POST is attempted with no retries. A
+// non-2xx response or a transport error is returned to the publisher, which
+// surfaces it without failing the evaluation.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+
+	"github.com/carabiner-dev/ampel/pkg/publisher"
+)
+
+// TypeMoniker is the moniker used to select this emitter in an initstring.
+const TypeMoniker = "webhook"
+
+// defaultTimeout bounds a single emit attempt.
+const defaultTimeout = 30 * time.Second
+
+// Build constructs a webhook emitter from its init string, which is the full
+// webhook URL (everything after the "webhook:" prefix).
+func Build(initString string) (publisher.Emitter, error) {
+	if initString == "" {
+		return nil, errors.New(`webhook emitter requires a URL (eg "webhook:https://example.com/hook")`)
+	}
+	u, err := url.Parse(initString)
+	if err != nil {
+		return nil, fmt.Errorf("parsing webhook url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("webhook url must be http or https, got %q", u.Scheme)
+	}
+	return &Emitter{
+		URL:    initString,
+		Client: &http.Client{Timeout: defaultTimeout},
+	}, nil
+}
+
+// Emitter POSTs the evaluation results to URL.
+type Emitter struct {
+	URL    string
+	Client *http.Client
+}
+
+// Emit marshals the results to JSON and POSTs them to the configured URL.
+func (e *Emitter) Emit(ctx context.Context, results papi.Results, _ ...publisher.EmitOpt) error {
+	client := e.Client
+	if client == nil {
+		client = &http.Client{Timeout: defaultTimeout}
+	}
+
+	data, err := json.Marshal(results)
+	if err != nil {
+		return fmt.Errorf("marshaling results: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.URL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("building webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("posting to webhook: %w", err)
+	}
+	defer resp.Body.Close()
+	// Drain the body so the connection can be reused.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned non-success status %s", resp.Status)
+	}
+	return nil
+}

--- a/pkg/publisher/webhook/webhook_test.go
+++ b/pkg/publisher/webhook/webhook_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuild(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		spec    string
+		mustErr bool
+		wantURL string
+	}{
+		{name: "bare-uri", spec: "https://example.com/hook", wantURL: "https://example.com/hook"},
+		{name: "uri-with-query", spec: "https://host/hook?token=abc", wantURL: "https://host/hook?token=abc"},
+		{name: "http-ok", spec: "http://example.com/hook", wantURL: "http://example.com/hook"},
+		{name: "missing-uri", spec: "", mustErr: true},
+		{name: "bad-scheme", spec: "ftp://example.com/hook", mustErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p, err := Build(tc.spec)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantURL, p.(*Emitter).URL)
+		})
+	}
+}
+
+func TestPublish(t *testing.T) {
+	t.Parallel()
+	var gotBody []byte
+	var gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	e := &Emitter{URL: srv.URL}
+	rs := &papi.ResultSet{
+		PolicySet: &papi.PolicyRef{Id: "test-set"},
+		Status:    papi.StatusPASS,
+	}
+	require.NoError(t, e.Emit(context.Background(), rs))
+	require.Equal(t, "application/json", gotContentType)
+	require.Contains(t, string(gotBody), "test-set")
+}
+
+func TestPublishNonSuccess(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	e := &Emitter{URL: srv.URL}
+	require.Error(t, e.Emit(context.Background(), &papi.ResultSet{}))
+}

--- a/pkg/publisher/webhook/webhook_test.go
+++ b/pkg/publisher/webhook/webhook_test.go
@@ -36,7 +36,9 @@ func TestBuild(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tc.wantURL, p.(*Emitter).URL)
+			emitter, ok := p.(*Emitter)
+			require.True(t, ok)
+			require.Equal(t, tc.wantURL, emitter.URL)
 		})
 	}
 }
@@ -47,7 +49,7 @@ func TestPublish(t *testing.T) {
 	var gotContentType string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotContentType = r.Header.Get("Content-Type")
-		gotBody, _ = io.ReadAll(r.Body)
+		gotBody, _ = io.ReadAll(r.Body) //nolint:errcheck // test handler
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()

--- a/pkg/verifier/ampel.go
+++ b/pkg/verifier/ampel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/carabiner-dev/signer/key"
 
 	"github.com/carabiner-dev/ampel/pkg/oscal"
+	"github.com/carabiner-dev/ampel/pkg/publisher"
 )
 
 var ErrMissingAttestations = errors.New("required attestations missing to verify subject")
@@ -85,9 +86,34 @@ var WithCollectorInits = func(init []string) fnOpt {
 	}
 }
 
+// WithPublisherInit adds a publisher from an init string ("driver:spec")
+var WithPublisherInit = func(init string) fnOpt {
+	return func(ampel *Ampel) error {
+		p, err := publisher.New(init)
+		if err != nil {
+			return err
+		}
+		ampel.publishers = append(ampel.publishers, p)
+		return nil
+	}
+}
+
+// WithPublisherInits adds multiple publishers from a list of init strings
+var WithPublisherInits = func(init []string) fnOpt {
+	return func(ampel *Ampel) error {
+		pubs, err := publisher.NewSet(init)
+		if err != nil {
+			return err
+		}
+		ampel.publishers = append(ampel.publishers, pubs...)
+		return nil
+	}
+}
+
 // Ampel is the attestation verifier
 type Ampel struct {
-	impl      AmpelVerifier
-	checker   AmpelStatusChecker
-	Collector *collector.Agent
+	impl       AmpelVerifier
+	checker    AmpelStatusChecker
+	Collector  *collector.Agent
+	publishers []publisher.Publisher
 }

--- a/pkg/verifier/ampel.go
+++ b/pkg/verifier/ampel.go
@@ -6,6 +6,7 @@ package verifier
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/collector"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/carabiner-dev/ampel/pkg/oscal"
 	"github.com/carabiner-dev/ampel/pkg/publisher"
+	publisherdrivers "github.com/carabiner-dev/ampel/pkg/publisher/drivers"
 )
 
 var ErrMissingAttestations = errors.New("required attestations missing to verify subject")
@@ -33,6 +35,7 @@ func New(opts ...fnOpt) (*Ampel, error) {
 		impl:      &defaultIplementation{},
 		checker:   &defaultStatusChecker{},
 		Collector: agent,
+		publisher: publisher.New(),
 	}
 
 	for _, opFn := range opts {
@@ -40,6 +43,18 @@ func New(opts ...fnOpt) (*Ampel, error) {
 			return nil, err
 		}
 	}
+
+	// Register the built-in emitter types (unless disabled) before the publisher
+	// builds its queued emitters, which look them up by moniker.
+	if ampel.publisher.LoadsDefaults() {
+		if err := publisherdrivers.LoadDefaultEmitterTypes(); err != nil {
+			return nil, fmt.Errorf("loading default emitter types: %w", err)
+		}
+	}
+	if err := ampel.publisher.Build(); err != nil {
+		return nil, fmt.Errorf("building publisher: %w", err)
+	}
+
 	return ampel, nil
 }
 
@@ -86,34 +101,38 @@ var WithCollectorInits = func(init []string) fnOpt {
 	}
 }
 
-// WithPublisherInit adds a publisher from an init string ("driver:spec")
+// WithPublisherInit adds an emitter from an init string ("moniker:spec"). The
+// emitter is built when the verifier is created, after the default emitter
+// types are registered.
 var WithPublisherInit = func(init string) fnOpt {
 	return func(ampel *Ampel) error {
-		p, err := publisher.New(init)
-		if err != nil {
-			return err
-		}
-		ampel.publishers = append(ampel.publishers, p)
+		ampel.publisher.AddEmitterInit(init)
 		return nil
 	}
 }
 
-// WithPublisherInits adds multiple publishers from a list of init strings
+// WithPublisherInits adds multiple emitters from a list of init strings.
 var WithPublisherInits = func(init []string) fnOpt {
 	return func(ampel *Ampel) error {
-		pubs, err := publisher.NewSet(init)
-		if err != nil {
-			return err
-		}
-		ampel.publishers = append(ampel.publishers, pubs...)
+		ampel.publisher.AddEmitterInit(init...)
+		return nil
+	}
+}
+
+// WithDefaultPublishers controls whether the built-in emitter types are
+// registered when the verifier is created. It is enabled by default; pass false
+// to manage the emitter registry yourself.
+var WithDefaultPublishers = func(load bool) fnOpt {
+	return func(ampel *Ampel) error {
+		ampel.publisher.SetLoadDefaults(load)
 		return nil
 	}
 }
 
 // Ampel is the attestation verifier
 type Ampel struct {
-	impl       AmpelVerifier
-	checker    AmpelStatusChecker
-	Collector  *collector.Agent
-	publishers []publisher.Publisher
+	impl      AmpelVerifier
+	checker   AmpelStatusChecker
+	Collector *collector.Agent
+	publisher *publisher.Publisher
 }

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -18,6 +18,7 @@ import (
 	sapi "github.com/carabiner-dev/signer/api/v1"
 	gointoto "github.com/in-toto/attestation/go/v1"
 	"github.com/nozzle/throttler"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -37,8 +38,26 @@ type PolicyError struct {
 	Guidance string
 }
 
-// Verify checks a subject against a policy using the available evidence
+// Verify checks a subject against a policy using the available evidence. The
+// policy argument may be a single policy, a policy group or a policy set; the
+// results are published once per call, regardless of the material kind.
 func (ampel *Ampel) Verify(
+	ctx context.Context, opts *VerificationOptions, policy any, subject attestation.Subject,
+) (papi.Results, error) {
+	results, err := ampel.verify(ctx, opts, policy, subject)
+	if err != nil {
+		return nil, err
+	}
+
+	// Publish the results to any configured publishers (best-effort).
+	ampel.publish(ctx, results)
+
+	return results, nil
+}
+
+// verify dispatches the verification to the right routine depending on the kind
+// of policy material supplied and returns the assembled results.
+func (ampel *Ampel) verify(
 	ctx context.Context, opts *VerificationOptions, policy any, subject attestation.Subject,
 ) (papi.Results, error) {
 	switch v := policy.(type) {
@@ -297,6 +316,20 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 
 	// Succcess!
 	return resultSet, nil
+}
+
+// publish sends the results to all configured publishers. Publishing is
+// best effort for now. AMPEL does not queue or retry. If a publisher error
+// happens,  it is just logged but never returned.
+func (ampel *Ampel) publish(ctx context.Context, results papi.Results) {
+	if results == nil {
+		return
+	}
+	for _, p := range ampel.publishers {
+		if err := p.Publish(ctx, results); err != nil {
+			logrus.Warnf("publishing results: %v", err)
+		}
+	}
 }
 
 // VerifySubjectWithPolicy verifies a subject against a single policy

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -18,7 +18,6 @@ import (
 	sapi "github.com/carabiner-dev/signer/api/v1"
 	gointoto "github.com/in-toto/attestation/go/v1"
 	"github.com/nozzle/throttler"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -49,8 +48,9 @@ func (ampel *Ampel) Verify(
 		return nil, err
 	}
 
-	// Publish the results to any configured publishers (best-effort).
-	ampel.publish(ctx, results)
+	// Publish the results (best-effort): the publisher fans them out to the
+	// configured emitters and we ignore any emitter errors.
+	_ = ampel.publisher.PublishResults(ctx, results)
 
 	return results, nil
 }
@@ -316,20 +316,6 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 
 	// Succcess!
 	return resultSet, nil
-}
-
-// publish sends the results to all configured publishers. Publishing is
-// best effort for now. AMPEL does not queue or retry. If a publisher error
-// happens,  it is just logged but never returned.
-func (ampel *Ampel) publish(ctx context.Context, results papi.Results) {
-	if results == nil {
-		return
-	}
-	for _, p := range ampel.publishers {
-		if err := p.Publish(ctx, results); err != nil {
-			logrus.Warnf("publishing results: %v", err)
-		}
-	}
 }
 
 // VerifySubjectWithPolicy verifies a subject against a single policy

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -49,8 +49,8 @@ func (ampel *Ampel) Verify(
 	}
 
 	// Publish the results (best-effort): the publisher fans them out to the
-	// configured emitters and we ignore any emitter errors.
-	_ = ampel.publisher.PublishResults(ctx, results)
+	// configured emitters and we intentionally ignore any emitter errors.
+	_ = ampel.publisher.PublishResults(ctx, results) //nolint:errcheck // best-effort publish
 
 	return results, nil
 }


### PR DESCRIPTION
This PR adds to the verifier support for results publishers. The idea here is that evaluation results can be submitted to other systems right from the verifier.