### PR TITLE
Fix worker-count-dependent policy verdicts (#298)

### DIFF
--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -24,6 +24,7 @@ import (
 	sapi "github.com/carabiner-dev/signer/api/v1"
 	gointoto "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -247,9 +248,18 @@ func (di *defaultIplementation) GatherAttestations(
 	).Run(attestations, attestation.WithMode(attestation.QueryModeOr))
 
 	// Pass any verification keys to the collector so it can verify
-	// signatures on fetched attestations (e.g. keys embedded in policies).
+	// signatures on fetched attestations (e.g. keys embedded in policies). The
+	// agent (and its key set) is shared across the concurrently-evaluated
+	// policies and groups of a run, and AddKeys is not internally synchronized,
+	// so guard it with the per-run evidence lock (nil outside a fan-out).
 	if len(opts.Keys) > 0 {
-		agent.AddKeys(opts.Keys...)
+		if mu := sharedEvidenceLock(ctx); mu != nil {
+			mu.Lock()
+			agent.AddKeys(opts.Keys...)
+			mu.Unlock()
+		} else {
+			agent.AddKeys(opts.Keys...)
+		}
 	}
 
 	// Now, query the collector to get all attestations available for the artifact.
@@ -516,7 +526,15 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 	}
 
 	// Verify signatures and collect only envelopes with a matching identity.
+	// The envelopes are shared across the concurrently-evaluated policies of a
+	// PolicySet, and their verification is cached/recomputed on the shared
+	// predicate, so serialize the verify-and-match step under the per-run lock
+	// published on the context (nil outside a concurrent fan-out).
 	validSigners := make([][]*sapi.Identity, len(envelopes))
