### PR TITLE
chore: update cel version for optional/cross-referencing support

### DIFF
--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -29,7 +29,7 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/url"
 )
 
-var Class = class.MustParseClass("cel@v0")
+var Class = class.MustParseClass("cel@v1")
 
 // EvaluationError captures error details when executing CEL code
 type EvaluationError struct {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -10,6 +10,7 @@ import (
 	papi "github.com/carabiner-dev/policy/api/v1"
 	"github.com/stretchr/testify/require"
 
+	"github.com/carabiner-dev/ampel/pkg/evaluator/cel"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
@@ -61,7 +62,7 @@ func TestFactoryVersionMismatch(t *testing.T) {
 		require.NoError(t, err)
 		_, ok := e.(*versionMismatchEvaluator)
 		require.True(t, ok, "cel@v99 should return a versionMismatchEvaluator")
-		require.Equal(t, "v0", e.SupportedVersion())
+		require.Equal(t, cel.Class.Version(), e.SupportedVersion())
 	})
 
 	t.Run("stub ExecTenet returns FAIL with message", func(t *testing.T) {
@@ -72,7 +73,7 @@ func TestFactoryVersionMismatch(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, papi.StatusFAIL, result.GetStatus())
 		require.Contains(t, result.GetError().GetMessage(), "cel@v99")
-		require.Contains(t, result.GetError().GetMessage(), "cel@v0")
+		require.Contains(t, result.GetError().GetMessage(), cel.Class.String())
 		require.Equal(t, "test-tenet", result.GetId())
 	})
 

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/carabiner-dev/signer/key"
 
 	"github.com/carabiner-dev/ampel/pkg/context"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/cel"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
 )
@@ -117,7 +118,7 @@ var DefaultVerificationOptions = VerificationOptions{
 
 	// DefaultEvaluator the the default eval enfine is the lowest version
 	// of CEL available
-	DefaultEvaluator: class.MustParseClass("cel@v0"),
+	DefaultEvaluator: cel.Class,
 
 	// ResultsAttestationPath path to the results attestation
 	ResultsAttestationPath: "results.intoto.json",


### PR DESCRIPTION
This PR updated the cel version within the codebase to v1.  This is required because of the recent changes introducing support for CEL optional types as well as support for cross-referencing within the output variables.
