### PR TITLE
add support for versioning the runtime and associated plugins

### DIFF
--- a/pkg/api/v1/plugin.go
+++ b/pkg/api/v1/plugin.go
@@ -51,4 +51,5 @@ type (
 
 type EvalEnginePlugin interface {
 	CanRegisterFor(class.Class) bool
+	Identity() *class.Identity
 }

--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -29,7 +29,7 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/url"
 )
 
-var Class = class.Class("cel@v0")
+var Class = class.MustParseClass("cel@v0")
 
 // EvaluationError captures error details when executing CEL code
 type EvaluationError struct {
@@ -109,6 +109,10 @@ func (e *Evaluator) rebuildEnvironment(opts *options.EvaluatorOptions) error {
 		}
 	}
 
+	for _, p := range e.Plugins {
+		logrus.Debugf("registered CEL plugin %T version %s", p, p.Identity().Version())
+	}
+
 	// Create the env
 	env, err := e.impl.CreateEnvironment(opts, e.Plugins)
 	if err != nil {
@@ -126,12 +130,10 @@ type Evaluator struct {
 }
 
 type Plugin interface {
-	// CanRegisterDataFor implements the plugin api function that flags if
-	// the plugin is compatible with a class of evaluator
-	CanRegisterFor(class.Class) bool
+	api.EvalEnginePlugin
 
-	// EnvVariables returns the data (as a cel.Variable list) that will be
-	// registered as global variables in the evaluation environment
+	// Library returns the CEL environment option that registers this plugin's
+	// types and functions into the evaluation environment.
 	Library() cel.EnvOption
 
 	// VarValues returns the values of the variables handled by the plugin
@@ -154,7 +156,7 @@ func (e *Evaluator) RegisterPlugin(plugin api.Plugin) error {
 		if !ok {
 			return fmt.Errorf("plugin declares compatibility with %s but does not implement cel.Plugin", Class)
 		}
-		e.Plugins[fmt.Sprintf("%T", dp)] = dp
+		e.Plugins[dp.Identity().Name()] = dp
 	}
 
 	return nil
@@ -326,4 +328,18 @@ func (e *Evaluator) ExecTenet(
 	result.Output = outStruct
 
 	return result, err
+}
+
+func (e *Evaluator) SupportedVersion() string {
+	return Class.Version()
+}
+
+// RegisteredPlugins returns the plugins registered with this evaluator keyed
+// by plugin name.
+func (e *Evaluator) RegisteredPlugins() map[string]api.EvalEnginePlugin {
+	result := make(map[string]api.EvalEnginePlugin, len(e.Plugins))
+	for k, v := range e.Plugins {
+		result[k] = v
+	}
+	return result
 }

--- a/pkg/evaluator/class/class.go
+++ b/pkg/evaluator/class/class.go
@@ -3,17 +3,235 @@
 
 package class
 
-import "strings"
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
 
-// Class is a label that describes an evaluator class
-type Class string
-
-func (c *Class) Version() string {
-	_, a, _ := strings.Cut(string(*c), "@")
-	return a
+// Identity is a validated versioned name identifier for a plugin or transformer.
+// Format: "name@vN"
+type Identity struct {
+	name    string
+	version string
 }
 
+func (i *Identity) Name() string {
+	return i.name
+}
+
+func (i *Identity) Version() string {
+	return i.version
+}
+
+func (i *Identity) String() string {
+	if i.version == "" {
+		return i.name
+	}
+	return i.name + "@" + i.version
+}
+
+// ParseIdentity parses and validates a versioned name string.
+func ParseIdentity(s string) (*Identity, error) {
+	if s == "" {
+		return nil, fmt.Errorf("identity string must not be empty")
+	}
+	name, version, _ := strings.Cut(s, "@")
+	if name == "" {
+		return nil, fmt.Errorf("identity %q: name must not be empty", s)
+	}
+	if version != "" {
+		if err := validateVersion(version, s); err != nil {
+			return nil, err
+		}
+	}
+	return &Identity{name: name, version: version}, nil
+}
+
+// MustParseIdentity parses a versioned name string and panics on error.
+func MustParseIdentity(s string) *Identity {
+	i, err := ParseIdentity(s)
+	if err != nil {
+		panic(fmt.Sprintf("MustParseIdentity(%q): %v", s, err))
+	}
+	return i
+}
+
+// Class is a full policy runtime specification: the base evaluator name@version
+// plus optional plugin and transformer version requirements.
+// Format: "name@version[?plugin:name=version[&transformer:name=version...]]"
+// Example: "cel@v1?plugin:semver=v1&transformer:protobom=v1"
+type Class string
+
+// BaseClass returns the base "name@version" part of the class, stripping any
+// plugin/transformer requirements.
+func (c *Class) BaseClass() Class {
+	base, _, _ := strings.Cut(string(*c), "?")
+	return Class(base)
+}
+
+// Identity returns the base name and version as a parsed Identity.
+// Panics if the class string is malformed; use ParseClass before calling this.
+func (c *Class) Identity() *Identity {
+	base, _, _ := strings.Cut(string(*c), "?")
+	return MustParseIdentity(base)
+}
+
+// Version returns the evaluator version from the class.
+func (c *Class) Version() string {
+	base, _, _ := strings.Cut(string(*c), "?")
+	_, version, _ := strings.Cut(base, "@")
+	return version
+}
+
+// Name returns the evaluator name from the class.
 func (c *Class) Name() string {
-	b, _, _ := strings.Cut(string(*c), "@")
-	return b
+	base, _, _ := strings.Cut(string(*c), "?")
+	name, _, _ := strings.Cut(base, "@")
+	return name
+}
+
+// Plugins returns the plugin name→version requirements declared in the class.
+// Returns nil if no plugin requirements are set.
+func (c *Class) Plugins() map[string]string {
+	return c.requirementsByKind("plugin")
+}
+
+// Transformers returns the transformer name→version requirements declared in the class.
+// Returns nil if no transformer requirements are set.
+func (c *Class) Transformers() map[string]string {
+	return c.requirementsByKind("transformer")
+}
+
+// String returns the class string.
+func (c *Class) String() string {
+	return string(*c)
+}
+
+// requirementsByKind parses the query string and returns requirements whose
+// key prefix matches kind (e.g. "plugin" or "transformer").
+func (c *Class) requirementsByKind(kind string) map[string]string {
+	_, qs, ok := strings.Cut(string(*c), "?")
+	if !ok {
+		return nil
+	}
+	vals, err := url.ParseQuery(qs)
+	if err != nil {
+		return nil
+	}
+	prefix := kind + ":"
+	var result map[string]string
+	for key, versions := range vals {
+		name, found := strings.CutPrefix(key, prefix)
+		if !found {
+			continue
+		}
+		version := ""
+		if len(versions) > 0 {
+			version = versions[0]
+		}
+		if result == nil {
+			result = map[string]string{}
+		}
+		result[name] = version
+	}
+	return result
+}
+
+// ParseClass parses and validates a class string. The evaluator name must be
+// non-empty, and versions must be in vN format. Each query param key must have a
+// recognised prefix ("plugin:" or "transformer:"), a non-empty name, and
+// a valid vN version value.
+func ParseClass(s string) (Class, error) {
+	if s == "" {
+		return "", fmt.Errorf("class string must not be empty")
+	}
+	base, qs, hasRequirements := strings.Cut(s, "?")
+
+	if err := validateBase(base, s); err != nil {
+		return "", err
+	}
+
+	if hasRequirements {
+		vals, err := url.ParseQuery(qs)
+		if err != nil {
+			return "", fmt.Errorf("class %q: invalid query string: %w", s, err)
+		}
+		for key, versions := range vals {
+			kind, name, ok := strings.Cut(key, ":")
+			if !ok {
+				return "", fmt.Errorf("class %q: requirement key %q must have a kind prefix (plugin: or transformer:)", s, key)
+			}
+			if kind != "plugin" && kind != "transformer" {
+				return "", fmt.Errorf("class %q: unknown requirement kind %q (must be plugin or transformer)", s, kind)
+			}
+			if name == "" {
+				return "", fmt.Errorf("class %q: %s requirement has an empty name", s, kind)
+			}
+			version := ""
+			if len(versions) > 0 {
+				version = versions[0]
+			}
+			if version == "" {
+				return "", fmt.Errorf("class %q: %s %q has no version", s, kind, name)
+			}
+			if err := validateVersion(version, s); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return Class(s), nil
+}
+
+// MustParseClass parses a class string and panics on error.
+// Intended for package-level var declarations and test helpers.
+func MustParseClass(s string) Class {
+	c, err := ParseClass(s)
+	if err != nil {
+		panic(fmt.Sprintf("MustParseClass(%q): %v", s, err))
+	}
+	return c
+}
+
+// SupportsVersion reports whether the requested version is satisfied by the
+// supported version. An empty requested version is treated as compatible.
+// Versions are numeric suffixes: "v0", "v1", etc.
+func SupportsVersion(requested, supported string) bool {
+	if requested == "" {
+		return true
+	}
+	req, err := strconv.Atoi(strings.TrimPrefix(requested, "v"))
+	if err != nil {
+		return false
+	}
+	sup, err := strconv.Atoi(strings.TrimPrefix(supported, "v"))
+	if err != nil {
+		return false
+	}
+	return req <= sup
+}
+
+// validateBase checks that a name@version string has a non-empty name and,
+// if a version is present, that it is in vN format.
+func validateBase(s, context string) error {
+	name, version, _ := strings.Cut(s, "@")
+	if name == "" {
+		return fmt.Errorf("class %q: %q has an empty name", context, s)
+	}
+	if version == "" {
+		return nil
+	}
+	return validateVersion(version, context)
+}
+
+func validateVersion(version, context string) error {
+	if !strings.HasPrefix(version, "v") {
+		return fmt.Errorf("class %q: version %q must start with 'v'", context, version)
+	}
+	if _, err := strconv.Atoi(strings.TrimPrefix(version, "v")); err != nil {
+		return fmt.Errorf("class %q: version %q must be in vN format (e.g. v0, v1)", context, version)
+	}
+	return nil
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -5,28 +5,77 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/carabiner-dev/attestation"
 	papi "github.com/carabiner-dev/policy/api/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	api "github.com/carabiner-dev/ampel/pkg/api/v1"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/cel"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
 
 // Ensure the known evaluators satisfy the interface
-var _ Evaluator = (*cel.Evaluator)(nil)
+var (
+	_ Evaluator = (*cel.Evaluator)(nil)
+	_ Evaluator = (*versionMismatchEvaluator)(nil)
+)
 
 type Factory struct{}
 
 func (f *Factory) Get(opts *options.EvaluatorOptions, c class.Class) (Evaluator, error) {
+	var e Evaluator
+	var err error
 	switch c.Name() {
 	case cel.Class.Name():
-		return cel.NewWithOptions(opts)
+		e, err = cel.NewWithOptions(opts)
 	default:
 		return nil, fmt.Errorf("no evaluator defined for class %q", c.Name())
 	}
+	if err != nil {
+		return nil, err
+	}
+	if !class.SupportsVersion(c.Version(), e.SupportedVersion()) {
+		return &versionMismatchEvaluator{
+			errMsg:    fmt.Sprintf("version %s is not supported by this engine (supports %s@%s)", c.String(), c.Name(), e.SupportedVersion()),
+			supported: e.SupportedVersion(),
+		}, nil
+	}
+	if pp, ok := e.(PluginAware); ok {
+		if err := checkPluginRequirements(pp.RegisteredPlugins(), c.Plugins()); err != nil {
+			return &versionMismatchEvaluator{ //nolint:nilerr
+				errMsg:    err.Error(),
+				supported: e.SupportedVersion(),
+			}, nil
+		}
+	}
+	return e, nil
+}
+
+// PluginAware is an optional interface for evaluators that register named
+// plugins. The factory uses it to check plugin version requirements from the
+// policy runtime spec.
+type PluginAware interface {
+	RegisteredPlugins() map[string]api.EvalEnginePlugin
+}
+
+// checkPluginRequirements verifies that every name→version requirement in reqs
+// is satisfied by the provided plugins. Returns an error for the first unmet
+// requirement.
+func checkPluginRequirements(plugins map[string]api.EvalEnginePlugin, reqs map[string]string) error {
+	for name, required := range reqs {
+		p, ok := plugins[name]
+		if !ok {
+			return fmt.Errorf("plugin %s@%s is required but not available in this engine", name, required)
+		}
+		if !class.SupportsVersion(required, p.Identity().Version()) {
+			return fmt.Errorf("plugin %s@%s is required but this engine only has %s@%s", name, required, name, p.Identity().Version())
+		}
+	}
+	return nil
 }
 
 // Evaluator
@@ -39,4 +88,41 @@ type Evaluator interface {
 	// subject and any other evaluation-time data from the evalcontext.EvaluationContext
 	// stored in ctx.
 	EvalExpression(context.Context, *options.EvaluatorOptions, string) (any, error)
+
+	// SupportedVersion returns the maximum runtime version this evaluator can
+	// satisfy. The factory rejects policy specs that request a higher version.
+	SupportedVersion() string
+}
+
+// versionMismatchEvaluator is returned by the factory when the policy spec
+// requests a runtime or plugin version the engine binary does not support.
+// Every tenet routed to it produces a FAIL with a clear message; no code is executed.
+type versionMismatchEvaluator struct {
+	errMsg    string
+	supported string
+}
+
+func (v *versionMismatchEvaluator) ExecTenet(_ context.Context, _ *options.EvaluatorOptions, tenet *papi.Tenet, _ []attestation.Predicate) (*papi.EvalResult, error) {
+	return &papi.EvalResult{
+		Id:     tenet.GetId(),
+		Status: papi.StatusFAIL,
+		Date:   timestamppb.Now(),
+		Error:  &papi.Error{Message: v.err().Error()},
+	}, nil
+}
+
+func (v *versionMismatchEvaluator) ExecChainedSelector(_ context.Context, _ *options.EvaluatorOptions, _ *papi.ChainedPredicate, _ attestation.Predicate) ([]attestation.Subject, error) {
+	return nil, v.err()
+}
+
+func (v *versionMismatchEvaluator) EvalExpression(_ context.Context, _ *options.EvaluatorOptions, _ string) (any, error) {
+	return nil, v.err()
+}
+
+func (v *versionMismatchEvaluator) SupportedVersion() string {
+	return v.supported
+}
+
+func (v *versionMismatchEvaluator) err() error {
+	return errors.New(v.errMsg)
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package evaluator
+
+import (
+	"context"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
+)
+
+func TestSupportsVersion(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		requested string
+		supported string
+		want      bool
+	}{
+		{"", "v0", true},
+		{"v0", "v0", true},
+		{"v1", "v0", false},
+		{"v99", "v0", false},
+		{"garbage", "v0", false},
+		{"v1", "v1", true},
+		{"v0", "v1", true},
+	} {
+		got := class.SupportsVersion(tc.requested, tc.supported)
+		require.Equal(t, tc.want, got, "supportsVersion(%q, %q)", tc.requested, tc.supported)
+	}
+}
+
+func TestFactoryVersionMismatch(t *testing.T) {
+	t.Parallel()
+	f := &Factory{}
+	opts := &options.Default
+
+	t.Run("supported version returns real evaluator", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.False(t, ok, "cel@v0 should return a real evaluator, not a stub")
+	})
+
+	t.Run("no version suffix returns real evaluator", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.False(t, ok, "cel (no version) should return a real evaluator")
+	})
+
+	t.Run("unsupported version returns stub", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v99"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.True(t, ok, "cel@v99 should return a versionMismatchEvaluator")
+		require.Equal(t, "v0", e.SupportedVersion())
+	})
+
+	t.Run("stub ExecTenet returns FAIL with message", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v99"))
+		require.NoError(t, err)
+		result, err := e.ExecTenet(context.Background(), opts, &papi.Tenet{Id: "test-tenet"}, nil)
+		require.NoError(t, err)
+		require.Equal(t, papi.StatusFAIL, result.GetStatus())
+		require.Contains(t, result.GetError().GetMessage(), "cel@v99")
+		require.Contains(t, result.GetError().GetMessage(), "cel@v0")
+		require.Equal(t, "test-tenet", result.GetId())
+	})
+
+	t.Run("satisfied plugin requirement returns real evaluator", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?plugin:semver=v0"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.False(t, ok, "cel@v0?plugin:semver=v0 should return a real evaluator")
+	})
+
+	t.Run("unsatisfied plugin version returns stub", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?plugin:semver=v99"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.True(t, ok, "cel@v0?plugin:semver=v99 should return a versionMismatchEvaluator")
+		result, err := e.ExecTenet(context.Background(), opts, &papi.Tenet{Id: "t"}, nil)
+		require.NoError(t, err)
+		require.Equal(t, papi.StatusFAIL, result.GetStatus())
+		require.Contains(t, result.GetError().GetMessage(), "semver")
+		require.Contains(t, result.GetError().GetMessage(), "v99")
+	})
+
+	t.Run("unknown plugin name returns stub", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?plugin:nosuchplugin=v0"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.True(t, ok, "unknown plugin should return a versionMismatchEvaluator")
+	})
+
+	t.Run("unknown runtime name returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := f.Get(opts, class.MustParseClass("unknown@v0"))
+		require.Error(t, err)
+	})
+
+	t.Run("all plugins satisfied returns real evaluator", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?plugin:semver=v0&plugin:purl=v0"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.False(t, ok, "all satisfied plugins should return a real evaluator")
+	})
+
+	t.Run("one unsatisfied plugin among multiple returns stub", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?plugin:semver=v0&plugin:purl=v99"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.True(t, ok, "one unsatisfied plugin should return a versionMismatchEvaluator")
+		result, err := e.ExecTenet(context.Background(), opts, &papi.Tenet{Id: "t"}, nil)
+		require.NoError(t, err)
+		require.Equal(t, papi.StatusFAIL, result.GetStatus())
+		require.Contains(t, result.GetError().GetMessage(), "purl")
+		require.Contains(t, result.GetError().GetMessage(), "v99")
+	})
+
+	t.Run("transformer requirement does not block evaluator", func(t *testing.T) {
+		t.Parallel()
+		// Transformer requirements in the class string are not yet checked at the
+		// evaluator factory level. A class with only a transformer requirement should
+		// still return a usable evaluator.
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?transformer:protobom=v0"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.False(t, ok, "transformer-only requirement should not block the evaluator")
+	})
+
+	t.Run("plugin and transformer combined returns real evaluator when plugin satisfied", func(t *testing.T) {
+		t.Parallel()
+		e, err := f.Get(opts, class.MustParseClass("cel@v0?plugin:semver=v0&transformer:protobom=v0"))
+		require.NoError(t, err)
+		_, ok := e.(*versionMismatchEvaluator)
+		require.False(t, ok, "satisfied plugin with transformer requirement should return a real evaluator")
+	})
+}

