### PR TITLE
Allow non-SLSA things in VSA verifiedResults

### DIFF
--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -32,10 +32,11 @@ const (
 //
 // The VerificationResult on the VSA is mapped from the PolicySet
 // assessment status, and the VerifiedLevels list is taken from the
-// SLSA controls advertised by the policies. Dependency levels are
+// controls advertised by the policies; SLSA-track controls
+// additionally set the VSA's slsaVersion. Dependency levels are
 // computed by extracting the results of policies chained to a
 // different subject — those policies are expected to have their own
-// controls section, defining the SLSA level they check.
+// controls section, defining the level they check.
 func (a *ResultsAttester) attestVSA(w io.Writer, results papi.Results, o attestOptions) error {
 	switch r := results.(type) {
 	case *papi.Result:
@@ -89,7 +90,7 @@ func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet
 			}
 		}
 
-		// Collect any SLSA levels into the dep count
+		// Collect the levels advertised by passing policies.
 		if r.GetStatus() != papi.StatusPASS {
 			continue
 		}
@@ -98,11 +99,12 @@ func (a *ResultsAttester) writeVSAFromResultSet(w io.Writer, set *papi.ResultSet
 				continue
 			}
 			label := strings.ReplaceAll(ctl.Label(), "-", "_")
-			if !strings.HasPrefix(label, "SLSA_") {
-				continue
-			}
 
-			verifiedSomeSlsa = true
+			// Only SLSA-track controls set the VSA's slsaVersion; controls
+			// from other frameworks still contribute their namespaced label.
+			if strings.HasPrefix(label, "SLSA_") {
+				verifiedSomeSlsa = true
+			}
 
 			// Add the level to the verified levels when the result subject
 			// matches the policyset subject. Otherwise treat the policyset as
@@ -156,11 +158,16 @@ func (a *ResultsAttester) writeVSAFromResult(w io.Writer, result *papi.Result, o
 
 	var verifiedSomeSlsa bool
 	for _, ctl := range result.GetMeta().GetControls() {
-		label := strings.ReplaceAll(ctl.Label(), "-", "_")
-		if !strings.HasPrefix(label, "SLSA_") {
+		if ctl.Id == "" {
 			continue
 		}
-		verifiedSomeSlsa = true
+		label := strings.ReplaceAll(ctl.Label(), "-", "_")
+
+		// Only SLSA-track controls set the VSA's slsaVersion; controls
+		// from other frameworks still contribute their namespaced label.
+		if strings.HasPrefix(label, "SLSA_") {
+			verifiedSomeSlsa = true
+		}
 		vsaData.VerifiedLevels = append(vsaData.VerifiedLevels, label)
 	}
 

--- a/pkg/attest/vsa_test.go
+++ b/pkg/attest/vsa_test.go
@@ -50,18 +50,18 @@ func emitVSA(t *testing.T, results papi.Results) vsaShape {
 	return got
 }
 
-// A WRANGLE-framework control reaches verifiedLevels on both writer
-// paths, and because it is not a SLSA-track level it must not stamp
-// slsaVersion on the VSA.
+// A control from a non-SLSA framework reaches verifiedLevels on both
+// writer paths, and because it is not a SLSA-track level it must not
+// stamp slsaVersion on the VSA.
 func TestVSA_NamespacedLevel_NoSlsaVersion(t *testing.T) {
-	wrangle := &papi.Control{Framework: "WRANGLE", Id: "RELEASE_PINNED"}
+	foo := &papi.Control{Framework: "FOO", Id: "BAR"}
 
 	t.Run("ResultSet", func(t *testing.T) {
 		rs := newResultSet(t, "deadbeef")
-		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{wrangle}}
+		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{foo}}
 		got := emitVSA(t, rs)
-		if !slices.Contains(got.Predicate.VerifiedLevels, "WRANGLE_RELEASE_PINNED") {
-			t.Errorf("verifiedLevels = %v, want WRANGLE_RELEASE_PINNED", got.Predicate.VerifiedLevels)
+		if !slices.Contains(got.Predicate.VerifiedLevels, "FOO_BAR") {
+			t.Errorf("verifiedLevels = %v, want FOO_BAR", got.Predicate.VerifiedLevels)
 		}
 		if got.Predicate.SlsaVersion != "" {
 			t.Errorf("slsaVersion = %q, want empty for a non-SLSA level", got.Predicate.SlsaVersion)
@@ -69,9 +69,38 @@ func TestVSA_NamespacedLevel_NoSlsaVersion(t *testing.T) {
 	})
 
 	t.Run("Result", func(t *testing.T) {
-		got := emitVSA(t, resultWithControls("deadbeef", wrangle))
-		if !slices.Contains(got.Predicate.VerifiedLevels, "WRANGLE_RELEASE_PINNED") {
-			t.Errorf("verifiedLevels = %v, want WRANGLE_RELEASE_PINNED", got.Predicate.VerifiedLevels)
+		got := emitVSA(t, resultWithControls("deadbeef", foo))
+		if !slices.Contains(got.Predicate.VerifiedLevels, "FOO_BAR") {
+			t.Errorf("verifiedLevels = %v, want FOO_BAR", got.Predicate.VerifiedLevels)
+		}
+		if got.Predicate.SlsaVersion != "" {
+			t.Errorf("slsaVersion = %q, want empty for a non-SLSA level", got.Predicate.SlsaVersion)
+		}
+	})
+}
+
+// A non-SLSA control that also carries a Class composes its full
+// framework-class-id label into verifiedLevels, mirroring how a SLSA
+// control with a Class (e.g. SLSA_BUILD_LEVEL_3) is handled.
+func TestVSA_NamespacedClassedLevel(t *testing.T) {
+	foo := &papi.Control{Framework: "FOO", Class: "BAZ", Id: "BAR"}
+
+	t.Run("ResultSet", func(t *testing.T) {
+		rs := newResultSet(t, "deadbeef")
+		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{foo}}
+		got := emitVSA(t, rs)
+		if !slices.Contains(got.Predicate.VerifiedLevels, "FOO_BAZ_BAR") {
+			t.Errorf("verifiedLevels = %v, want FOO_BAZ_BAR", got.Predicate.VerifiedLevels)
+		}
+		if got.Predicate.SlsaVersion != "" {
+			t.Errorf("slsaVersion = %q, want empty for a non-SLSA level", got.Predicate.SlsaVersion)
+		}
+	})
+
+	t.Run("Result", func(t *testing.T) {
+		got := emitVSA(t, resultWithControls("deadbeef", foo))
+		if !slices.Contains(got.Predicate.VerifiedLevels, "FOO_BAZ_BAR") {
+			t.Errorf("verifiedLevels = %v, want FOO_BAZ_BAR", got.Predicate.VerifiedLevels)
 		}
 		if got.Predicate.SlsaVersion != "" {
 			t.Errorf("slsaVersion = %q, want empty for a non-SLSA level", got.Predicate.SlsaVersion)
@@ -83,13 +112,13 @@ func TestVSA_NamespacedLevel_NoSlsaVersion(t *testing.T) {
 // and still stamps slsaVersion (the SLSA level is what gates it).
 func TestVSA_MixedLevels_StampsSlsaVersion(t *testing.T) {
 	slsa := &papi.Control{Framework: "SLSA", Class: "BUILD", Id: "LEVEL_3"}
-	wrangle := &papi.Control{Framework: "WRANGLE", Id: "RELEASE_PINNED"}
+	foo := &papi.Control{Framework: "FOO", Id: "BAR"}
 
 	t.Run("ResultSet", func(t *testing.T) {
 		rs := newResultSet(t, "deadbeef")
-		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{slsa, wrangle}}
+		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{slsa, foo}}
 		got := emitVSA(t, rs)
-		for _, want := range []string{"SLSA_BUILD_LEVEL_3", "WRANGLE_RELEASE_PINNED"} {
+		for _, want := range []string{"SLSA_BUILD_LEVEL_3", "FOO_BAR"} {
 			if !slices.Contains(got.Predicate.VerifiedLevels, want) {
 				t.Errorf("verifiedLevels = %v, want %s", got.Predicate.VerifiedLevels, want)
 			}
@@ -100,8 +129,8 @@ func TestVSA_MixedLevels_StampsSlsaVersion(t *testing.T) {
 	})
 
 	t.Run("Result", func(t *testing.T) {
-		got := emitVSA(t, resultWithControls("deadbeef", slsa, wrangle))
-		for _, want := range []string{"SLSA_BUILD_LEVEL_3", "WRANGLE_RELEASE_PINNED"} {
+		got := emitVSA(t, resultWithControls("deadbeef", slsa, foo))
+		for _, want := range []string{"SLSA_BUILD_LEVEL_3", "FOO_BAR"} {
 			if !slices.Contains(got.Predicate.VerifiedLevels, want) {
 				t.Errorf("verifiedLevels = %v, want %s", got.Predicate.VerifiedLevels, want)
 			}
@@ -116,7 +145,7 @@ func TestVSA_MixedLevels_StampsSlsaVersion(t *testing.T) {
 // verifiedLevels — the guard that prevents an empty-string entry once
 // the SLSA_ prefix filter no longer drops it.
 func TestVSA_EmptyIdControl_Dropped(t *testing.T) {
-	empty := &papi.Control{Framework: "WRANGLE"}
+	empty := &papi.Control{Framework: "FOO"}
 
 	t.Run("ResultSet", func(t *testing.T) {
 		rs := newResultSet(t, "deadbeef")
@@ -140,7 +169,7 @@ func TestVSA_EmptyIdControl_Dropped(t *testing.T) {
 // hold for namespaced controls just as it does for SLSA ones.
 func TestVSA_NamespacedDependencyLevel(t *testing.T) {
 	rs := newResultSet(t, "deadbeef")
-	dep := resultWithControls("feedface", &papi.Control{Framework: "WRANGLE", Id: "RELEASE_PINNED"})
+	dep := resultWithControls("feedface", &papi.Control{Framework: "FOO", Id: "BAR"})
 	rs.Results = append(rs.Results, dep)
 
 	var buf bytes.Buffer
@@ -157,10 +186,10 @@ func TestVSA_NamespacedDependencyLevel(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshaling vsa: %v\nbody: %s", err, buf.String())
 	}
-	if got.Predicate.DependencyLevels["WRANGLE_RELEASE_PINNED"] != "1" {
-		t.Errorf("dependencyLevels = %v, want WRANGLE_RELEASE_PINNED:1", got.Predicate.DependencyLevels)
+	if got.Predicate.DependencyLevels["FOO_BAR"] != "1" {
+		t.Errorf("dependencyLevels = %v, want FOO_BAR:1", got.Predicate.DependencyLevels)
 	}
-	if slices.Contains(got.Predicate.VerifiedLevels, "WRANGLE_RELEASE_PINNED") {
+	if slices.Contains(got.Predicate.VerifiedLevels, "FOO_BAR") {
 		t.Errorf("dependency level leaked into verifiedLevels: %v", got.Predicate.VerifiedLevels)
 	}
 }

--- a/pkg/attest/vsa_test.go
+++ b/pkg/attest/vsa_test.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package attest
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// vsaShape is the minimal slice of the SLSA VSA predicate the level
+// tests assert on. Binding only these fields keeps the tests robust to
+// unrelated predicate growth.
+type vsaShape struct {
+	Predicate struct {
+		VerifiedLevels []string `json:"verifiedLevels"`
+		SlsaVersion    string   `json:"slsaVersion"`
+	} `json:"predicate"`
+}
+
+// resultWithControls builds a passing *papi.Result for digest carrying
+// the given controls, so the VSA writers have levels to lift.
+func resultWithControls(digest string, controls ...*papi.Control) *papi.Result {
+	return &papi.Result{
+		Subject:   newSubject(digest),
+		Status:    papi.StatusPASS,
+		DateStart: timestamppb.Now(),
+		DateEnd:   timestamppb.Now(),
+		Meta:      &papi.Meta{Controls: controls},
+	}
+}
+
+// emitVSA renders results as a VSA and returns the parsed predicate
+// fields the tests assert on.
+func emitVSA(t *testing.T, results papi.Results) vsaShape {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := New().AttestTo(&buf, results, WithFormat("vsa")); err != nil {
+		t.Fatalf("AttestTo vsa: %v", err)
+	}
+	var got vsaShape
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshaling vsa: %v\nbody: %s", err, buf.String())
+	}
+	return got
+}
+
+// A WRANGLE-framework control reaches verifiedLevels on both writer
+// paths, and because it is not a SLSA-track level it must not stamp
+// slsaVersion on the VSA.
+func TestVSA_NamespacedLevel_NoSlsaVersion(t *testing.T) {
+	wrangle := &papi.Control{Framework: "WRANGLE", Id: "RELEASE_PINNED"}
+
+	t.Run("ResultSet", func(t *testing.T) {
+		rs := newResultSet(t, "deadbeef")
+		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{wrangle}}
+		got := emitVSA(t, rs)
+		if !slices.Contains(got.Predicate.VerifiedLevels, "WRANGLE_RELEASE_PINNED") {
+			t.Errorf("verifiedLevels = %v, want WRANGLE_RELEASE_PINNED", got.Predicate.VerifiedLevels)
+		}
+		if got.Predicate.SlsaVersion != "" {
+			t.Errorf("slsaVersion = %q, want empty for a non-SLSA level", got.Predicate.SlsaVersion)
+		}
+	})
+
+	t.Run("Result", func(t *testing.T) {
+		got := emitVSA(t, resultWithControls("deadbeef", wrangle))
+		if !slices.Contains(got.Predicate.VerifiedLevels, "WRANGLE_RELEASE_PINNED") {
+			t.Errorf("verifiedLevels = %v, want WRANGLE_RELEASE_PINNED", got.Predicate.VerifiedLevels)
+		}
+		if got.Predicate.SlsaVersion != "" {
+			t.Errorf("slsaVersion = %q, want empty for a non-SLSA level", got.Predicate.SlsaVersion)
+		}
+	})
+}
+
+// A SLSA-track control alongside a namespaced one yields both levels
+// and still stamps slsaVersion (the SLSA level is what gates it).
+func TestVSA_MixedLevels_StampsSlsaVersion(t *testing.T) {
+	slsa := &papi.Control{Framework: "SLSA", Class: "BUILD", Id: "LEVEL_3"}
+	wrangle := &papi.Control{Framework: "WRANGLE", Id: "RELEASE_PINNED"}
+
+	t.Run("ResultSet", func(t *testing.T) {
+		rs := newResultSet(t, "deadbeef")
+		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{slsa, wrangle}}
+		got := emitVSA(t, rs)
+		for _, want := range []string{"SLSA_BUILD_LEVEL_3", "WRANGLE_RELEASE_PINNED"} {
+			if !slices.Contains(got.Predicate.VerifiedLevels, want) {
+				t.Errorf("verifiedLevels = %v, want %s", got.Predicate.VerifiedLevels, want)
+			}
+		}
+		if got.Predicate.SlsaVersion != slsaVersion {
+			t.Errorf("slsaVersion = %q, want %q", got.Predicate.SlsaVersion, slsaVersion)
+		}
+	})
+
+	t.Run("Result", func(t *testing.T) {
+		got := emitVSA(t, resultWithControls("deadbeef", slsa, wrangle))
+		for _, want := range []string{"SLSA_BUILD_LEVEL_3", "WRANGLE_RELEASE_PINNED"} {
+			if !slices.Contains(got.Predicate.VerifiedLevels, want) {
+				t.Errorf("verifiedLevels = %v, want %s", got.Predicate.VerifiedLevels, want)
+			}
+		}
+		if got.Predicate.SlsaVersion != slsaVersion {
+			t.Errorf("slsaVersion = %q, want %q", got.Predicate.SlsaVersion, slsaVersion)
+		}
+	})
+}
+
+// A control with an empty Id has no label and must never reach
+// verifiedLevels — the guard that prevents an empty-string entry once
+// the SLSA_ prefix filter no longer drops it.
+func TestVSA_EmptyIdControl_Dropped(t *testing.T) {
+	empty := &papi.Control{Framework: "WRANGLE"}
+
+	t.Run("ResultSet", func(t *testing.T) {
+		rs := newResultSet(t, "deadbeef")
+		rs.Results[0].Meta = &papi.Meta{Controls: []*papi.Control{empty}}
+		got := emitVSA(t, rs)
+		if slices.Contains(got.Predicate.VerifiedLevels, "") {
+			t.Errorf("verifiedLevels contains an empty entry: %v", got.Predicate.VerifiedLevels)
+		}
+	})
+
+	t.Run("Result", func(t *testing.T) {
+		got := emitVSA(t, resultWithControls("deadbeef", empty))
+		if slices.Contains(got.Predicate.VerifiedLevels, "") {
+			t.Errorf("verifiedLevels contains an empty entry: %v", got.Predicate.VerifiedLevels)
+		}
+	})
+}
+
+// Controls from a result whose subject differs from the policyset
+// subject are dependency levels, not verifiedLevels — this split must
+// hold for namespaced controls just as it does for SLSA ones.
+func TestVSA_NamespacedDependencyLevel(t *testing.T) {
+	rs := newResultSet(t, "deadbeef")
+	dep := resultWithControls("feedface", &papi.Control{Framework: "WRANGLE", Id: "RELEASE_PINNED"})
+	rs.Results = append(rs.Results, dep)
+
+	var buf bytes.Buffer
+	if err := New().AttestTo(&buf, rs, WithFormat("vsa")); err != nil {
+		t.Fatalf("AttestTo vsa: %v", err)
+	}
+	var got struct {
+		Predicate struct {
+			VerifiedLevels []string `json:"verifiedLevels"`
+			// protojson encodes the uint64 dependency counts as strings.
+			DependencyLevels map[string]string `json:"dependencyLevels"`
+		} `json:"predicate"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshaling vsa: %v\nbody: %s", err, buf.String())
+	}
+	if got.Predicate.DependencyLevels["WRANGLE_RELEASE_PINNED"] != "1" {
+		t.Errorf("dependencyLevels = %v, want WRANGLE_RELEASE_PINNED:1", got.Predicate.DependencyLevels)
+	}
+	if slices.Contains(got.Predicate.VerifiedLevels, "WRANGLE_RELEASE_PINNED") {
+		t.Errorf("dependency level leaked into verifiedLevels: %v", got.Predicate.VerifiedLevels)
+	}
+}


### PR DESCRIPTION
I'd like to be able to encode non-SLSA results in verifiedLevels. This is [allowed by the spec](https://slsa.dev/spec/v1.2/verification_summary#slsaresult) and actually [encouraged](https://slsa.dev/spec/v1.2/verified-properties) for "verifiedProperties". I'm hoping to use this in Wrangle to encode things like "has an SBOM" and to mark some subtle differences in the quality of the provenance (https://github.com/TomHennen/wrangle/issues/424), but not being able to encode custom properties in verifiedLevels is blocking that.

This stops the VSA writers from dropping control labels that don't start with SLSA_, while keeping the SLSA_ prefix as the gate for slsaVersion — so a VSA carrying only custom levels doesn't falsely claim a SLSA version. Also adds the empty-Id guard to writeVSAFromResult so an id-less control can't append an empty label now that the prefix filter no longer screens it out.