+	if mu := sharedEvidenceLock(ctx); mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
 	for i, e := range envelopes {
 		if err := e.Verify(keys); err != nil {
 			logrus.Debugf("attestation %d (type %s): signature verification error, skipping: %v", i, e.GetStatement().GetType(), err)
@@ -562,6 +580,9 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 // verified against the policy when ingesting the attestations. Envelopes whose
 // identity list is empty (not admitted by CheckIdentities) are excluded.
 //
+// The matched identities are exposed to the evaluator through a per-policy
+// matchedPredicate wrapper rather than by mutating the shared predicate.
+//
 // TODO(puerco): Implement filtering before 1.0
 func (di *defaultIplementation) FilterAttestations(opts *VerificationOptions, subject attestation.Subject, envs []attestation.Envelope, ids [][]*sapi.Identity) ([]attestation.Predicate, error) {
 	preds := make([]attestation.Predicate, 0, len(envs))
@@ -575,16 +596,37 @@ func (di *defaultIplementation) FilterAttestations(opts *VerificationOptions, su
 		if ids != nil {
 			matchedIds = ids[i]
 		}
-		pred.SetVerification(&sapi.Verification{
-			Signature: &sapi.SignatureVerification{
-				Date:       timestamppb.Now(),
-				Verified:   true,
-				Identities: matchedIds,
+		preds = append(preds, &matchedPredicate{
+			Predicate: pred,
+			verification: &sapi.Verification{
+				Signature: &sapi.SignatureVerification{
+					Date:       timestamppb.Now(),
+					Verified:   true,
+					Identities: matchedIds,
+				},
 			},
 		})
-		preds = append(preds, pred)
 	}
 	return preds, nil
+}
+
+// matchedPredicate wraps a shared attestation.Predicate to carry the identities
+// the signer matched for a single policy without mutating the underlying
+// predicate, which is shared across the policies of a PolicySet. It overrides
+// the verification accessors so the evaluator sees the per-policy matched
+// identities while leaving the shared predicate (and the signer identity cached
+// on its envelope) untouched. See FilterAttestations and issue #298.
+type matchedPredicate struct {
+	attestation.Predicate
+	verification attestation.Verification
+}
+
+func (mp *matchedPredicate) GetVerification() attestation.Verification {
+	return mp.verification
+}
+
+func (mp *matchedPredicate) SetVerification(v attestation.Verification) {
+	mp.verification = v
 }
 
 // evaluateChain evaluates an evidence chain and returns the resulting subject
@@ -828,6 +870,22 @@ func newResourceDescriptorFromSubject(s attestation.Subject) *gointoto.ResourceD
 	}
 }
 
+// mergeContextValClone returns base with over merged into it, without mutating
+// base. base may be a *papi.ContextVal shared by reference across the
+// concurrently evaluated policies of a run (e.g. inherited from the PolicySet
+// common context), so it is cloned before merging (issue #298).
+func mergeContextValClone(base, over *papi.ContextVal) *papi.ContextVal {
+	merged, ok := proto.Clone(base).(*papi.ContextVal)
+	if !ok {
+		// proto.Clone of a *papi.ContextVal always returns a *papi.ContextVal;
+		// rebuild from base on the unreachable miss so we still never mutate it.
+		merged = &papi.ContextVal{}
+		merged.Merge(base)
+	}
+	merged.Merge(over)
+	return merged
+}
+
 // AssembleEvalContextValues puts together the context values map by assembling
 // the context definition starting with its defaults, received values from
 // upstream and context value providers.
@@ -888,8 +946,12 @@ func (di *defaultIplementation) AssembleEvalContextValues(
 		}
 		lcnames[strings.ToLower(k)] = k
 		// Validate the key? Probably in a policy validation func
-		if _, ok := assembledContext[k]; ok {
-			assembledContext[k].Merge(def)
+		if existing, ok := assembledContext[k]; ok {
+			// The existing value may be inherited from the PolicySet common
+			// context, which is shared by reference across the concurrently
+			// evaluated policies. Merge into a clone so the policy's own
+			// context definition never mutates that shared object (issue #298).
+			assembledContext[k] = mergeContextValClone(existing, def)
 		} else {
 			assembledContext[k] = def
 		}

--- a/pkg/verifier/shared_envelope_test.go
+++ b/pkg/verifier/shared_envelope_test.go
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/carabiner-dev/collector"
+	"github.com/carabiner-dev/collector/predicate/generic"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	sapi "github.com/carabiner-dev/signer/api/v1"
+	"github.com/carabiner-dev/signer/key"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKey is a no-op key.PublicKeyProvider; GatherAttestations only appends it
+// to the shared collector key set, so its contents are irrelevant here.
+type fakeKey struct{}
+
+func (fakeKey) PublicKey() (*key.Public, error) { return &key.Public{}, nil }
+
+// fakePredicate is a minimal attestation.Predicate backed by the generic
+// predicate so SetVerification/GetVerification behave like a real one.
+type sharedFakeStatement struct {
+	pred attestation.Predicate
+}
+
+func (s *sharedFakeStatement) GetSubjects() []attestation.Subject          { return nil }
+func (s *sharedFakeStatement) GetPredicate() attestation.Predicate         { return s.pred }
+func (s *sharedFakeStatement) GetPredicateType() attestation.PredicateType { return "test/v1" }
+func (s *sharedFakeStatement) GetType() string                             { return "https://in-toto.io/Statement/v1" }
+func (s *sharedFakeStatement) GetVerification() attestation.Verification {
+	return s.pred.GetVerification()
+}
+
+// sharedFakeEnvelope emulates a sigstore bundle envelope: Verify() resolves the
+// concrete signer identity from the (mocked) signing material exactly once and
+// caches it on the predicate, returning early on subsequent calls. This is the
+// behavior in collector/envelope/bundle that, combined with sharing envelopes
+// across policy evaluations, exposes the issue #298 corruption.
+type sharedFakeEnvelope struct {
+	stmt   *sharedFakeStatement
+	signer *sapi.Identity
+}
+
+func newSharedFakeEnvelope(signer *sapi.Identity) *sharedFakeEnvelope {
+	return &sharedFakeEnvelope{
+		stmt:   &sharedFakeStatement{pred: &generic.Predicate{Type: "test/v1"}},
+		signer: signer,
+	}
+}
+
+func (e *sharedFakeEnvelope) GetStatement() attestation.Statement     { return e.stmt }
+func (e *sharedFakeEnvelope) GetPredicate() attestation.Predicate     { return e.stmt.pred }
+func (e *sharedFakeEnvelope) GetSignatures() []attestation.Signature  { return nil }
+func (e *sharedFakeEnvelope) GetCertificate() attestation.Certificate { return nil }
+func (e *sharedFakeEnvelope) GetVerification() attestation.Verification {
+	return e.stmt.pred.GetVerification()
+}
+
+func (e *sharedFakeEnvelope) Verify(_ ...any) error {
+	// Emulate the bundle envelope cache: the concrete signer identity is
+	// resolved once from the signing material and never recomputed.
+	if e.GetVerification() != nil {
+		return nil
+	}
+	e.stmt.pred.SetVerification(&sapi.Verification{
+		Signature: &sapi.SignatureVerification{
+			Verified:   true,
+			Identities: []*sapi.Identity{e.signer},
+		},
+	})
+	return nil
+}
+
+// concreteSigner is the identity actually carried by the signing material.
+func concreteSigner() *sapi.Identity {
+	return &sapi.Identity{
+		Sigstore: &sapi.IdentitySigstore{
+			Issuer:   "https://token.actions.githubusercontent.com",
+			Identity: "https://github.com/org/repo/.github/workflows/build.yml@refs/tags/v1.0.0",
+		},
+	}
+}
+
+// policyIdentity binds to the signer through matchers (not concrete values),
+// mirroring how real policies pin builders. The matched identity restamped by
+// the old FilterAttestations therefore carries empty Issuer/Identity, which is
+// what corrupts later identity checks.
+func policyIdentity() *sapi.Identity {
+	return &sapi.Identity{
+		Id: "wrangle-builder",
+		Sigstore: &sapi.IdentitySigstore{
+			IssuerMatch: &sapi.StringMatcher{
+				Kind: &sapi.StringMatcher_Exact{Exact: "https://token.actions.githubusercontent.com"},
+			},
+			IdentityMatch: &sapi.StringMatcher{
+				Kind: &sapi.StringMatcher_Regex{
+					Regex: "https://github.com/org/repo/.github/workflows/build.yml@.+",
+				},
+			},
+		},
+	}
+}
+
+// TestFilterAttestationsDoesNotMutateSharedEnvelope asserts the core invariant
+// behind issue #298: FilterAttestations must not overwrite the signer-identity
+// verification cached on the (shared) envelope. The old implementation called
+// pred.SetVerification with the per-policy matched identities, poisoning the
+// cache for every other policy that shares the same envelope.
+func TestFilterAttestationsDoesNotMutateSharedEnvelope(t *testing.T) {
+	t.Parallel()
+	di := &defaultIplementation{}
+	opts := &VerificationOptions{}
+	subject := &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": "aaaa0000000000000000000000000000000000000000000000000000000000aa"},
+	}
+
+	env := newSharedFakeEnvelope(concreteSigner())
+	envs := []attestation.Envelope{env}
+	ids := [][]*sapi.Identity{{policyIdentity()}}
+
+	// Establish the signer-identity verification as Verify() would.
+	require.NoError(t, env.Verify())
+	before := env.GetVerification()
+	require.NotNil(t, before)
+	require.True(t, before.MatchesIdentity(policyIdentity()),
+		"sanity: signer identity must match the policy identity before filtering")
+
+	if _, err := di.FilterAttestations(opts, subject, envs, ids); err != nil {
+		t.Fatalf("FilterAttestations: %v", err)
+	}
+
+	// The shared envelope's verification must still be the signer identity.
+	require.True(t, env.GetVerification().MatchesIdentity(policyIdentity()),
+		"FilterAttestations must not overwrite the shared envelope's signer identity")
+}
+
+// TestCheckIdentitiesWorkerIndependentSharing reproduces the issue #298 symptom
+// at the function level: two policies sharing the same envelope must both admit
+// the attestation. The first policy's FilterAttestations call used to corrupt
+// the shared verification so the second CheckIdentities spuriously failed.
+func TestCheckIdentitiesWorkerIndependentSharing(t *testing.T) {
+	t.Parallel()
+	di := &defaultIplementation{}
+	opts := &VerificationOptions{}
+	subject := &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": "aaaa0000000000000000000000000000000000000000000000000000000000aa"},
+	}
+	ctx := context.Background()
+
+	env := newSharedFakeEnvelope(concreteSigner())
+	envs := []attestation.Envelope{env}
+
+	// Policy A: admit, then filter (this is where the shared mutation happened).
+	allowA, idsA, errsA, err := di.CheckIdentities(ctx, opts, []*sapi.Identity{policyIdentity()}, envs)
+	require.NoError(t, err)
+	require.True(t, allowA, "policy A must admit the attestation: %v", errsA)
+	if _, err := di.FilterAttestations(opts, subject, envs, idsA); err != nil {
+		t.Fatalf("FilterAttestations: %v", err)
+	}
+
+	// Policy B shares the same envelope. It must still admit the attestation,
+	// independent of whether policy A ran first.
+	allowB, _, errsB, err := di.CheckIdentities(ctx, opts, []*sapi.Identity{policyIdentity()}, envs)
+	require.NoError(t, err)
+	require.True(t, allowB, "policy B must still admit the attestation after policy A filtered: %v", errsB)
+}
+
+// TestCheckIdentitiesRejectsWrongIdentity locks in the fail-closed property:
+// an attestation whose signer does not match the policy identity must be
+// rejected, and that rejection must survive a prior policy filtering the shared
+// envelope (i.e. the shared-state fix must not accidentally admit a wrong
+// signer).
+func TestCheckIdentitiesRejectsWrongIdentity(t *testing.T) {
+	t.Parallel()
+	di := &defaultIplementation{}
+	opts := &VerificationOptions{}
+	subject := &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": "aaaa0000000000000000000000000000000000000000000000000000000000aa"},
+	}
+	ctx := context.Background()
+
+	env := newSharedFakeEnvelope(concreteSigner())
+	envs := []attestation.Envelope{env}
+
+	// A correctly-matching policy admits and filters the shared envelope first.
+	allow, ids, _, err := di.CheckIdentities(ctx, opts, []*sapi.Identity{policyIdentity()}, envs)
+	require.NoError(t, err)
+	require.True(t, allow)
+	if _, err := di.FilterAttestations(opts, subject, envs, ids); err != nil {
+		t.Fatalf("FilterAttestations: %v", err)
+	}
+
+	// A policy binding a different identity must NOT be admitted.
+	wrong := &sapi.Identity{
+		Id: "wrong-builder",
+		Sigstore: &sapi.IdentitySigstore{
+			IssuerMatch: &sapi.StringMatcher{
+				Kind: &sapi.StringMatcher_Exact{Exact: "https://token.actions.githubusercontent.com"},
+			},
+			IdentityMatch: &sapi.StringMatcher{
+				Kind: &sapi.StringMatcher_Exact{Exact: "https://github.com/org/repo/.github/workflows/other.yml@refs/tags/v1.0.0"},
+			},
+		},
+	}
+	allowWrong, _, _, err := di.CheckIdentities(ctx, opts, []*sapi.Identity{wrong}, envs)
+	require.NoError(t, err)
+	require.False(t, allowWrong, "an attestation signed by a non-matching identity must be rejected")
+}
+
+// TestCheckIdentitiesConcurrentSharing exercises the concurrent path: many
+// policies verifying the same shared envelopes at once. It publishes the
+// per-run lock on the context exactly as VerifySubjectWithPolicySet does. Run
+// with -race to catch concurrent reads/writes of the shared verification.
+func TestCheckIdentitiesConcurrentSharing(t *testing.T) {
+	t.Parallel()
+	di := &defaultIplementation{}
+	opts := &VerificationOptions{}
+	subject := &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": "aaaa0000000000000000000000000000000000000000000000000000000000aa"},
+	}
+	ctx := context.WithValue(context.Background(), sharedEvidenceLockKey{}, &sync.Mutex{})
+
+	env := newSharedFakeEnvelope(concreteSigner())
+	envs := []attestation.Envelope{env}
+
+	var wg sync.WaitGroup
+	results := make([]bool, 16)
+	for i := range results {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			allow, ids, _, err := di.CheckIdentities(ctx, opts, []*sapi.Identity{policyIdentity()}, envs)
+			if err != nil {
+				return
+			}
+			if _, err := di.FilterAttestations(opts, subject, envs, ids); err != nil {
+				t.Errorf("FilterAttestations: %v", err)
+				return
+			}
+			results[idx] = allow
+		}(i)
+	}
+	wg.Wait()
+
+	for i, allow := range results {
+		require.True(t, allow, "goroutine %d must admit the shared attestation", i)
+	}
+}
+
+// TestGatherAttestationsConcurrentKeyDistribution exercises the shared collector
+// agent: the per-policy GatherAttestations distributes verification keys into
+// the one agent shared across a run's concurrent policies/groups. AddKeys is not
+// internally synchronized, so without the per-run evidence lock this races on
+// the agent's key slice. It publishes the lock as VerifySubjectWithPolicySet
+// does; run with -race.
+func TestGatherAttestationsConcurrentKeyDistribution(t *testing.T) {
+	t.Parallel()
+	di := &defaultIplementation{}
+	agent, err := collector.New()
+	require.NoError(t, err)
+
+	opts := &VerificationOptions{Keys: []key.PublicKeyProvider{fakeKey{}, fakeKey{}}}
+	subject := &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha256": "aaaa0000000000000000000000000000000000000000000000000000000000aa"},
+	}
+	policy := &papi.Policy{Id: "p"}
+	ctx := context.WithValue(context.Background(), sharedEvidenceLockKey{}, &sync.Mutex{})
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// No fetcher repos are configured, so this returns no envelopes; the
+			// point is the AddKeys call on the shared agent before the fetch.
+			if _, err := di.GatherAttestations(ctx, opts, agent, policy, subject, nil); err != nil {
+				t.Errorf("GatherAttestations: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -38,6 +38,28 @@ type PolicyError struct {
 	Guidance string
 }
 
+// sharedEvidenceLockKey is the context key under which VerifySubjectWithPolicySet
+// publishes a per-run mutex. The policies and groups of a set are evaluated
+// concurrently but share evidence-handling state: the attestation envelopes
+// (whose Verify() caches/recomputes verification on the shared predicate) and
+// the collector agent (whose AddKeys mutates a shared key set). The lock
+// serializes mutation of that shared state for one run; it is scoped to the run
+// (not the verifier) so unrelated runs proceed in parallel. See
+// sharedEvidenceLock and issue #298.
+type sharedEvidenceLockKey struct{}
+
+// sharedEvidenceLock returns the per-run evidence lock published on the context,
+// or nil when none is set. A nil lock means the caller is not part of a
+// concurrent fan-out (e.g. a single policy verified directly), so the shared
+// envelopes and collector are not at risk and no locking is required.
+func sharedEvidenceLock(ctx context.Context) *sync.Mutex {
+	mu, ok := ctx.Value(sharedEvidenceLockKey{}).(*sync.Mutex)
+	if !ok {
+		return nil
+	}
+	return mu
+}
+
 // Verify checks a subject against a policy using the available evidence. The
 // policy argument may be a single policy, a policy group or a policy set; the
 // results are published once per call, regardless of the material kind.
@@ -238,6 +260,14 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 		}
 		return softPassPolicySet(ctx, policySet, resultSet)
 	}
