### PR TITLE
fix: propagate policyFail flag when evaluateChain returns an error

### DIFF
--- a/pkg/verifier/group_test.go
+++ b/pkg/verifier/group_test.go
@@ -14,6 +14,89 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
 
+func TestPolicyGroupEnforceOFF(t *testing.T) {
+	t.Parallel()
+
+	passingPolicy := &papi.Policy{
+		Id:   "pass",
+		Meta: &papi.Meta{AssertMode: "OR"},
+		Tenets: []*papi.Tenet{
+			{Id: "t1", Code: "true"},
+		},
+	}
+
+	failingPolicy := &papi.Policy{
+		Id:   "fail",
+		Meta: &papi.Meta{AssertMode: "OR"},
+		Tenets: []*papi.Tenet{
+			{Id: "t1", Code: "false", Error: &papi.Error{Message: "expected failure"}},
+		},
+	}
+
+	subject := &gointoto.ResourceDescriptor{
+		Name:   "test-subject",
+		Digest: map[string]string{"sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+	}
+
+	for _, tc := range []struct {
+		name           string
+		group          *papi.PolicyGroup
+		expectedStatus string
+	}{
+		{
+			name: "enforce-OFF-failing-group-softfails",
+			group: &papi.PolicyGroup{
+				Id:   "group-enforce-off-fail",
+				Meta: &papi.PolicyGroupMeta{Enforce: "OFF"},
+				Blocks: []*papi.PolicyBlock{
+					{Id: "block-1", Meta: &papi.PolicyBlockMeta{}, Policies: []*papi.Policy{failingPolicy}},
+				},
+			},
+			expectedStatus: papi.StatusSOFTFAIL,
+		},
+		{
+			name: "enforce-OFF-passing-group-still-passes",
+			group: &papi.PolicyGroup{
+				Id:   "group-enforce-off-pass",
+				Meta: &papi.PolicyGroupMeta{Enforce: "OFF"},
+				Blocks: []*papi.PolicyBlock{
+					{Id: "block-1", Meta: &papi.PolicyBlockMeta{}, Policies: []*papi.Policy{passingPolicy}},
+				},
+			},
+			expectedStatus: papi.StatusPASS,
+		},
+		{
+			name: "enforce-ON-failing-group-hard-fails",
+			group: &papi.PolicyGroup{
+				Id:   "group-enforce-on-fail",
+				Meta: &papi.PolicyGroupMeta{},
+				Blocks: []*papi.PolicyBlock{
+					{Id: "block-1", Meta: &papi.PolicyBlockMeta{}, Policies: []*papi.Policy{failingPolicy}},
+				},
+			},
+			expectedStatus: papi.StatusFAIL,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &VerificationOptions{
+				EvaluatorOptions:    options.Default,
+				DefaultEvaluator:    DefaultVerificationOptions.DefaultEvaluator,
+				EnforceExpiration:   false,
+				AllowEmptySetChains: true,
+			}
+
+			ampel, err := New()
+			require.NoError(t, err)
+
+			res, err := ampel.VerifySubjectWithPolicyGroup(context.Background(), opts, tc.group, subject)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Equal(t, tc.expectedStatus, res.GetStatus())
+		})
+	}
+}
+
 func TestPolicyGroupAssertMode(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -324,14 +324,14 @@ func (di *defaultIplementation) AssertResult(policy *papi.Policy, result *papi.R
 			}
 		}
 		result.Status = papi.StatusFAIL
-		if policy.GetMeta().GetEnforce() == "OFF" {
+		if policy.GetMeta().GetEnforce() == enforceOFF {
 			result.Status = papi.StatusSOFTFAIL
 		}
 	case assertModeAND:
 		for _, er := range result.EvalResults {
 			if er.Status == papi.StatusFAIL {
 				result.Status = papi.StatusFAIL
-				if policy.GetMeta().GetEnforce() == "OFF" {
+				if policy.GetMeta().GetEnforce() == enforceOFF {
 					result.Status = papi.StatusSOFTFAIL
 				}
 				return nil

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -35,6 +35,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/transformer"
 )
 
+const defaultEvaluatorClass = "default"
+
 // AmpelImplementation
 type AmpelVerifier interface {
 	// CheckPolicy verifies the policy is sound to evaluate before running it
@@ -364,7 +366,7 @@ func (di *defaultIplementation) BuildEvaluators(opts *VerificationOptions, p *pa
 		return nil, fmt.Errorf("unable to build default runtime: %w", err)
 	}
 	logrus.Debugf("Registered default evaluator of class %s", def)
-	evaluators[class.Class("default")] = e
+	evaluators[class.Class(defaultEvaluatorClass)] = e
 	evaluators[def] = e
 	if p.GetMeta().GetRuntime() != "" {
 		evaluators[class.Class(p.GetMeta().GetRuntime())] = e
@@ -791,7 +793,7 @@ func (di *defaultIplementation) ProcessChainedSubjects(
 		attestations, ids, defaultEvalClass,
 	)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, fail, err
 	}
 
 	if len(subjects) > 1 {
@@ -975,7 +977,7 @@ func (di *defaultIplementation) AssembleEvalContextValues(
 			}
 			cls := class.Class(contextDef.GetRuntime())
 			if cls == "" {
-				cls = "default"
+				cls = defaultEvaluatorClass
 			}
 			ev, ok := evaluators[cls]
 			if !ok {
@@ -1066,7 +1068,7 @@ func (di *defaultIplementation) VerifySubject(
 	for i, tenet := range p.Tenets {
 		key := class.Class(tenet.Runtime)
 		if key == "" {
-			key = class.Class("default")
+			key = class.Class(defaultEvaluatorClass)
 		}
 
 		// Filter the predicates to those requested by the tenet or the policy:
@@ -1212,7 +1214,7 @@ func (di *defaultIplementation) ProcessPolicySetChainedSubjects(
 		attestations, policySet.GetCommon().GetIdentities(), defaultEvalClass,
 	)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, fail, err
 	}
 
 	return subjects, chain, fail, nil

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -636,6 +636,127 @@ func TestFilterAttestationsSkipsNonAdmitted(t *testing.T) {
 	require.Len(t, preds, 2, "only admitted envelopes should produce predicates")
 }
 
+// TestProcessChainedSubjectsPropagatesFailFlag verifies that ProcessChainedSubjects
+// propagates policyFail=true when evaluateChain returns both an error and fail=true.
+// This covers the bug where the fail flag was discarded (hardcoded false) on error.
+//
+// The scenario: a chain link requires predicate type "https://example.com/nonexistent"
+// but the loaded attestation is an SPDX document. evaluateChain finds no matching
+// attestations and returns (nil, nil, true, PolicyError{...}). ProcessChainedSubjects
+// must surface fail=true to the caller unchanged.
+func TestProcessChainedSubjectsPropagatesFailFlag(t *testing.T) {
+	t.Parallel()
+
+	di := &defaultIplementation{}
+	factory := evaluator.Factory{}
+
+	def, err := factory.Get(&eoptions.Default, DefaultVerificationOptions.DefaultEvaluator)
+	require.NoError(t, err)
+	evaluators := map[class.Class]evaluator.Evaluator{
+		"default": def,
+		DefaultVerificationOptions.DefaultEvaluator: def,
+	}
+
+	subject := &gointoto.ResourceDescriptor{
+		Name: "test",
+		Digest: map[string]string{
+			"sha256": "851074691728c479a4c83628de8310eaca792cc7",
+		},
+	}
+
+	// Build a policy with a chain link that requires a predicate type that does
+	// not exist in the loaded attestation. evaluateChain will return fail=true
+	// with a PolicyError when no matching attestations are found.
+	policy := &papi.Policy{
+		Chain: []*papi.ChainLink{
+			{
+				Source: &papi.ChainLink_Predicate{
+					Predicate: &papi.ChainedPredicate{
+						Type:     "https://example.com/nonexistent",
+						Selector: `"sha256:0000000000000000000000000000000000000000000000000000000000000000"`,
+					},
+				},
+			},
+		},
+	}
+
+	opts := DefaultVerificationOptions
+	opts.AttestationFiles = []string{"testdata/wtf-frontend.spdx.json"}
+
+	attestations, err := di.ParseAttestations(t.Context(), &opts, subject)
+	require.NoError(t, err)
+
+	_, _, fail, gotErr := di.ProcessChainedSubjects(
+		t.Context(), &opts, evaluators,
+		nil, // collector agent not required for this test
+		policy,
+		nil, // no context values
+		subject,
+		attestations,
+	)
+
+	require.Error(t, gotErr, "ProcessChainedSubjects must return an error when the chain cannot be satisfied")
+	require.True(t, fail, "policyFail must be true when evaluateChain returns fail=true with an error")
+	require.IsType(t, PolicyError{}, gotErr, "error must be a PolicyError") //nolint:testifylint // Checking for type, not value
+}
+
+// TestProcessPolicySetChainedSubjectsPropagatesFailFlag is the PolicySet
+// equivalent of TestProcessChainedSubjectsPropagatesFailFlag. It verifies that
+// ProcessPolicySetChainedSubjects propagates policyFail=true when evaluateChain
+// returns both an error and fail=true, rather than hardcoding false.
+func TestProcessPolicySetChainedSubjectsPropagatesFailFlag(t *testing.T) {
+	t.Parallel()
+
+	di := &defaultIplementation{}
+	factory := evaluator.Factory{}
+
+	def, err := factory.Get(&eoptions.Default, DefaultVerificationOptions.DefaultEvaluator)
+	require.NoError(t, err)
+	evaluators := map[class.Class]evaluator.Evaluator{
+		"default": def,
+		DefaultVerificationOptions.DefaultEvaluator: def,
+	}
+
+	subject := &gointoto.ResourceDescriptor{
+		Name: "test",
+		Digest: map[string]string{
+			"sha256": "851074691728c479a4c83628de8310eaca792cc7",
+		},
+	}
+
+	policySet := &papi.PolicySet{
+		Chain: []*papi.ChainLink{
+			{
+				Source: &papi.ChainLink_Predicate{
+					Predicate: &papi.ChainedPredicate{
+						Type:     "https://example.com/nonexistent",
+						Selector: `"sha256:0000000000000000000000000000000000000000000000000000000000000000"`,
+					},
+				},
+			},
+		},
+	}
+
+	opts := DefaultVerificationOptions
+	opts.AttestationFiles = []string{"testdata/wtf-frontend.spdx.json"}
+
+	attestations, err := di.ParseAttestations(t.Context(), &opts, subject)
+	require.NoError(t, err)
+
+	_, _, fail, gotErr := di.ProcessPolicySetChainedSubjects(
+		t.Context(), &opts, evaluators,
+		nil,
+		policySet,
+		nil,
+		subject,
+		attestations,
+	)
+
+	require.Error(t, gotErr)
+	require.True(t, fail, "policyFail must be true when evaluateChain returns fail=true with an error")
+	require.IsType(t, PolicyError{}, gotErr, "error must be a PolicyError") //nolint:testifylint // Checking for type, not value
+}
+
 // TestVerifySubjectErrOnMissingAttestations covers the ErrOnMissingAttestations
 // option: when off (default) a tenet that requires predicates but receives none
 // produces a failed EvalResult with the sentinel in Error.Message and no

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -30,6 +30,7 @@ import (
 const (
 	assertModeAND = "AND"
 	assertModeOR  = "OR"
+	enforceOFF    = "OFF"
 )
 
 type PolicyError struct {
@@ -610,7 +611,7 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 
 	// If the group has enforce OFF, downgrade FAIL to SOFTFAIL so the result
 	// is informational rather than blocking.
-	if res.Status == papi.StatusFAIL && group.GetMeta().GetEnforce() == "OFF" {
+	if res.Status == papi.StatusFAIL && group.GetMeta().GetEnforce() == enforceOFF {
 		res.Status = papi.StatusSOFTFAIL
 	}
 

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -608,6 +608,12 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 		res.Error = fmt.Sprintf("Evaluation failed by blocks [%s]", strings.Join(fails, ", "))
 	}
 
+	// If the group has enforce OFF, downgrade FAIL to SOFTFAIL so the result
+	// is informational rather than blocking.
+	if res.Status == papi.StatusFAIL && group.GetMeta().GetEnforce() == "OFF" {
+		res.Status = papi.StatusSOFTFAIL
+	}
+
 	// Record the end of the group eval
 	res.DateEnd = timestamppb.Now()
 	return res, nil


### PR DESCRIPTION

fix: propagate policyFail flag when evaluateChain returns an error

ProcessChainedSubjects called evaluateChain which returns both an error and a policyFail bool. When both were set, the bool was hardcoded to false on return, so callers could not distinguish a policy failure from a system error, causing chain evaluation failures to be misreported.

Adds TestProcessChainedSubjectsPropagatesFailFlag to cover the scenario where no matching attestations are found for a chain link.

fix: downgrade PolicyGroup FAIL to SOFTFAIL when enforce is OFF

VerifySubjectWithPolicyGroup was not honoring the group-level enforce flag. When enforce is set to OFF, a failing group should produce a SOFTFAIL (informational) result rather than a hard FAIL, consistent with how BuildPolicyEvalResult handles the policy-level enforce flag.

Adds TestPolicyGroupEnforceOFF covering failing/passing groups with enforce OFF and enforce ON.

fix: extract repeated string literals into named constants

Replace repeated "default" and "OFF" string literals with named constants defaultEvaluatorClass and enforceOFF to satisfy the goconst linter.