--- a/pkg/evaluator/plugins/cvss/plugin.go
+++ b/pkg/evaluator/plugins/cvss/plugin.go
@@ -12,6 +12,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("cvss@v0")
+
 type Plugin struct {
 	Tool *CvssTool
 }
@@ -40,4 +42,8 @@ func (p *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestatio
 	return map[string]any{
 		"cvss": p.Tool,
 	}
+}
+
+func (p *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/evaluator/plugins/github/plugin.go
+++ b/pkg/evaluator/plugins/github/plugin.go
@@ -12,6 +12,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("github@v0")
+
 type Plugin struct {
 	Util *GitHubUtil
 }
@@ -40,4 +42,8 @@ func (h *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestatio
 	return map[string]any{
 		"github": h.Util,
 	}
+}
+
+func (h *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/evaluator/plugins/hasher/plugin.go
+++ b/pkg/evaluator/plugins/hasher/plugin.go
@@ -13,6 +13,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("hasher@v0")
+
 type Plugin struct {
 	Hasher *Hasher
 }
@@ -47,4 +49,8 @@ func (h *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestatio
 		"hashAlgorithms": algos,
 		"hasher":         h.Hasher,
 	}
+}
+
+func (h *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/evaluator/plugins/protobom/protobom.go
+++ b/pkg/evaluator/plugins/protobom/protobom.go
@@ -20,6 +20,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("protobom@v0")
+
 func New() *Plugin {
 	return &Plugin{}
 }
@@ -62,4 +64,8 @@ func (p *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, preds []attest
 		"protobom": elements.Protobom{},
 		"sboms":    sbomList,
 	}
+}
+
+func (p *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/evaluator/plugins/purl/plugin.go
+++ b/pkg/evaluator/plugins/purl/plugin.go
@@ -12,6 +12,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("purl@v0")
+
 type Plugin struct {
 	Tool *PurlTool
 }
@@ -40,4 +42,8 @@ func (p *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestatio
 	return map[string]any{
 		"purl": p.Tool,
 	}
+}
+
+func (p *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/evaluator/plugins/semver/plugin.go
+++ b/pkg/evaluator/plugins/semver/plugin.go
@@ -16,6 +16,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("semver@v0")
+
 // Plugin wires the semver tool into ampel's CEL evaluator.
 type Plugin struct {
 	Tool *SemverTool
@@ -42,4 +44,8 @@ func (p *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestatio
 	return map[string]any{
 		"semver": p.Tool,
 	}
+}
+
+func (p *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/evaluator/plugins/url/plugin.go
+++ b/pkg/evaluator/plugins/url/plugin.go
@@ -12,6 +12,8 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 )
 
+var Identity = class.MustParseIdentity("url@v0")
+
 type Plugin struct {
 	Tool *UrlTool
 }
@@ -40,4 +42,8 @@ func (h *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestatio
 	return map[string]any{
 		"url": h.Tool,
 	}
+}
+
+func (h *Plugin) Identity() *class.Identity {
+	return Identity
 }

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -36,7 +36,7 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/transformer"
 )
 
-const defaultEvaluatorClass = "default"
+var defaultEvaluatorClass = class.MustParseClass("default")
 
 // AmpelImplementation
 type AmpelVerifier interface {
@@ -358,51 +358,64 @@ func (di *defaultIplementation) AssertResult(policy *papi.Policy, result *papi.R
 func (di *defaultIplementation) BuildEvaluators(opts *VerificationOptions, p *papi.Policy) (map[class.Class]evaluator.Evaluator, error) {
 	evaluators := map[class.Class]evaluator.Evaluator{}
 	factory := evaluator.Factory{}
-	// First, build the default evaluator
-	def := class.Class(p.GetMeta().GetRuntime())
+	var (
+		defRT class.Class
+		err   error
+	)
 
 	// Compute the default runtime, first from the options received.
 	// If not set, then from the default options set.
-	if p.GetMeta().GetRuntime() == "" {
-		if opts.DefaultEvaluator != "" {
-			def = opts.DefaultEvaluator
-		} else {
-			def = DefaultVerificationOptions.DefaultEvaluator
+	switch {
+	case p.GetMeta().GetRuntime() != "":
+		defRT, err = class.ParseClass(p.GetMeta().GetRuntime())
+		if err != nil {
+			return nil, fmt.Errorf("invalid policy runtime: %w", err)
 		}
+	case opts.DefaultEvaluator != "":
+		defRT = opts.DefaultEvaluator
+	default:
+		defRT = DefaultVerificationOptions.DefaultEvaluator
 	}
 
-	e, err := factory.Get(&opts.EvaluatorOptions, def)
+	e, err := factory.Get(&opts.EvaluatorOptions, defRT)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build default runtime: %w", err)
 	}
-	logrus.Debugf("Registered default evaluator of class %s", def)
-	evaluators[class.Class(defaultEvaluatorClass)] = e
-	evaluators[def] = e
-	if p.GetMeta().GetRuntime() != "" {
-		evaluators[class.Class(p.GetMeta().GetRuntime())] = e
-	}
+	logrus.Debugf("Registered default evaluator of class %s", defRT)
+	evaluators[defaultEvaluatorClass] = e
+	evaluators[defRT.BaseClass()] = e
 
 	for _, link := range p.GetChain() {
-		if classString := link.GetPredicate().GetRuntime(); classString != "" {
-			e, err := factory.Get(&opts.EvaluatorOptions, def)
-			if err != nil {
-				return nil, fmt.Errorf("unable to build chained subject runtime")
-			}
-			logrus.Debugf("registered evaluator of class %s for chained predicate", classString)
-			evaluators[class.Class(classString)] = e
+		classString := link.GetPredicate().GetRuntime()
+		if classString == "" {
+			continue
 		}
+		chainRT, err := class.ParseClass(classString)
+		if err != nil {
+			return nil, fmt.Errorf("invalid chain predicate runtime: %w", err)
+		}
+		e, err := factory.Get(&opts.EvaluatorOptions, chainRT)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build chained subject runtime")
+		}
+		logrus.Debugf("registered evaluator of class %s for chained predicate", classString)
+		evaluators[chainRT.BaseClass()] = e
 	}
 
 	for _, t := range p.Tenets {
 		if t.Runtime == "" {
 			continue
 		}
-		cl := class.Class(t.Runtime)
+		rt, err := class.ParseClass(t.Runtime)
+		if err != nil {
+			return nil, fmt.Errorf("tenet %q has invalid runtime: %w", t.GetId(), err)
+		}
+		cl := rt.BaseClass()
 		if _, ok := evaluators[cl]; ok {
 			continue
 		}
 		// TODO(puerco): Options here should come from the verifier options
-		e, err := factory.Get(&options.EvaluatorOptions{}, cl)
+		e, err := factory.Get(&options.EvaluatorOptions{}, rt)
 		if err != nil {
 			return nil, fmt.Errorf("building %q runtime: %w", t.Runtime, err)
 		}
@@ -727,13 +740,10 @@ func (di *defaultIplementation) evaluateChain(
 		if classString == "" {
 			classString = defaultEvalClass
 		}
-		if classString == "" {
-			classString = string(opts.DefaultEvaluator)
-		}
 
-		key := class.Class(classString)
-		if key == "" {
-			key = opts.DefaultEvaluator
+		key := classForRuntime(classString)
+		if key == "" && opts.DefaultEvaluator != "" {
+			key = opts.DefaultEvaluator.BaseClass()
 		}
 		if _, ok := evaluators[key]; !ok {
 			return nil, nil, false, fmt.Errorf("no evaluator loaded for class %s", key)
@@ -1037,7 +1047,7 @@ func (di *defaultIplementation) AssembleEvalContextValues(
 			if expr == "" {
 				continue
 			}
-			cls := class.Class(contextDef.GetRuntime())
+			cls := classForRuntime(contextDef.GetRuntime())
 			if cls == "" {
 				cls = defaultEvaluatorClass
 			}
@@ -1128,9 +1138,9 @@ func (di *defaultIplementation) VerifySubject(
 	)
 
 	for i, tenet := range p.Tenets {
-		key := class.Class(tenet.Runtime)
+		key := classForRuntime(tenet.Runtime)
 		if key == "" {
-			key = class.Class(defaultEvaluatorClass)
+			key = defaultEvaluatorClass
 		}
 
 		// Filter the predicates to those requested by the tenet or the policy:
@@ -1296,4 +1306,19 @@ func (di *defaultIplementation) BuildGroupEvaluators(opts *VerificationOptions, 
 		}
 	}
 	return evaluators, nil
+}
+
+// classForRuntime parses a raw runtime string and returns its base evaluator
+// class. Returns "" for an empty string; logs a warning and returns "" on
+// parse failure so callers can fall through to their own default.
+func classForRuntime(runtimeStr string) class.Class {
+	if runtimeStr == "" {
+		return ""
+	}
+	rt, err := class.ParseClass(runtimeStr)
+	if err != nil {
+		logrus.Warnf("invalid runtime %q, using default evaluator: %v", runtimeStr, err)
+		return ""
+	}
+	return rt.BaseClass()
 }

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -29,8 +29,8 @@ func TestEvaluateChain(t *testing.T) {
 	def, err := factory.Get(&eoptions.Default, DefaultVerificationOptions.DefaultEvaluator)
 	require.NoError(t, err)
 	evaluators := map[class.Class]evaluator.Evaluator{
-		"default": def,
-		DefaultVerificationOptions.DefaultEvaluator: def,
+		defaultEvaluatorClass: def,
+		DefaultVerificationOptions.DefaultEvaluator.BaseClass(): def,
 	}
 
 	defaultSubject := &gointoto.ResourceDescriptor{
@@ -211,14 +211,17 @@ func TestEvaluateChain(t *testing.T) {
 
 			// Check if there is an evaluator for the link's runtime
 			for _, l := range tt.chainLinks {
-				if runtime := l.GetPredicate().GetRuntime(); runtime != "" {
-					if _, ok := localEvaluators[class.Class(runtime)]; ok {
-						continue
-					}
-					ev, err := factory.Get(&eoptions.Default, class.Class(runtime))
-					require.NoError(t, err)
-					localEvaluators[class.Class(runtime)] = ev
+				runtime := l.GetPredicate().GetRuntime()
+				if runtime == "" {
+					continue
 				}
+				rt := class.MustParseClass(runtime)
+				if _, ok := localEvaluators[rt.BaseClass()]; ok {
+					continue
+				}
+				ev, err := factory.Get(&eoptions.Default, rt)
+				require.NoError(t, err)
+				localEvaluators[rt.BaseClass()] = ev
 			}
 
 			// should we test policyFail?
@@ -653,7 +656,7 @@ func TestProcessChainedSubjectsPropagatesFailFlag(t *testing.T) {
 	def, err := factory.Get(&eoptions.Default, DefaultVerificationOptions.DefaultEvaluator)
 	require.NoError(t, err)
 	evaluators := map[class.Class]evaluator.Evaluator{
-		"default": def,
+		defaultEvaluatorClass:                       def,
 		DefaultVerificationOptions.DefaultEvaluator: def,
 	}
 
@@ -713,7 +716,7 @@ func TestProcessPolicySetChainedSubjectsPropagatesFailFlag(t *testing.T) {
 	def, err := factory.Get(&eoptions.Default, DefaultVerificationOptions.DefaultEvaluator)
 	require.NoError(t, err)
 	evaluators := map[class.Class]evaluator.Evaluator{
-		"default": def,
+		defaultEvaluatorClass:                       def,
 		DefaultVerificationOptions.DefaultEvaluator: def,
 	}
 

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -117,7 +117,7 @@ var DefaultVerificationOptions = VerificationOptions{
 
 	// DefaultEvaluator the the default eval enfine is the lowest version
 	// of CEL available
-	DefaultEvaluator: class.Class("cel@v0"),
+	DefaultEvaluator: class.MustParseClass("cel@v0"),
 
 	// ResultsAttestationPath path to the results attestation
 	ResultsAttestationPath: "results.intoto.json",


### PR DESCRIPTION
Add versioning support for the runtime and plugins.

The versioned runtime format follows: `name@version[?type:name=version[&type:name=version...]]"` where `type` can either be `plugin` or `transformer`.  Note: the transformer configurations are currently ignored, only the plugins take effect at this time.