### PR TITLE
feat: add support for lazy expression evaluation and cross-referencing

### DIFF
--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -276,25 +276,8 @@ func (e *Evaluator) ExecTenet(
 		return status, nil
 	}
 
-	outputMap, err := e.impl.EvaluateOutputs(e.Environment, outputAsts, vars)
-	if err != nil {
-		//nolint:errorlint
-		ee, ok := err.(*EvaluationError)
-		if ok {
-			return &papi.EvalResult{
-				Id:         tenet.Id,
-				Status:     papi.StatusFAIL,
-				Date:       timestamppb.Now(),
-				Output:     &structpb.Struct{},
-				Statements: statementRefs,
-				Error: &papi.Error{
-					Message:  "Evaluating policy outputs: " + ee.Message,
-					Guidance: ee.EvalError.Error(),
-				},
-			}, nil
-		}
-		return nil, fmt.Errorf("evaluating outputs: %w", err)
-	}
+	lazy := newLazyExprMap(e.Environment, outputAsts, *vars)
+	(*vars)[VarNameOutputs] = lazy
 
 	// Evaluate the ASTs and compile the results into a resultset
 	result, err := e.impl.Evaluate(e.Environment, ast, vars)
@@ -320,6 +303,11 @@ func (e *Evaluator) ExecTenet(
 	// with the tenet data
 	result.Id = tenet.Id
 	result.Statements = statementRefs
+
+	outputMap, err := serializeOutputs(lazy.snapshot())
+	if err != nil {
+		return nil, fmt.Errorf("serializing outputs: %w", err)
+	}
 
 	outStruct, err := structpb.NewStruct(outputMap)
 	if err != nil {

--- a/pkg/evaluator/cel/implementation.go
+++ b/pkg/evaluator/cel/implementation.go
@@ -295,6 +295,31 @@ func (dce *defaulCelEvaluator) EvaluateOutputs(
 	return ret, nil
 }
 
+// serializeOutputs converts a snapshot of evaluated outputs (ref.Val values)
+// to a JSON-normalized map[string]any suitable for serialization into the
+// tenet result. Only the evaluated outputs are included.
+func serializeOutputs(snapshot map[string]ref.Val) (map[string]any, error) {
+	dataResult := outputDataResult{}
+	for id, result := range snapshot {
+		dr := result.Value()
+		if rv, ok := dr.([]ref.Val); ok {
+			dr = deRefList(rv)
+		}
+		dataResult[id] = dr
+	}
+
+	data, err := json.Marshal(&dataResult)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling output evals: %w", err)
+	}
+
+	ret := map[string]any{}
+	if err := json.Unmarshal(data, &ret); err != nil {
+		return nil, fmt.Errorf("unmarshaling data: %w", err)
+	}
+	return ret, nil
+}
+
 type outputDataResult map[string]any
 
 func (odr *outputDataResult) MarshalJSON() ([]byte, error) {

--- a/pkg/evaluator/cel/implementation_test.go
+++ b/pkg/evaluator/cel/implementation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/carabiner-dev/collector/predicate"
+	"github.com/google/cel-go/cel"
 	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/require"
 
@@ -128,6 +129,105 @@ func TestOptionalOperators(t *testing.T) {
 			got, err := ev.EvaluateExpression(env, ast, vars)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestLazyExprMap verifies that a lazyExprMap evaluates entries on first
+// reference, that entries can reference siblings via both dot and bracket
+// notation, that cycles are detected and reported as errors, and that
+// unreferenced entries are absent from the snapshot.
+func TestLazyExprMap(t *testing.T) {
+	t.Parallel()
+	ev := &defaulCelEvaluator{}
+
+	env, err := ev.CreateEnvironment(nil, nil)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name       string
+		outputs    map[string]string
+		mainCode   string
+		wantVal    any
+		wantErr    string
+		wantSnap   []string
+		absentSnap []string
+	}{
+		{
+			name: "dot notation cross-reference resolves correctly",
+			outputs: map[string]string{
+				"a": `"hello"`,
+				"b": `outputs.a + " world"`,
+			},
+			mainCode: `outputs.b == "hello world"`,
+			wantVal:  true,
+		},
+		{
+			name: "bracket notation also resolves correctly",
+			outputs: map[string]string{
+				"a": `"hello"`,
+				"b": `outputs.a + " world"`,
+			},
+			mainCode: `outputs["b"] == "hello world"`,
+			wantVal:  true,
+		},
+		{
+			name: "cycle detection returns error",
+			outputs: map[string]string{
+				"cycleA": `outputs.cycleB`,
+				"cycleB": `outputs.cycleA`,
+			},
+			mainCode: `outputs.cycleA`,
+			wantErr:  "cycle",
+		},
+		{
+			name: "unreferenced output absent from snapshot",
+			outputs: map[string]string{
+				"a":      `"hello"`,
+				"b":      `outputs.a + " world"`,
+				"unused": `"never evaluated"`,
+			},
+			mainCode:   `outputs.b == "hello world"`,
+			wantSnap:   []string{"a", "b"},
+			absentSnap: []string{"unused"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			asts := make(map[string]*cel.Ast, len(tc.outputs))
+			for name, code := range tc.outputs {
+				ast, err := ev.CompileCode(env, code)
+				require.NoError(t, err)
+				asts[name] = ast
+			}
+
+			vars := map[string]any{}
+			lazy := newLazyExprMap(env, asts, vars)
+			vars[VarNameOutputs] = lazy
+
+			mainAst, err := ev.CompileCode(env, tc.mainCode)
+			require.NoError(t, err)
+
+			got, err := ev.EvaluateExpression(env, mainAst, &vars)
+			if tc.wantErr != "" {
+				require.Error(t, err, "expected evaluation error containing %q", tc.wantErr)
+				require.Contains(t, err.Error(), tc.wantErr, "error message mismatch")
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.wantVal != nil {
+				require.Equal(t, tc.wantVal, got, "evaluation result mismatch")
+			}
+
+			snap := lazy.snapshot()
+			for _, k := range tc.wantSnap {
+				require.Contains(t, snap, k, "expected %q in snapshot", k)
+			}
+			for _, k := range tc.absentSnap {
+				require.NotContains(t, snap, k, "expected %q absent from snapshot", k)
+			}
 		})
 	}
 }

--- a/pkg/evaluator/cel/lazy_expr_map.go
+++ b/pkg/evaluator/cel/lazy_expr_map.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package cel
+
+import (
+	"errors"
+	"maps"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// lazyExprMapType is the CEL object type for the lazy expression map value.
+var lazyExprMapType = cel.ObjectType("lazyExprMap", traits.IndexerType)
+
+// lazyExprMap is a CEL map value whose entries are backed by pre-compiled CEL
+// ASTs evaluated lazily on first access. Entries are accessible via both dot
+// notation (map.name) and bracket notation (map["name"]). Results are cached
+// for the duration of the evaluation.
+// Expressions can reference sibling entries and they resolve recursively,
+// circular references are detected and returned as errors.
+type lazyExprMap struct {
+	asts       map[string]*cel.Ast
+	env        *cel.Env
+	vars       map[string]any
+	cache      map[string]ref.Val
+	inProgress map[string]bool
+}
+
+func newLazyExprMap(env *cel.Env, asts map[string]*cel.Ast, vars map[string]any) *lazyExprMap {
+	return &lazyExprMap{
+		asts:       asts,
+		env:        env,
+		vars:       vars,
+		cache:      make(map[string]ref.Val, len(asts)),
+		inProgress: make(map[string]bool, len(asts)),
+	}
+}
+
+func (lo *lazyExprMap) Type() ref.Type {
+	return lazyExprMapType
+}
+
+func (lo *lazyExprMap) Value() any {
+	return lo.cache
+}
+
+func (lo *lazyExprMap) Equal(_ ref.Val) ref.Val {
+	return types.NewErr("lazyExprMap cannot be compared")
+}
+
+func (lo *lazyExprMap) ConvertToNative(_ reflect.Type) (any, error) {
+	return nil, errors.New("lazyExprMap cannot be converted to native")
+}
+
+func (lo *lazyExprMap) ConvertToType(typeVal ref.Type) ref.Val {
+	if typeVal == types.TypeType {
+		return lazyExprMapType
+	}
+	return types.NewErr("type conversion not supported for lazyExprMap")
+}
+
+// Get implements traits.Indexer. On the first access of a named entry it
+// evaluates the pre-compiled AST against the full variable set and caches
+// the result. A cycle, where evaluating entry A triggers evaluation of entry
+// B which in turn needs A, is detected and returned as an error.
+func (lo *lazyExprMap) Get(index ref.Val) ref.Val {
+	name, ok := index.Value().(string)
+	if !ok {
+		return types.NewErr("lazyExprMap key must be a string")
+	}
+	if v, ok := lo.cache[name]; ok {
+		return v
+	}
+	if lo.inProgress[name] {
+		return types.NewErr("cycle detected evaluating: %s", name)
+	}
+	ast, ok := lo.asts[name]
+	if !ok {
+		return types.NewErr("unknown entry: %s", name)
+	}
+	lo.inProgress[name] = true
+	defer func() {
+		lo.inProgress[name] = false
+	}()
+	program, err := lo.env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+	if err != nil {
+		return types.NewErr("building program for %s: %v", name, err)
+	}
+	result, _, err := program.Eval(lo.vars)
+	if err != nil {
+		return types.NewErr("evaluating %s: %v", name, err)
+	}
+	lo.cache[name] = result
+	return result
+}
+
+// snapshot returns a copy of the entries that were actually evaluated.
+// Entries never referenced during the evaluation are absent.
+func (lo *lazyExprMap) snapshot() map[string]ref.Val {
+	snap := make(map[string]ref.Val, len(lo.cache))
+	maps.Copy(snap, lo.cache)
+	return snap
+}
+
+var (
+	_ ref.Val        = (*lazyExprMap)(nil)
+	_ traits.Indexer = (*lazyExprMap)(nil)
+)


### PR DESCRIPTION
@puerco One thing to note is that the cyclic reference detection happens at runtime because of the map, there's no defined order.