+
+	// The policies and groups below are evaluated concurrently but share the
+	// attestation envelopes parsed once above and the collector agent. Publish a
+	// lock on the context so the evidence-gathering steps (GatherAttestations'
+	// key distribution and CheckIdentities' signature verification) can serialize
+	// their mutation of that shared state for this run (see issue #298 and
+	// sharedEvidenceLock).
+	ctx = context.WithValue(ctx, sharedEvidenceLockKey{}, &sync.Mutex{})
 
 	var mtx sync.Mutex
 	t := throttler.New(int(opts.ParallelWorkers), len(policySet.Policies)*len(subjects))


### PR DESCRIPTION
Fixes #298.

`ampel verify` could fail a policy's signer-identity check purely as a function of `--workers`: when a policy set has more identity-bound policies than workers, the later-evaluated ones were
  wrongly rejected with "attestation identity validation failed" even though the attestation was signed by an identity they bind. Deterministic and fail-closed — valid releases get spuriously rejected (a
  wrong identity is still rejected at every worker count).
  
  The envelopes are parsed once per set and shared across the per-policy goroutines, but two steps mutated that shared state during the concurrent fan-out:
  
  - `FilterAttestations` restamped the *shared* predicate's verification with the policy's matched identities. The sigstore bundle caches the real signer identity on that same predicate and skips
  re-verification once it's set, so the restamp clobbered the signer identity every later policy relied on, and they matched against the wrong data. (Also a `-race` data race.)
  - `AssembleEvalContextValues` merged a policy's context into the `*papi.ContextVal` inherited from the set's common context — another shared-object race.
  
  The number of policies that passed was exactly `min(--workers, #policies)` — only the first concurrent batch read the signer identity before it got clobbered, so fewer workers was actually *worse*.
  
  What changed:
  
  - `FilterAttestations` exposes the matched identities to the evaluator through a per-policy `matchedPredicate` wrapper instead of mutating the shared predicate, so the cached signer identity stays put.
  - `VerifySubjectWithPolicySet` publishes a per-run lock on the context, and the evidence-gathering steps that touch shared state take it: `CheckIdentities` around verifying/matching the shared envelopes,
  and `GatherAttestations` around the shared collector's `AddKeys` (which wasn't synchronized and was racy the same way). It's scoped to the run, so unrelated runs still verify in parallel.
  - `AssembleEvalContextValues` merges into a clone, matching the `proto.Clone` "never mutate the shared proto" convention from #285. 
  
  Verdict is now independent of `--workers` and `pkg/verifier` is clean under `go test -race`. New tests cover the shared-envelope invariant, worker-independence, fail-closed rejection, and the two concurrent
  paths.
  
  ### Example
  
  Repro from the issue (a 7-policy set). Before, the verdict tracked `--workers`; after, it's the same at every count:
  
  ```console
  # before
  $ ampel verify -p ampel-workers-repro.hjson -c jsonl:signed.bundle.jsonl -s "$sub" -x "$ctx"
    Status: ● FAIL     # default --workers=4: 4 pass / 3 fail
  $ ampel verify … --workers=1
    Status: ● FAIL     # 1 pass / 6 fail
  $ ampel verify … --workers=32 
    Status: ● PASS 
    
  # after — every worker count
  $ ampel verify … --workers=1     →  ● PASS
  $ ampel verify … --workers=4     →  ● PASS
  $ ampel verify … --workers=32    →  ● PASS
  
  (Out of scope: the envelopes are still shared by reference, and go test -race still flags pre-existing races inside the policy dep during compilation.)