### PR TITLE
Bump linter to v2.12 and fix all nits

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,24 @@ on:
 permissions: {}
 
 jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      stable: ${{ steps.versions.outputs.GO_MINOR_VERSION_STABLE }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Determine Go versions
+        id: versions
+        uses: carabiner-dev/actions/go/versions@e0e3b8149dafed833431095bc148d50e7eade4e8 # main
+
   golangci:
+    needs: resolve-versions
     name: lint
     runs-on: ubuntu-latest
 
@@ -30,8 +47,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: ${{ needs.resolve-versions.outputs.stable }}
           check-latest: true
+          cache: true
 
       - name: Check go.mod
         id: gomodtidy
@@ -40,4 +58,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.11
+          version: v2.12

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -181,3 +181,10 @@ linters:
       require-explanation: false
       # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
       require-specific: true
+  exclusions:
+    rules:
+      # Test files lean on repeated literal fixtures (digests, subject names,
+      # predicate types); hoisting them into constants hurts readability.
+      - path: _test\.go
+        linters:
+          - goconst

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -48,14 +48,19 @@ func attestFormatFor(format string) (string, bool) {
 	switch format {
 	case "attestation":
 		return "ampel", true
-	case "vsa":
-		return "vsa", true
-	case "svr":
-		return "svr", true
+	case formatVSA:
+		return formatVSA, true
+	case formatSVR:
+		return formatSVR, true
 	default:
 		return "", false
 	}
 }
+
+const (
+	formatVSA = "vsa"
+	formatSVR = "svr"
+)
 
 const (
 	grpSubject      = "subject"

--- a/internal/drivers/gotable/gotable.go
+++ b/internal/drivers/gotable/gotable.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 )
 
+const headerSubject = "Subject"
+
 type TableBuilder struct {
 	Decorator TableDecorator
 }
@@ -59,7 +61,7 @@ func (tb *TableBuilder) ResultsTable(result *papi.Result) (table.Writer, error) 
 	t.AppendRow(table.Row{"Results Date", "Results Date", result.DateEnd.AsTime().Local()}, rowConfigAutoMerge)
 	t.AppendRow(table.Row{"Execution Time", "Execution Time", result.DateEnd.AsTime().Sub(result.DateStart.AsTime())}, rowConfigAutoMerge)
 	t.AppendRow(table.Row{"Tenets", "Tenets", tb.Decorator.TenetsToString(result)}, rowConfigAutoMerge)
-	t.AppendRow(table.Row{"Subject", "Subject", tb.Decorator.SubjectToString(result.Subject, result.Chain)}, rowConfigAutoMerge)
+	t.AppendRow(table.Row{headerSubject, headerSubject, tb.Decorator.SubjectToString(result.Subject, result.Chain)}, rowConfigAutoMerge)
 	if len(result.GetMeta().Controls) > 0 {
 		t.AppendRow(table.Row{"Controls", "Controls", tb.Decorator.ControlsToString(result, "", "")}, rowConfigAutoMerge)
 	}
@@ -113,7 +115,7 @@ func (tb *TableBuilder) ResultSetTable(set *papi.ResultSet) (table.Writer, error
 		t.AppendRow(
 			table.Row{
 				fmt.Sprintf("Status: %s %s", tb.Decorator.StatusToDot(set.Status), tb.Decorator.Bold(set.Status)),
-				"Subject", st, st,
+				headerSubject, st, st,
 			},
 			rowConfigAutoMerge,
 		)
@@ -239,7 +241,7 @@ func (tb *TableBuilder) ResultGroupTable(grp *papi.ResultGroup) (table.Writer, e
 		t.AppendRow(
 			table.Row{
 				tb.Decorator.Bold("Status:") + fmt.Sprintf(" %s %s", tb.Decorator.StatusToDot(grp.GetStatus()), tb.Decorator.Bold(grp.GetStatus())),
-				tb.Decorator.Bold("Subject"), st, st,
+				tb.Decorator.Bold(headerSubject), st, st,
 			},
 			rowConfigAutoMerge,
 		)

--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -30,6 +30,10 @@ import (
 // resultset format).
 const ampelVerifierID = "https://carabiner.dev/ampel@v1"
 
+// formatAmpel is the canonical name of the native ampel resultset
+// attestation format.
+const formatAmpel = "ampel"
+
 // ResultsAttester writes a results attestation in the format chosen
 // per call via WithFormat. The "ampel" format produces an in-toto
 // statement carrying a predicates.ResultSet; "vsa" and "svr" route
@@ -71,7 +75,7 @@ type attestOptions struct {
 // defaultAttestOptions returns the baseline config used when no
 // FnOpts are supplied at construction or call time.
 func defaultAttestOptions() attestOptions {
-	return attestOptions{format: "ampel", prettyPrint: true}
+	return attestOptions{format: formatAmpel, prettyPrint: true}
 }
 
 // WithFormat selects the results-attestation format for the call.
@@ -135,7 +139,7 @@ func (a *ResultsAttester) AttestTo(w io.Writer, results papi.Results, opts ...Fn
 		fn(&o)
 	}
 	switch o.format {
-	case "ampel", "":
+	case formatAmpel, "":
 		return a.attestAmpel(w, results, o)
 	case "vsa":
 		return a.attestVSA(w, results, o)

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -26,6 +26,10 @@ const (
 	// vsaContextResourceURIKey is the policy-context key recognized
 	// for overriding the VSA resource URI.
 	vsaContextResourceURIKey = "vsa.resourceUri"
+
+	// statusPassed is the SLSA VerificationResult value for a passing
+	// verification.
+	statusPassed = "PASSED"
 )
 
 // attestVSA writes a VSA attestation for results.
@@ -211,7 +215,7 @@ func (a *ResultsAttester) writeVSAStatement(w io.Writer, subject attestation.Sub
 func resultStringToSLSAResult(status string) string {
 	switch status {
 	case papi.StatusPASS, papi.StatusSOFTFAIL:
-		return "PASSED"
+		return statusPassed
 	case papi.StatusFAIL:
 		return "FAILED"
 	default:

--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -29,6 +29,12 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
 
+// Shared map-key / CEL identifier literals used across the package.
+const (
+	keyPredicateType = "predicate_type"
+	keyData          = "data"
+)
+
 type CelEvaluatorImplementation interface {
 	CompileCode(*cel.Env, string) (*cel.Ast, error)
 	CreateEnvironment(*options.EvaluatorOptions, map[string]Plugin) (*cel.Env, error)
@@ -118,8 +124,8 @@ func (dce *defaulCelEvaluator) BuildVariables(
 			return nil, fmt.Errorf("unmarshalling predicate data: %w", err)
 		}
 		predMap := map[string]any{
-			"predicate_type": string(p.GetType()),
-			"data":           d,
+			keyPredicateType: string(p.GetType()),
+			keyData:          d,
 		}
 		val, err := structpb.NewValue(predMap)
 		if err != nil {
@@ -517,8 +523,8 @@ func (dce *defaulCelEvaluator) BuildSelectorVariables(
 		return nil, fmt.Errorf("unmarshaling predicate data: %w", err)
 	}
 	predMap := map[string]any{
-		"predicate_type": string(predicate.GetType()),
-		"data":           d,
+		keyPredicateType: string(predicate.GetType()),
+		keyData:          d,
 	}
 	val, err := structpb.NewValue(predMap)
 	if err != nil {

--- a/pkg/evaluator/cel/verification.go
+++ b/pkg/evaluator/cel/verification.go
@@ -43,9 +43,9 @@ func extractVerificationData(pred attestation.Predicate) map[string]any {
 		}
 		if k := id.GetKey(); k != nil {
 			idMap["key"] = map[string]any{
-				"id":   k.GetId(),
-				"type": k.GetType(),
-				"data": k.GetData(),
+				"id":    k.GetId(),
+				"type":  k.GetType(),
+				keyData: k.GetData(),
 			}
 		}
 		if r := id.GetRef(); r != nil {

--- a/pkg/evaluator/plugins/cvss/tool.go
+++ b/pkg/evaluator/plugins/cvss/tool.go
@@ -42,6 +42,10 @@ const (
 	Prefix30 = "CVSS:3.0/"
 	Prefix31 = "CVSS:3.1/"
 	Prefix40 = "CVSS:4.0/"
+
+	severityHigh = "HIGH"
+	keyVersion   = "version"
+	keySeverity  = "severity"
 )
 
 var CvssType = cel.ObjectType("cvss", traits.ReceiverType)
@@ -104,7 +108,7 @@ func getCVSSResult(vector string) (*cvssResult, error) {
 func rating20(score float64) string {
 	switch {
 	case score >= 7.0:
-		return "HIGH"
+		return severityHigh
 	case score >= 4.0:
 		return "MEDIUM"
 	default:
@@ -121,14 +125,14 @@ func (ct *CvssTool) Functions() []cel.EnvOption {
 			}
 			return res.score, nil
 		}),
-		memberStringFn("severity", func(v string) (string, error) {
+		memberStringFn(keySeverity, func(v string) (string, error) {
 			res, err := getCVSSResult(v)
 			if err != nil {
 				return "", err
 			}
 			return res.severity, nil
 		}),
-		memberStringFn("version", func(v string) (string, error) {
+		memberStringFn(keyVersion, func(v string) (string, error) {
 			res, err := getCVSSResult(v)
 			if err != nil {
 				return "", err
@@ -183,9 +187,9 @@ func (ct *CvssTool) Functions() []cel.EnvOption {
 						return types.NewErrFromString(err.Error())
 					}
 					m := map[string]any{
-						"version":  res.version,
-						"score":    res.score,
-						"severity": res.severity,
+						keyVersion:  res.version,
+						"score":     res.score,
+						keySeverity: res.severity,
 					}
 					for _, abv := range res.metrics {
 						if val, getErr := res.doc.Get(abv); getErr == nil {

--- a/pkg/evaluator/plugins/github/github.go
+++ b/pkg/evaluator/plugins/github/github.go
@@ -18,6 +18,17 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+const (
+	keyScheme = "scheme"
+	keyHost   = "host"
+	keyOrg    = "org"
+	keyRepo   = "repo"
+	keyName   = "name"
+	keyURI    = "uri"
+	keyDigest = "digest"
+	keySHA256 = "sha256"
+)
+
 type GitHubUtil struct{}
 
 var GitHubType = cel.ObjectType("github", traits.ReceiverType)
@@ -87,10 +98,10 @@ func parseRepoURI(uri string) (map[string]string, error) {
 	}
 
 	return map[string]string{
-		"scheme": strings.TrimPrefix(parsed.Scheme, "git+"),
-		"host":   parsed.Hostname(),
-		"org":    parts[0],
-		"repo":   repo,
+		keyScheme: strings.TrimPrefix(parsed.Scheme, "git+"),
+		keyHost:   parsed.Hostname(),
+		keyOrg:    parts[0],
+		keyRepo:   repo,
 	}, nil
 }
 
@@ -108,20 +119,20 @@ var uriToRepoDescriptor = func(_ ref.Val, rhs ref.Val) ref.Val {
 		if err != nil {
 			return types.NewErrFromString(err.Error())
 		}
-		if parts["repo"] == "" {
+		if parts[keyRepo] == "" {
 			return types.NewErrFromString("unable to create descriptor, no repo name defined in URL")
 		}
-		name := fmt.Sprintf("%s/%s/%s", parts["host"], parts["org"], parts["repo"])
+		name := fmt.Sprintf("%s/%s/%s", parts[keyHost], parts[keyOrg], parts[keyRepo])
 
 		h := sha256.New()
 		h.Write([]byte(name))
 		digest := fmt.Sprintf("%x", h.Sum(nil))
 
 		mapa := map[string]any{
-			"name": name,
-			"uri":  fmt.Sprintf("https://%s", name),
-			"digest": map[string]any{
-				"sha256": digest,
+			keyName: name,
+			keyURI:  fmt.Sprintf("https://%s", name),
+			keyDigest: map[string]any{
+				keySHA256: digest,
 			},
 		}
 
@@ -154,21 +165,21 @@ var uriToOrgDescriptor = func(_ ref.Val, rhs ref.Val) ref.Val {
 		if err != nil {
 			return types.NewErrFromString(err.Error())
 		}
-		if parts["org"] == "" || parts["host"] == "" {
+		if parts[keyOrg] == "" || parts[keyHost] == "" {
 			return types.NewErrFromString("could not parse org from repo uri")
 		}
-		name := fmt.Sprintf("%s/%s", parts["host"], parts["org"])
+		name := fmt.Sprintf("%s/%s", parts[keyHost], parts[keyOrg])
 
 		h := sha256.New()
 		h.Write([]byte(name))
 		digest := fmt.Sprintf("%x", h.Sum(nil))
 
 		mapa := map[string]any{
-			"digest": map[string]any{
-				"sha256": digest,
+			keyDigest: map[string]any{
+				keySHA256: digest,
 			},
-			"name": name,
-			"uri":  fmt.Sprintf("https://%s", name),
+			keyName: name,
+			keyURI:  fmt.Sprintf("https://%s", name),
 		}
 
 		reg, err := types.NewRegistry()
@@ -218,20 +229,20 @@ var uriToBranchDescriptor = func(args ...ref.Val) ref.Val {
 	if err != nil {
 		return types.NewErrFromString(err.Error())
 	}
-	if parts["repo"] == "" {
+	if parts[keyRepo] == "" {
 		return types.NewErrFromString("unable to create descriptor, no repo name defined in URL")
 	}
-	name := fmt.Sprintf("%s/%s/%s@%s", parts["host"], parts["org"], parts["repo"], branch)
+	name := fmt.Sprintf("%s/%s/%s@%s", parts[keyHost], parts[keyOrg], parts[keyRepo], branch)
 
 	h := sha256.New()
 	h.Write([]byte(name))
 	digest := fmt.Sprintf("%x", h.Sum(nil))
 
 	mapa := map[string]any{
-		"name": name,
-		"uri":  fmt.Sprintf("git+https://%s", name),
-		"digest": map[string]any{
-			"sha256": digest,
+		keyName: name,
+		keyURI:  fmt.Sprintf("git+https://%s", name),
+		keyDigest: map[string]any{
+			keySHA256: digest,
 		},
 	}
 

--- a/pkg/evaluator/plugins/purl/tool.go
+++ b/pkg/evaluator/plugins/purl/tool.go
@@ -15,6 +15,14 @@ import (
 
 type PurlTool struct{}
 
+const (
+	keyType      = "type"
+	keyNamespace = "namespace"
+	keyName      = "name"
+	keyVersion   = "version"
+	keySubpath   = "subpath"
+)
+
 var PurlType = cel.ObjectType("purl")
 
 func (pt *PurlTool) Functions() []cel.EnvOption {
@@ -36,7 +44,7 @@ func (pt *PurlTool) Functions() []cel.EnvOption {
 			),
 		),
 		cel.Function(
-			"namespace",
+			keyNamespace,
 			cel.MemberOverload(
 				"purl_namespace_binding",
 				[]*cel.Type{PurlType, cel.StringType}, cel.StringType,
@@ -44,7 +52,7 @@ func (pt *PurlTool) Functions() []cel.EnvOption {
 			),
 		),
 		cel.Function(
-			"name",
+			keyName,
 			cel.MemberOverload(
 				"purl_name_binding",
 				[]*cel.Type{PurlType, cel.StringType}, cel.StringType,
@@ -52,7 +60,7 @@ func (pt *PurlTool) Functions() []cel.EnvOption {
 			),
 		),
 		cel.Function(
-			"version",
+			keyVersion,
 			cel.MemberOverload(
 				"purl_version_binding",
 				[]*cel.Type{PurlType, cel.StringType}, cel.StringType,
@@ -68,7 +76,7 @@ func (pt *PurlTool) Functions() []cel.EnvOption {
 			),
 		),
 		cel.Function(
-			"subpath",
+			keySubpath,
 			cel.MemberOverload(
 				"purl_subpath_binding",
 				[]*cel.Type{PurlType, cel.StringType}, cel.StringType,
@@ -94,11 +102,11 @@ var parse = func(_ ref.Val, rhs ref.Val) ref.Val {
 
 		// Create a map with all PURL components
 		result := map[string]any{
-			"type":      parsed.Type,
-			"namespace": parsed.Namespace,
-			"name":      parsed.Name,
-			"version":   parsed.Version,
-			"subpath":   parsed.Subpath,
+			keyType:      parsed.Type,
+			keyNamespace: parsed.Namespace,
+			keyName:      parsed.Name,
+			keyVersion:   parsed.Version,
+			keySubpath:   parsed.Subpath,
 		}
 
 		// Convert qualifiers to CEL-compatible map

--- a/pkg/verifier/context.go
+++ b/pkg/verifier/context.go
@@ -12,6 +12,11 @@ import (
 	papi "github.com/carabiner-dev/policy/api/v1"
 )
 
+const (
+	valueTrue  = "true"
+	valueFalse = "false"
+)
+
 // ensureContextType makes sure the loaded context values are match the types
 // defined in the context definition. For now we ensure the types of simple
 // types: string, bool, int and convert between them as much as possible.
@@ -38,9 +43,9 @@ func convertToString(value any) string {
 		return ""
 	case bool:
 		if v {
-			return "true"
+			return valueTrue
 		}
-		return "false"
+		return valueFalse
 	case int, int8, int16, int32, int64:
 		return fmt.Sprintf("%d", v)
 	case uint, uint8, uint16, uint32, uint64:
@@ -58,9 +63,9 @@ func convertToBool(value any) (bool, error) {
 	case bool:
 		return v, nil
 	case string:
-		if strings.EqualFold(v, "true") {
+		if strings.EqualFold(v, valueTrue) {
 			return true, nil
-		} else if strings.EqualFold(v, "false") {
+		} else if strings.EqualFold(v, valueFalse) {
 			return false, nil
 		}
 		// Try to parse as number

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -314,7 +314,7 @@ func (di *defaultIplementation) ParseAttestations(ctx context.Context, opts *Ver
 // result sets returned by the evaluators.
 func (di *defaultIplementation) AssertResult(policy *papi.Policy, result *papi.Result) error {
 	switch policy.GetMeta().GetAssertMode() {
-	case "OR", "":
+	case assertModeOR, "":
 		for _, er := range result.EvalResults {
 			if er.Status == papi.StatusPASS {
 				result.Status = papi.StatusPASS
@@ -325,7 +325,7 @@ func (di *defaultIplementation) AssertResult(policy *papi.Policy, result *papi.R
 		if policy.GetMeta().GetEnforce() == "OFF" {
 			result.Status = papi.StatusSOFTFAIL
 		}
-	case "AND":
+	case assertModeAND:
 		for _, er := range result.EvalResults {
 			if er.Status == papi.StatusFAIL {
 				result.Status = papi.StatusFAIL


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the codebase, focusing on standardizing constant usage, updating linting configurations, and making workflows more robust. The main themes are: (1) refactoring to use named constants for map keys and identifiers, (2) updating and refining linting workflows and configurations, and (3) minor code cleanups for clarity and maintainability.

**Refactoring: Consistent Use of Named Constants**
- Replaced string literals used as map keys and identifiers throughout the codebase (e.g., in CEL evaluator, GitHub, CVSS, and PURL plugins) with named constants to improve maintainability and reduce errors. [[1]](diffhunk://#diff-96d20c22554a5ece49b2540937d4128109a797f1bcc5ad8bddff51c8a111522dR32-R37) [[2]](diffhunk://#diff-138f9c36e5e011bcd8701ca3c919520894683d6b4f1f24cd4bb0ecaaf81c9786R45-R48) [[3]](diffhunk://#diff-04f3d62f49f6a1fe154abc52f9e4d6db9e268b7d19fe0a5122a4ea9c70754ae9R21-R31) [[4]](diffhunk://#diff-4f3238aad7cfe77451b2bece335c95165d30bed84ffcab76d92a08aa032f9129R18-R25)
- Updated function calls and map constructions to use these new constants, ensuring consistency and easier refactoring in the future. [[1]](diffhunk://#diff-96d20c22554a5ece49b2540937d4128109a797f1bcc5ad8bddff51c8a111522dL121-R128) [[2]](diffhunk://#diff-96d20c22554a5ece49b2540937d4128109a797f1bcc5ad8bddff51c8a111522dL520-R527) [[3]](diffhunk://#diff-c7ed8fc9b83739ecd5f467bbc792ea26d52d9e45bb48b30d2c81b8a4755286bfL48-R48) [[4]](diffhunk://#diff-138f9c36e5e011bcd8701ca3c919520894683d6b4f1f24cd4bb0ecaaf81c9786L124-R135) [[5]](diffhunk://#diff-138f9c36e5e011bcd8701ca3c919520894683d6b4f1f24cd4bb0ecaaf81c9786L186-R192) [[6]](diffhunk://#diff-04f3d62f49f6a1fe154abc52f9e4d6db9e268b7d19fe0a5122a4ea9c70754ae9L90-R104) [[7]](diffhunk://#diff-04f3d62f49f6a1fe154abc52f9e4d6db9e268b7d19fe0a5122a4ea9c70754ae9L111-R135) [[8]](diffhunk://#diff-04f3d62f49f6a1fe154abc52f9e4d6db9e268b7d19fe0a5122a4ea9c70754ae9L157-R182) [[9]](diffhunk://#diff-04f3d62f49f6a1fe154abc52f9e4d6db9e268b7d19fe0a5122a4ea9c70754ae9L221-R245) [[10]](diffhunk://#diff-4f3238aad7cfe77451b2bece335c95165d30bed84ffcab76d92a08aa032f9129L39-R63) [[11]](diffhunk://#diff-4f3238aad7cfe77451b2bece335c95165d30bed84ffcab76d92a08aa032f9129L71-R79) [[12]](diffhunk://#diff-4f3238aad7cfe77451b2bece335c95165d30bed84ffcab76d92a08aa032f9129L97-R109)

**Linting and CI Workflow Improvements**
- Added a new `resolve-versions` job to the GitHub Actions lint workflow to dynamically determine the stable Go version, and updated the `golangci` job to use this version and enable caching. [[1]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bR17-R34) [[2]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL33-R52)
- Updated `golangci-lint` to version 2.12 and changed the linter configuration to use `gomodguard_v2` instead of `gomodguard`. [[1]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL43-R61) [[2]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L63-R63)
- Added an exclusion rule in `.golangci.yaml` to suppress the `goconst` linter for test files, improving readability of test fixtures.

**General Code Cleanups and Minor Refactors**
- Centralized format string constants for attestation formats (e.g., `"ampel"`, `"vsa"`, `"svr"`) to avoid magic strings and improve clarity. [[1]](diffhunk://#diff-e22ed4820f305527283ae8c41a33d4aac1d0f0121e4fc2ca7bfa79ac5686742bL51-R64) [[2]](diffhunk://#diff-06d30b9c5500714e87fb5fcac905ca3d436b4172bdb405d992a35fb96d83df6cR33-R36) [[3]](diffhunk://#diff-06d30b9c5500714e87fb5fcac905ca3d436b4172bdb405d992a35fb96d83df6cL74-R78) [[4]](diffhunk://#diff-06d30b9c5500714e87fb5fcac905ca3d436b4172bdb405d992a35fb96d83df6cL138-R142) [[5]](diffhunk://#diff-7664046d969093792032aa1c3a51077f4452194967a4d9fa481ca3c551d12d2dR29-R32) [[6]](diffhunk://#diff-7664046d969093792032aa1c3a51077f4452194967a4d9fa481ca3c551d12d2dL214-R218)
- Replaced repeated string literals for table headers (e.g., `"Subject"`) with a named constant in the `gotable` driver for consistency. [[1]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2R19-R20) [[2]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2L62-R64) [[3]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2L116-R118) [[4]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2L242-R244)

These changes collectively improve the maintainability, readability, and reliability of the codebase by enforcing consistency and modernizing tooling.