### PR TITLE
OSV cel plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carabiner-dev/collector v0.3.9-0.20260710065700-35858011e579
 	github.com/carabiner-dev/command v0.3.1
 	github.com/carabiner-dev/hasher v0.2.4
-	github.com/carabiner-dev/osv v0.1.0
+	github.com/carabiner-dev/osv v0.1.1
 	github.com/carabiner-dev/policy v0.5.1
 	github.com/carabiner-dev/predicates v0.5.0
 	github.com/carabiner-dev/termtable v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/carabiner-dev/jsonl v0.2.1 h1:2cBv4mGoqWfVkeQO1krIGds9WUm9Jet89QdqWLo
 github.com/carabiner-dev/jsonl v0.2.1/go.mod h1:fTypVHMYsAnn6LlW0SqER6XUaI9Wlc/Kv6uyMF+NmKo=
 github.com/carabiner-dev/openeox v1.0.0-pre.1 h1:47Oe0vcH9m8nBFFQCPLNVR2HwiumXstFXRknU78zPZ0=
 github.com/carabiner-dev/openeox v1.0.0-pre.1/go.mod h1:+6i8M7PhtWk2jRtUC1anZnhmOr5cXKMLGYjwFcqPDa0=
-github.com/carabiner-dev/osv v0.1.0 h1:DAyNKWahY49lVQks2Ajbo2+sO60/vfqkN0G1UiCa6j0=
-github.com/carabiner-dev/osv v0.1.0/go.mod h1:V4+Ai2X1/iTqzdd4xDrdjQ+LXs0ov9OdD6b6Hfjp/Jc=
+github.com/carabiner-dev/osv v0.1.1 h1:koVLTk5BpeV2ARvLtz7YNy2QgNGC1REUOXOCcPvIaaY=
+github.com/carabiner-dev/osv v0.1.1/go.mod h1:V4+Ai2X1/iTqzdd4xDrdjQ+LXs0ov9OdD6b6Hfjp/Jc=
 github.com/carabiner-dev/policy v0.5.1 h1:u6RN5mD+73NMHaRyg0CvsxwJRn+Qc+pNbS3SNxUdD00=
 github.com/carabiner-dev/policy v0.5.1/go.mod h1:KmqdpxhKxKtlhCiFnBdb41uu8CBLCuNx6svbWnh+OCM=
 github.com/carabiner-dev/predicates v0.5.0 h1:CG2xO5xTXWXakjJkAFuS2xSA2olP9Ew25k6CAyL8waI=

--- a/pkg/evaluator/cel/evaluator.go
+++ b/pkg/evaluator/cel/evaluator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/cvss"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/github"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/hasher"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/osv"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/protobom"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/purl"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/semver"
@@ -75,6 +76,7 @@ func NewWithOptions(opts *options.EvaluatorOptions) (*Evaluator, error) {
 // Ensure the default plugins implement the cel plugin interface
 var (
 	_ Plugin = (*hasher.Plugin)(nil)
+	_ Plugin = (*osv.Plugin)(nil)
 	_ Plugin = (*url.Plugin)(nil)
 	_ Plugin = (*github.Plugin)(nil)
 	_ Plugin = (*protobom.Plugin)(nil)
@@ -106,6 +108,9 @@ func (e *Evaluator) rebuildEnvironment(opts *options.EvaluatorOptions) error {
 		}
 		if err := e.RegisterPlugin(cvss.New()); err != nil {
 			return fmt.Errorf("registering cvss: %w", err)
+		}
+		if err := e.RegisterPlugin(osv.New()); err != nil {
+			return fmt.Errorf("registering osv: %w", err)
 		}
 	}
 

--- a/pkg/evaluator/plugins/cvss/tool.go
+++ b/pkg/evaluator/plugins/cvss/tool.go
@@ -116,6 +116,16 @@ func Score(vector string) (float64, error) {
 	return res.score, nil
 }
 
+// Severity parses a CVSS vector string and returns its qualitative rating
+// (CRITICAL/HIGH/MEDIUM/LOW/NONE). Exported for reuse by sibling plugins.
+func Severity(vector string) (string, error) {
+	res, err := getCVSSResult(vector)
+	if err != nil {
+		return "", err
+	}
+	return res.severity, nil
+}
+
 func rating20(score float64) string {
 	switch {
 	case score >= 7.0:

--- a/pkg/evaluator/plugins/cvss/tool.go
+++ b/pkg/evaluator/plugins/cvss/tool.go
@@ -105,6 +105,17 @@ func getCVSSResult(vector string) (*cvssResult, error) {
 	}
 }
 
+// Score parses a CVSS vector string and returns its numeric (base) score. It is
+// exported so sibling plugins (e.g. osv) can reuse the version-aware scoring
+// without duplicating the parsing logic.
+func Score(vector string) (float64, error) {
+	res, err := getCVSSResult(vector)
+	if err != nil {
+		return 0, err
+	}
+	return res.score, nil
+}
+
 func rating20(score float64) string {
 	switch {
 	case score >= 7.0:

--- a/pkg/evaluator/plugins/osv/osv_test.go
+++ b/pkg/evaluator/plugins/osv/osv_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package osv
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleData mirrors the JSON shape of an OSV results predicate: two
+// vulnerabilities on one package, the first carrying an alias and a critical
+// CVSS vector, the second a medium one.
+func sampleData() map[string]any {
+	return map[string]any{
+		"results": []any{
+			map[string]any{
+				"source": map[string]any{"path": "go.mod", "type": "lockfile"},
+				"packages": []any{
+					map[string]any{
+						"package": map[string]any{"name": "github.com/x/y", "ecosystem": "Go"},
+						"vulnerabilities": []any{
+							map[string]any{
+								"id":      "GHSA-aaaa-bbbb-cccc",
+								"aliases": []any{"CVE-2026-0001"},
+								"severity": []any{
+									map[string]any{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+								},
+							},
+							map[string]any{
+								"id": "CVE-2026-0002",
+								"severity": []any{
+									map[string]any{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func run(t *testing.T, expr string, data any) any {
+	t.Helper()
+	p := New()
+	env, err := cel.NewEnv(p.Library(), cel.Variable("data", cel.DynType))
+	require.NoError(t, err)
+	ast, iss := env.Compile(expr)
+	require.NoError(t, iss.Err(), "compile %q", expr)
+	program, err := env.Program(ast)
+	require.NoError(t, err)
+	vars := p.VarValues(nil, nil, nil)
+	vars["data"] = data
+	result, _, err := program.Eval(vars)
+	require.NoError(t, err, "eval %q", expr)
+	return result.Value()
+}
+
+func TestVulnsAndIDs(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(2), run(t, "size(osv.vulns(data))", sampleData()))
+	require.Equal(t, true, run(t, "osv.ids(data) == ['GHSA-aaaa-bbbb-cccc', 'CVE-2026-0002']", sampleData()))
+	// The returned vulns are usable objects.
+	require.Equal(t, "GHSA-aaaa-bbbb-cccc", run(t, "osv.vulns(data)[0].id", sampleData()))
+}
+
+func TestAliasesAndMatchesID(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, true, run(t, "osv.aliases(osv.vulns(data)[0]) == ['GHSA-aaaa-bbbb-cccc', 'CVE-2026-0001']", sampleData()))
+	// Match by primary id and by alias, and reject a non-match.
+	require.Equal(t, true, run(t, "osv.matchesID(osv.vulns(data)[0], 'GHSA-aaaa-bbbb-cccc')", sampleData()))
+	require.Equal(t, true, run(t, "osv.matchesID(osv.vulns(data)[0], 'CVE-2026-0001')", sampleData()))
+	require.Equal(t, false, run(t, "osv.matchesID(osv.vulns(data)[0], 'CVE-9999-9999')", sampleData()))
+	// The alias-aware form composes into a document-level check.
+	require.Equal(t, true, run(t, "osv.vulns(data).exists(v, osv.matchesID(v, 'CVE-2026-0001'))", sampleData()))
+}
+
+func TestCVSS(t *testing.T) {
+	t.Parallel()
+	require.InDelta(t, 9.8, run(t, "osv.cvss(osv.vulns(data)[0])", sampleData()), 0.05)
+	// A realistic policy: any fixable-or-not critical present.
+	require.Equal(t, true, run(t, "osv.vulns(data).exists(v, osv.cvss(v) >= 9.0)", sampleData()))
+	require.Equal(t, false, run(t, "osv.vulns(data).exists(v, osv.cvss(v) >= 9.0 && osv.matchesID(v, 'CVE-2026-0002'))", sampleData()))
+}
+
+func TestUnwrapsPredicate(t *testing.T) {
+	t.Parallel()
+	// Passing a whole predicate (with a data key) works the same as its data.
+	pred := map[string]any{
+		"predicate_type": "https://ossf.github.io/osv-schema/results@v1",
+		"data":           sampleData(),
+	}
+	require.Equal(t, int64(2), run(t, "size(osv.vulns(data))", pred))
+}
+
+func TestEmptyAndMalformed(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(0), run(t, "size(osv.vulns(data))", map[string]any{}))
+	require.Equal(t, int64(0), run(t, "size(osv.ids(data))", map[string]any{"results": []any{}}))
+	require.InDelta(t, 0.0, run(t, "osv.cvss({})", sampleData()), 0.001)
+}

--- a/pkg/evaluator/plugins/osv/osv_test.go
+++ b/pkg/evaluator/plugins/osv/osv_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // sampleData mirrors the JSON shape of an OSV results predicate: two
-// vulnerabilities on one package, the first carrying an alias and a critical
-// CVSS vector, the second a medium one.
+// vulnerabilities across two packages — a critical, aliased, already-fixed Go
+// finding and an unfixed medium PyPI finding.
 func sampleData() map[string]any {
 	return map[string]any{
 		"results": []any{
@@ -28,11 +28,38 @@ func sampleData() map[string]any {
 								"severity": []any{
 									map[string]any{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
 								},
+								"affected": []any{
+									map[string]any{
+										"package": map[string]any{"name": "github.com/x/y", "ecosystem": "Go", "purl": "pkg:golang/github.com/x/y@1.2.0"},
+										"ranges": []any{
+											map[string]any{"type": "ECOSYSTEM", "events": []any{
+												map[string]any{"introduced": "0"},
+												map[string]any{"fixed": "1.3.0"},
+											}},
+										},
+									},
+								},
+								"database_specific": map[string]any{"severity": "CRITICAL"},
 							},
+						},
+					},
+					map[string]any{
+						"package": map[string]any{"name": "requests", "ecosystem": "PyPI"},
+						"vulnerabilities": []any{
 							map[string]any{
 								"id": "CVE-2026-0002",
 								"severity": []any{
 									map[string]any{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"},
+								},
+								"affected": []any{
+									map[string]any{
+										"package": map[string]any{"name": "requests", "ecosystem": "PyPI", "purl": "pkg:pypi/requests@2.0"},
+										"ranges": []any{
+											map[string]any{"type": "ECOSYSTEM", "events": []any{
+												map[string]any{"introduced": "0"},
+											}},
+										},
+									},
 								},
 							},
 						},
@@ -94,6 +121,52 @@ func TestUnwrapsPredicate(t *testing.T) {
 		"data":           sampleData(),
 	}
 	require.Equal(t, int64(2), run(t, "size(osv.vulns(data))", pred))
+}
+
+func TestFixStatus(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, true, run(t, "osv.isFixed(osv.vulns(data)[0])", sampleData()))
+	require.Equal(t, false, run(t, "osv.isFixed(osv.vulns(data)[1])", sampleData()))
+	require.Equal(t, true, run(t, "osv.fixedVersions(osv.vulns(data)[0]) == ['1.3.0']", sampleData()))
+	require.Equal(t, int64(0), run(t, "size(osv.fixedVersions(osv.vulns(data)[1]))", sampleData()))
+}
+
+func TestSeverityLabel(t *testing.T) {
+	t.Parallel()
+	// Derived from the highest CVSS vector.
+	require.Equal(t, "CRITICAL", run(t, "osv.severityLabel(osv.vulns(data)[0])", sampleData()))
+	// Falls back to the scanner's own label (upper-cased) when there is no CVSS.
+	require.Equal(t, "HIGH", run(t, "osv.severityLabel({'database_specific': {'severity': 'high'}})", sampleData()))
+	require.Empty(t, run(t, "osv.severityLabel({})", sampleData()))
+}
+
+func TestPackageAccessors(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "pkg:golang/github.com/x/y@1.2.0", run(t, "osv.purl(osv.vulns(data)[0])", sampleData()))
+	require.Equal(t, "Go", run(t, "osv.ecosystem(osv.vulns(data)[0])", sampleData()))
+	require.Equal(t, "PyPI", run(t, "osv.ecosystem(osv.vulns(data)[1])", sampleData()))
+	require.Empty(t, run(t, "osv.purl({})", sampleData()))
+}
+
+func TestFilters(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(1), run(t, "size(osv.forEcosystem(data, 'Go'))", sampleData()))
+	// Ecosystem match is case-insensitive.
+	require.Equal(t, "GHSA-aaaa-bbbb-cccc", run(t, "osv.forEcosystem(data, 'go')[0].id", sampleData()))
+	require.Equal(t, int64(1), run(t, "size(osv.forEcosystem(data, 'PyPI'))", sampleData()))
+	// forPackage matches by bare name appearing in the PURL.
+	require.Equal(t, "GHSA-aaaa-bbbb-cccc", run(t, "osv.forPackage(data, 'github.com/x/y')[0].id", sampleData()))
+	require.Equal(t, int64(0), run(t, "size(osv.forPackage(data, 'nonexistent'))", sampleData()))
+}
+
+func TestCompositePolicy(t *testing.T) {
+	t.Parallel()
+	// "no unpatched critical" — the critical vuln here is fixed, so this passes.
+	require.Equal(t, false, run(t, "osv.vulns(data).exists(v, osv.cvss(v) >= 9.0 && !osv.isFixed(v))", sampleData()))
+	// A critical fixable vuln does exist.
+	require.Equal(t, true, run(t, "osv.vulns(data).exists(v, osv.cvss(v) >= 9.0 && osv.isFixed(v))", sampleData()))
+	// Every Go vulnerability is fixed.
+	require.Equal(t, true, run(t, "osv.forEcosystem(data, 'Go').all(v, osv.isFixed(v))", sampleData()))
 }
 
 func TestEmptyAndMalformed(t *testing.T) {

--- a/pkg/evaluator/plugins/osv/osv_test.go
+++ b/pkg/evaluator/plugins/osv/osv_test.go
@@ -39,7 +39,17 @@ func sampleData() map[string]any {
 										},
 									},
 								},
-								"database_specific": map[string]any{"severity": "CRITICAL"},
+								"references": []any{
+									map[string]any{"type": "ADVISORY", "url": "https://github.com/advisories/GHSA-aaaa-bbbb-cccc"},
+									map[string]any{"type": "WEB", "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-0001"},
+								},
+								"database_specific": map[string]any{
+									"severity":        "CRITICAL",
+									"risk":            0.34,
+									"epss":            0.88,
+									"known_exploited": true,
+									"cwe_ids":         []any{"CWE-89"},
+								},
 							},
 						},
 					},
@@ -167,6 +177,30 @@ func TestCompositePolicy(t *testing.T) {
 	require.Equal(t, true, run(t, "osv.vulns(data).exists(v, osv.cvss(v) >= 9.0 && osv.isFixed(v))", sampleData()))
 	// Every Go vulnerability is fixed.
 	require.Equal(t, true, run(t, "osv.forEcosystem(data, 'Go').all(v, osv.isFixed(v))", sampleData()))
+}
+
+func TestReferences(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(2), run(t, "size(osv.references(osv.vulns(data)[0]))", sampleData()))
+	require.Equal(t, "https://github.com/advisories/GHSA-aaaa-bbbb-cccc", run(t, "osv.references(osv.vulns(data)[0])[0]", sampleData()))
+	require.Equal(t, int64(0), run(t, "size(osv.references(osv.vulns(data)[1]))", sampleData()))
+}
+
+func TestEnrichment(t *testing.T) {
+	t.Parallel()
+	// Present on the first (Go) finding.
+	require.InDelta(t, 0.88, run(t, "osv.epss(osv.vulns(data)[0])", sampleData()), 0.001)
+	require.InDelta(t, 0.34, run(t, "osv.risk(osv.vulns(data)[0])", sampleData()), 0.001)
+	require.Equal(t, true, run(t, "osv.isKEV(osv.vulns(data)[0])", sampleData()))
+	require.Equal(t, true, run(t, "osv.cwes(osv.vulns(data)[0]) == ['CWE-89']", sampleData()))
+
+	// Absent on the second finding — safe zero values.
+	require.InDelta(t, 0.0, run(t, "osv.epss(osv.vulns(data)[1])", sampleData()), 0.001)
+	require.Equal(t, false, run(t, "osv.isKEV(osv.vulns(data)[1])", sampleData()))
+	require.Equal(t, int64(0), run(t, "size(osv.cwes(osv.vulns(data)[1]))", sampleData()))
+
+	// A realistic triage policy: fail only on exploited-or-likely critical vulns.
+	require.Equal(t, true, run(t, "osv.vulns(data).exists(v, osv.cvss(v) >= 9.0 && (osv.isKEV(v) || osv.epss(v) >= 0.5))", sampleData()))
 }
 
 func TestEmptyAndMalformed(t *testing.T) {

--- a/pkg/evaluator/plugins/osv/plugin.go
+++ b/pkg/evaluator/plugins/osv/plugin.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package osv provides CEL helpers for writing policies over OSV results
+// predicates. OSV data nests findings three levels deep:
+//
+//	(results -> packages -> vulnerabilities)
+//
+// and encodes severity as CVSS vector strings, which makes raw CEL policies
+// verbose and error-prone. These plugin methods flatten the JSON traversal,
+// expose alias aware id matching, and reuse the AMPEL cvss plugin scorer
+// so authors can write intent-level checks.
+package osv
+
+import (
+	"github.com/carabiner-dev/attestation"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/google/cel-go/cel"
+
+	api "github.com/carabiner-dev/ampel/pkg/api/v1"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
+)
+
+var Identity = class.MustParseIdentity("osv@v1")
+
+type Plugin struct {
+	Tool *OSVTool
+}
+
+func New() *Plugin {
+	return &Plugin{
+		Tool: &OSVTool{},
+	}
+}
+
+func (p *Plugin) Capabilities() []api.Capability {
+	return []api.Capability{
+		api.CapabilityEvalEnginePlugin,
+	}
+}
+
+func (p *Plugin) CanRegisterFor(c class.Class) bool {
+	return c.Name() == "cel"
+}
+
+func (p *Plugin) Library() cel.EnvOption {
+	return cel.Lib(p.Tool)
+}
+
+func (p *Plugin) VarValues(_ *papi.Policy, _ attestation.Subject, _ []attestation.Predicate) map[string]any {
+	return map[string]any{
+		"osv": p.Tool,
+	}
+}
+
+func (p *Plugin) Identity() *class.Identity {
+	return Identity
+}

--- a/pkg/evaluator/plugins/osv/tool.go
+++ b/pkg/evaluator/plugins/osv/tool.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -22,23 +23,36 @@ var OSVType = cel.ObjectType("osv", traits.ReceiverType)
 
 type OSVTool struct{}
 
-// Functions returns the CEL member functions exposed on the `osv` object:
+// Functions returns the CEL member functions exposed on the `osv` object.
 //
-//	osv.vulns(data)        -> list  : every vulnerability, flattened across
-//	                                  results -> packages -> vulnerabilities
-//	osv.ids(data)          -> list  : the id of every vulnerability
-//	osv.aliases(vuln)      -> list  : a vulnerability's id plus its aliases
-//	osv.matchesID(vuln, id)-> bool  : true if id equals the vuln's id or an alias
-//	osv.cvss(vuln)         -> double: highest CVSS base score across the vuln's
-//	                                  severity vectors (0 when none parse)
+// Document-level take an OSV results object or a whole predicate, so both
+// osv.vulns(predicate) and osv.vulns(predicate.data) work:
 //
-// The data argument may be an OSV results object or a whole predicate (`data`
-// key is unwrapped automatically), so both osv.vulns(predicate) and
-// osv.vulns(predicate.data) work.
+//	osv.vulns(data)             -> list  : every vulnerability, flattened across
+//	                                       results -> packages -> vulnerabilities
+//	osv.ids(data)               -> list  : the id of every vulnerability
+//	osv.forEcosystem(data, eco) -> list  : vulnerabilities in the ecosystem
+//	osv.forPackage(data, name)  -> list  : vulnerabilities affecting the package
+//
+// Vulnerability-level (take a single vulnerability from osv.vulns):
+//
+//	osv.aliases(vuln)       -> list  : a vulnerability's id plus its aliases
+//	osv.matchesID(vuln, id) -> bool  : true if id equals the vuln's id or alias
+//	osv.cvss(vuln)          -> double: highest CVSS base score across severities
+//	osv.severityLabel(vuln) -> string: qualitative severity (CRITICAL/HIGH/...)
+//	osv.isFixed(vuln)       -> bool  : true if a fixed version is available
+//	osv.fixedVersions(vuln) -> list  : the versions that fix the vulnerability
+//	osv.purl(vuln)          -> string: the affected package URL
+//	osv.ecosystem(vuln)     -> string: the affected package ecosystem
 func (t *OSVTool) Functions() []cel.EnvOption {
 	return []cel.EnvOption{
+		// Document-level
 		dynListFn("vulns", flattenVulns),
 		stringListFn("ids", vulnIDs),
+		dynFilterFn("forEcosystem", forEcosystem),
+		dynFilterFn("forPackage", forPackage),
+
+		// Vulnerability-level
 		stringListFn("aliases", aliasesOf),
 		cel.Function("matchesID",
 			cel.MemberOverload("osv_matchesid_binding",
@@ -55,14 +69,12 @@ func (t *OSVTool) Functions() []cel.EnvOption {
 				}),
 			),
 		),
-		cel.Function("cvss",
-			cel.MemberOverload("osv_cvss_binding",
-				[]*cel.Type{OSVType, cel.DynType}, cel.DoubleType,
-				cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
-					return types.Double(bestCVSS(toGo(rhs)))
-				}),
-			),
-		),
+		doubleFn("cvss", bestCVSS),
+		stringFn("severityLabel", severityLabel),
+		boolFn("isFixed", isFixed),
+		stringListFn("fixedVersions", fixedVersions),
+		stringFn("purl", vulnPURL),
+		stringFn("ecosystem", vulnEcosystem),
 	}
 }
 
@@ -85,6 +97,62 @@ func stringListFn(name string, fn func(any) []string) cel.EnvOption {
 			[]*cel.Type{OSVType, cel.DynType}, cel.ListType(cel.StringType),
 			cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
 				return types.DefaultTypeAdapter.NativeToValue(fn(toGo(rhs)))
+			}),
+		),
+	)
+}
+
+// stringFn registers an (osv, dyn) -> string member function.
+func stringFn(name string, fn func(any) string) cel.EnvOption {
+	return cel.Function(name,
+		cel.MemberOverload("osv_"+name+"_binding",
+			[]*cel.Type{OSVType, cel.DynType}, cel.StringType,
+			cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
+				return types.String(fn(toGo(rhs)))
+			}),
+		),
+	)
+}
+
+// boolFn registers an (osv, dyn) -> bool member function.
+func boolFn(name string, fn func(any) bool) cel.EnvOption {
+	return cel.Function(name,
+		cel.MemberOverload("osv_"+name+"_binding",
+			[]*cel.Type{OSVType, cel.DynType}, cel.BoolType,
+			cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
+				return types.Bool(fn(toGo(rhs)))
+			}),
+		),
+	)
+}
+
+// doubleFn registers an (osv, dyn) -> double member function.
+func doubleFn(name string, fn func(any) float64) cel.EnvOption {
+	return cel.Function(name,
+		cel.MemberOverload("osv_"+name+"_binding",
+			[]*cel.Type{OSVType, cel.DynType}, cel.DoubleType,
+			cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
+				return types.Double(fn(toGo(rhs)))
+			}),
+		),
+	)
+}
+
+// dynFilterFn registers an (osv, dyn, string) -> list<dyn> member function used
+// by the document-level filters (forEcosystem, forPackage).
+func dynFilterFn(name string, fn func(any, string) []any) cel.EnvOption {
+	return cel.Function(name,
+		cel.MemberOverload("osv_"+name+"_binding",
+			[]*cel.Type{OSVType, cel.DynType, cel.StringType}, cel.ListType(cel.DynType),
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				if len(args) != 3 {
+					return types.NewErrFromString("osv." + name + " requires data and a string argument")
+				}
+				arg, ok := args[2].Value().(string)
+				if !ok {
+					return types.NewErrFromString("osv." + name + ": second argument must be a string")
+				}
+				return types.DefaultTypeAdapter.NativeToValue(fn(toGo(args[1]), arg))
 			}),
 		),
 	)
@@ -176,18 +244,18 @@ func aliasesOf(vuln any) []string {
 	return out
 }
 
-// bestCVSS returns the highest CVSS base score across the vulnerability's
-// severity vectors, or 0 when none are present or parseable.
-func bestCVSS(vuln any) float64 {
+// bestVector returns the severity vector with the highest CVSS score, or "".
+func bestVector(vuln any) string {
 	vm, ok := vuln.(map[string]any)
 	if !ok {
-		return 0
+		return ""
 	}
 	severities, ok := vm["severity"].([]any)
 	if !ok {
-		return 0
+		return ""
 	}
-	best := 0.0
+	best := ""
+	bestScore := -1.0
 	for _, s := range severities {
 		sm, ok := s.(map[string]any)
 		if !ok {
@@ -197,11 +265,163 @@ func bestCVSS(vuln any) float64 {
 		if !ok || vector == "" {
 			continue
 		}
-		if score, err := cvss.Score(vector); err == nil && score > best {
-			best = score
+		if score, err := cvss.Score(vector); err == nil && score > bestScore {
+			bestScore = score
+			best = vector
 		}
 	}
 	return best
+}
+
+// bestCVSS returns the highest CVSS base score across the vulnerability's
+// severity vectors, or 0 when none are present or parseable.
+func bestCVSS(vuln any) float64 {
+	vector := bestVector(vuln)
+	if vector == "" {
+		return 0
+	}
+	if score, err := cvss.Score(vector); err == nil {
+		return score
+	}
+	return 0
+}
+
+// severityLabel returns a qualitative severity: the CVSS rating of the highest
+// scoring vector, falling back to the scanner's own label in database_specific
+// (upper-cased) for vulnerabilities that carry no CVSS vector.
+func severityLabel(vuln any) string {
+	if vector := bestVector(vuln); vector != "" {
+		if severity, err := cvss.Severity(vector); err == nil && severity != "" {
+			return severity
+		}
+	}
+	if s := dbSpecificSeverity(vuln); s != "" {
+		return strings.ToUpper(s)
+	}
+	return ""
+}
+
+// dbSpecificSeverity returns the scanner-provided severity label stored in the
+// vulnerability's database_specific block, if any.
+func dbSpecificSeverity(vuln any) string {
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return ""
+	}
+	db, ok := vm["database_specific"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if s, ok := db["severity"].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// fixedVersions returns every version that fixes the vulnerability, drawn from
+// the affected ranges' "fixed" events.
+func fixedVersions(vuln any) []string {
+	out := []string{}
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return out
+	}
+	affected, ok := vm["affected"].([]any)
+	if !ok {
+		return out
+	}
+	for _, a := range affected {
+		am, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		ranges, ok := am["ranges"].([]any)
+		if !ok {
+			continue
+		}
+		for _, r := range ranges {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			events, ok := rm["events"].([]any)
+			if !ok {
+				continue
+			}
+			for _, e := range events {
+				em, ok := e.(map[string]any)
+				if !ok {
+					continue
+				}
+				if fixed, ok := em["fixed"].(string); ok && fixed != "" {
+					out = append(out, fixed)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// isFixed reports whether the vulnerability has at least one fixed version.
+func isFixed(vuln any) bool {
+	return len(fixedVersions(vuln)) > 0
+}
+
+// affectedPackageField returns the first non-empty value of the named field
+// across the vulnerability's affected packages.
+func affectedPackageField(vuln any, field string) string {
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return ""
+	}
+	affected, ok := vm["affected"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, a := range affected {
+		am, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		pkg, ok := am["package"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if v, ok := pkg[field].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func vulnPURL(vuln any) string      { return affectedPackageField(vuln, "purl") }
+func vulnEcosystem(vuln any) string { return affectedPackageField(vuln, "ecosystem") }
+
+// forEcosystem returns the vulnerabilities whose affected package is in the
+// given OSV ecosystem (matched case-insensitively).
+func forEcosystem(data any, ecosystem string) []any {
+	out := []any{}
+	for _, v := range flattenVulns(data) {
+		if strings.EqualFold(vulnEcosystem(v), ecosystem) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// forPackage returns the vulnerabilities affecting the given package, matched
+// by exact package name or PURL, or by the query appearing within the PURL (so
+// a bare package name matches its versioned PURL).
+func forPackage(data any, pkg string) []any {
+	out := []any{}
+	for _, v := range flattenVulns(data) {
+		name := affectedPackageField(v, "name")
+		purl := vulnPURL(v)
+		if name == pkg || purl == pkg || (pkg != "" && strings.Contains(purl, pkg)) {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // toGo converts a CEL value (a structpb-backed map/list from predicate data)

--- a/pkg/evaluator/plugins/osv/tool.go
+++ b/pkg/evaluator/plugins/osv/tool.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package osv
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/carabiner-dev/ampel/pkg/evaluator/plugins/cvss"
+)
+
+// OSVType is the CEL receiver type backing the `osv` variable.
+var OSVType = cel.ObjectType("osv", traits.ReceiverType)
+
+type OSVTool struct{}
+
+// Functions returns the CEL member functions exposed on the `osv` object:
+//
+//	osv.vulns(data)        -> list  : every vulnerability, flattened across
+//	                                  results -> packages -> vulnerabilities
+//	osv.ids(data)          -> list  : the id of every vulnerability
+//	osv.aliases(vuln)      -> list  : a vulnerability's id plus its aliases
+//	osv.matchesID(vuln, id)-> bool  : true if id equals the vuln's id or an alias
+//	osv.cvss(vuln)         -> double: highest CVSS base score across the vuln's
+//	                                  severity vectors (0 when none parse)
+//
+// The data argument may be an OSV results object or a whole predicate (`data`
+// key is unwrapped automatically), so both osv.vulns(predicate) and
+// osv.vulns(predicate.data) work.
+func (t *OSVTool) Functions() []cel.EnvOption {
+	return []cel.EnvOption{
+		dynListFn("vulns", flattenVulns),
+		stringListFn("ids", vulnIDs),
+		stringListFn("aliases", aliasesOf),
+		cel.Function("matchesID",
+			cel.MemberOverload("osv_matchesid_binding",
+				[]*cel.Type{OSVType, cel.DynType, cel.StringType}, cel.BoolType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					if len(args) != 3 {
+						return types.NewErrFromString("osv.matchesID requires a vulnerability and an id")
+					}
+					id, ok := args[2].Value().(string)
+					if !ok {
+						return types.NewErrFromString("osv.matchesID: id must be a string")
+					}
+					return types.Bool(slices.Contains(aliasesOf(toGo(args[1])), id))
+				}),
+			),
+		),
+		cel.Function("cvss",
+			cel.MemberOverload("osv_cvss_binding",
+				[]*cel.Type{OSVType, cel.DynType}, cel.DoubleType,
+				cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
+					return types.Double(bestCVSS(toGo(rhs)))
+				}),
+			),
+		),
+	}
+}
+
+// dynListFn registers an (osv, dyn) -> list<dyn> member function.
+func dynListFn(name string, fn func(any) []any) cel.EnvOption {
+	return cel.Function(name,
+		cel.MemberOverload("osv_"+name+"_binding",
+			[]*cel.Type{OSVType, cel.DynType}, cel.ListType(cel.DynType),
+			cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
+				return types.DefaultTypeAdapter.NativeToValue(fn(toGo(rhs)))
+			}),
+		),
+	)
+}
+
+// stringListFn registers an (osv, dyn) -> list<string> member function.
+func stringListFn(name string, fn func(any) []string) cel.EnvOption {
+	return cel.Function(name,
+		cel.MemberOverload("osv_"+name+"_binding",
+			[]*cel.Type{OSVType, cel.DynType}, cel.ListType(cel.StringType),
+			cel.BinaryBinding(func(_ ref.Val, rhs ref.Val) ref.Val {
+				return types.DefaultTypeAdapter.NativeToValue(fn(toGo(rhs)))
+			}),
+		),
+	)
+}
+
+// OSV traversal (operates on the native JSON shape produced by protojson).
+
+// osvResults returns the OSV results object, unwrapping a predicate `data` key
+// when present so callers may pass either a predicate or its data.
+func osvResults(data any) map[string]any {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if _, ok := m["results"]; ok {
+		return m
+	}
+	if inner, ok := m["data"].(map[string]any); ok {
+		if _, ok := inner["results"]; ok {
+			return inner
+		}
+	}
+	return nil
+}
+
+// flattenVulns collapses results -> packages -> vulnerabilities into one list.
+func flattenVulns(data any) []any {
+	out := []any{}
+	root := osvResults(data)
+	if root == nil {
+		return out
+	}
+	results, ok := root["results"].([]any)
+	if !ok {
+		return out
+	}
+	for _, r := range results {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		packages, ok := rm["packages"].([]any)
+		if !ok {
+			continue
+		}
+		for _, p := range packages {
+			pm, ok := p.(map[string]any)
+			if !ok {
+				continue
+			}
+			if vulns, ok := pm["vulnerabilities"].([]any); ok {
+				out = append(out, vulns...)
+			}
+		}
+	}
+	return out
+}
+
+// vulnIDs returns the id of every vulnerability in the document.
+func vulnIDs(data any) []string {
+	out := []string{}
+	for _, v := range flattenVulns(data) {
+		if vm, ok := v.(map[string]any); ok {
+			if id, ok := vm["id"].(string); ok && id != "" {
+				out = append(out, id)
+			}
+		}
+	}
+	return out
+}
+
+// aliasesOf returns a vulnerability's id followed by its declared aliases.
+func aliasesOf(vuln any) []string {
+	out := []string{}
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return out
+	}
+	if id, ok := vm["id"].(string); ok && id != "" {
+		out = append(out, id)
+	}
+	if aliases, ok := vm["aliases"].([]any); ok {
+		for _, a := range aliases {
+			if s, ok := a.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+// bestCVSS returns the highest CVSS base score across the vulnerability's
+// severity vectors, or 0 when none are present or parseable.
+func bestCVSS(vuln any) float64 {
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return 0
+	}
+	severities, ok := vm["severity"].([]any)
+	if !ok {
+		return 0
+	}
+	best := 0.0
+	for _, s := range severities {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		vector, ok := sm["score"].(string)
+		if !ok || vector == "" {
+			continue
+		}
+		if score, err := cvss.Score(vector); err == nil && score > best {
+			best = score
+		}
+	}
+	return best
+}
+
+// toGo converts a CEL value (a structpb-backed map/list from predicate data)
+// into native Go values (map[string]any / []any / primitives).
+func toGo(v ref.Val) any {
+	if v == nil {
+		return nil
+	}
+	if native, err := v.ConvertToNative(reflect.TypeFor[*structpb.Value]()); err == nil {
+		if sv, ok := native.(*structpb.Value); ok {
+			return sv.AsInterface()
+		}
+	}
+	return v.Value()
+}
+
+// CEL ref.Val + Library plumbing.
+
+func (t *OSVTool) ConvertToType(typeVal ref.Type) ref.Val {
+	if typeVal == types.TypeType {
+		return OSVType
+	}
+	return types.NewErr("type conversion not allowed for osv")
+}
+
+func (*OSVTool) Type() ref.Type { return OSVType }
+
+func (*OSVTool) Equal(_ ref.Val) ref.Val {
+	return types.NewErr("objects cannot be compared")
+}
+
+func (t *OSVTool) Value() any { return t }
+
+func (*OSVTool) ConvertToNative(_ reflect.Type) (any, error) {
+	return nil, errors.New("osv cannot be converted to native")
+}
+
+type TypeAdapter struct{}
+
+func (TypeAdapter) NativeToValue(value any) ref.Val {
+	if val, ok := value.(OSVTool); ok {
+		return &val
+	}
+	return types.DefaultTypeAdapter.NativeToValue(value)
+}
+
+func (t *OSVTool) CompileOptions() []cel.EnvOption {
+	funcs := t.Functions()
+	ret := make([]cel.EnvOption, 0, 3+len(funcs))
+	ret = append(ret,
+		cel.Types(OSVType),
+		cel.CustomTypeAdapter(&TypeAdapter{}),
+		cel.Variable("osv", OSVType),
+	)
+	ret = append(ret, funcs...)
+	return ret
+}
+
+func (*OSVTool) ProgramOptions() []cel.ProgramOption { return nil }

--- a/pkg/evaluator/plugins/osv/tool.go
+++ b/pkg/evaluator/plugins/osv/tool.go
@@ -44,6 +44,15 @@ type OSVTool struct{}
 //	osv.fixedVersions(vuln) -> list  : the versions that fix the vulnerability
 //	osv.purl(vuln)          -> string: the affected package URL
 //	osv.ecosystem(vuln)     -> string: the affected package ecosystem
+//	osv.references(vuln)    -> list  : reference URLs
+//
+// Enriched field provided by original scanners *stored in database_specific) and
+// which default to 0/false/empty when the scanner did not supply the field:
+//
+//	osv.epss(vuln)  -> double: EPSS exploitation probability (0..1)
+//	osv.risk(vuln)  -> double: scanner risk score
+//	osv.isKEV(vuln) -> bool  : listed in a known-exploited catalog (CISA KEV)
+//	osv.cwes(vuln)  -> list  : associated CWE identifiers
 func (t *OSVTool) Functions() []cel.EnvOption {
 	return []cel.EnvOption{
 		// Document-level
@@ -75,6 +84,13 @@ func (t *OSVTool) Functions() []cel.EnvOption {
 		stringListFn("fixedVersions", fixedVersions),
 		stringFn("purl", vulnPURL),
 		stringFn("ecosystem", vulnEcosystem),
+		stringListFn("references", vulnReferences),
+
+		// Enrichment (from database_specific)
+		doubleFn("epss", vulnEPSS),
+		doubleFn("risk", vulnRisk),
+		boolFn("isKEV", vulnIsKEV),
+		stringListFn("cwes", vulnCWEs),
 	}
 }
 
@@ -436,6 +452,102 @@ func toGo(v ref.Val) any {
 		}
 	}
 	return v.Value()
+}
+
+// vulnReferences returns the URLs of the vulnerability's references.
+func vulnReferences(vuln any) []string {
+	out := []string{}
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return out
+	}
+	refs, ok := vm["references"].([]any)
+	if !ok {
+		return out
+	}
+	for _, r := range refs {
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if url, ok := rm["url"].(string); ok && url != "" {
+			out = append(out, url)
+		}
+	}
+	return out
+}
+
+// dbSpecific returns the vulnerability's database_specific object, or nil.
+func dbSpecific(vuln any) map[string]any {
+	vm, ok := vuln.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if db, ok := vm["database_specific"].(map[string]any); ok {
+		return db
+	}
+	return nil
+}
+
+// vulnEPSS returns the EPSS probability from database_specific. It accepts
+// either a bare number or a list of EPSS records (scanner-dependent shape),
+// returning the first record's score in the latter case.
+func vulnEPSS(vuln any) float64 {
+	db := dbSpecific(vuln)
+	if db == nil {
+		return 0
+	}
+	switch v := db["epss"].(type) {
+	case float64:
+		return v
+	case []any:
+		if len(v) > 0 {
+			if m, ok := v[0].(map[string]any); ok {
+				if f, ok := m["epss"].(float64); ok {
+					return f
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// vulnRisk returns the scanner-provided risk score from database_specific.
+func vulnRisk(vuln any) float64 {
+	if db := dbSpecific(vuln); db != nil {
+		if f, ok := db["risk"].(float64); ok {
+			return f
+		}
+	}
+	return 0
+}
+
+// vulnIsKEV reports whether the vulnerability is flagged as known-exploited in
+// database_specific.
+func vulnIsKEV(vuln any) bool {
+	if db := dbSpecific(vuln); db != nil {
+		if b, ok := db["known_exploited"].(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+// vulnCWEs returns the CWE identifiers stored in database_specific.
+func vulnCWEs(vuln any) []string {
+	out := []string{}
+	db := dbSpecific(vuln)
+	if db == nil {
+		return out
+	}
+	if list, ok := db["cwe_ids"].([]any); ok {
+		for _, c := range list {
+			if s, ok := c.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
 }
 
 // CEL ref.Val + Library plumbing.

--- a/pkg/evaluator/plugins/osv/tool.go
+++ b/pkg/evaluator/plugins/osv/tool.go
@@ -451,6 +451,14 @@ func toGo(v ref.Val) any {
 			return sv.AsInterface()
 		}
 	}
+	// ampel's CEL predicate wrapper cannot convert to a native map but exposes
+	// its fields via indexing; pull out the OSV data so osv.vulns(predicate)
+	// works the same as osv.vulns(predicate.data).
+	if indexer, ok := v.(traits.Indexer); ok {
+		if data := indexer.Get(types.String("data")); data != nil && !types.IsError(data) {
+			return toGo(data)
+		}
+	}
 	return v.Value()
 }
 

--- a/pkg/transformer/vulnreport/vulnreport.go
+++ b/pkg/transformer/vulnreport/vulnreport.go
@@ -31,6 +31,11 @@ import (
 // official in-toto predicate type, so we adopt the tool's repository URL.
 const GrypePredicateType = attestation.PredicateType("https://github.com/anchore/grype")
 
+// legacyOSVPredicateType is the pre-@v1 OSV results type. The collector's osv
+// parser normalizes it to cosv.PredicateType, but the transformer also accepts
+// it directly for robustness.
+const legacyOSVPredicateType = attestation.PredicateType("https://ossf.github.io/osv-schema/results@v1.6.7")
+
 var ClassName = "vulnreport"
 
 // PredicateTypes are the scanner report predicate types this transformer
@@ -38,15 +43,17 @@ var ClassName = "vulnreport"
 var PredicateTypes = []attestation.PredicateType{
 	ctrivy.PredicateType,
 	cosv.PredicateType,
+	legacyOSVPredicateType,
 	GrypePredicateType,
 }
 
 // scannerURIs maps each accepted input type to the scanner identity recorded in
 // the vulns/v0.2 predicate (the OSV format does not carry scanner identity).
 var scannerURIs = map[attestation.PredicateType]string{
-	ctrivy.PredicateType: "https://trivy.dev",
-	cosv.PredicateType:   "https://github.com/google/osv-scanner",
-	GrypePredicateType:   "https://github.com/anchore/grype",
+	ctrivy.PredicateType:   "https://trivy.dev",
+	cosv.PredicateType:     "https://github.com/google/osv-scanner",
+	legacyOSVPredicateType: "https://github.com/google/osv-scanner",
+	GrypePredicateType:     "https://github.com/anchore/grype",
 }
 
 // Output formats the vulnreport transformer can emit.
@@ -127,27 +134,32 @@ func (t *Transformer) Mutate(
 	return nil, newPreds, nil
 }
 
+// osvParser is used only for its dual-read SupportsType, so a predicate typed
+// with either the current @v1 or the legacy @v1.6.7 OSV type is recognized even
+// if it was not normalized upstream by the collector.
+var osvParser = cosv.New()
+
 // toOSVResults normalizes a scanner report predicate into the OSV results
 // format. The bool is false when the predicate is not a supported scanner
 // report, in which case it should be skipped.
 func toOSVResults(pred attestation.Predicate) (*osv.Results, bool, error) {
 	data := pred.GetData()
-	switch pred.GetType() {
-	case ctrivy.PredicateType:
+	switch {
+	case pred.GetType() == ctrivy.PredicateType:
 		report, err := trivy.Parse(data)
 		if err != nil {
 			return nil, true, fmt.Errorf("parsing trivy report: %w", err)
 		}
 		results, err := report.ToOSV()
 		return results, true, err
-	case GrypePredicateType:
+	case pred.GetType() == GrypePredicateType:
 		doc, err := grype.Parse(data)
 		if err != nil {
 			return nil, true, fmt.Errorf("parsing grype report: %w", err)
 		}
 		results, err := doc.ToOSV()
 		return results, true, err
-	case cosv.PredicateType:
+	case osvParser.SupportsType(pred.GetType()):
 		// OSV-Scanner already emits OSV; parse it straight through.
 		results, err := osv.NewParser().ParseResults(data)
 		if err != nil {

--- a/pkg/transformer/vulnreport/vulnreport_test.go
+++ b/pkg/transformer/vulnreport/vulnreport_test.go
@@ -118,6 +118,22 @@ func TestMutate(t *testing.T) {
 				require.Equal(t, "https://github.com/google/osv-scanner", report.GetScanner().GetUri())
 			},
 		},
+		{
+			// A predicate still typed with the legacy @v1.6.7 OSV type (i.e. not
+			// normalized upstream) is accepted via the parser's dual-read and
+			// emitted as the current @v1 OSV type.
+			name:      "osvscanner-legacy-type-accepted",
+			inputType: legacyOSVPredicateType,
+			dataPath:  "testdata/osv-scanner.json",
+			output:    OutputOSV,
+			wantType:  cosv.PredicateType,
+			validate: func(t *testing.T, pred attestation.Predicate) {
+				t.Helper()
+				results, ok := pred.GetParsed().(*osv.Results)
+				require.True(t, ok, "parsed predicate must be *osv.Results")
+				require.NotEmpty(t, results.GetResults())
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This PR adds a new CEL plugin to make it easier to write policies on OSV vuilnerability data. The new methods avoid fattening the document, make it easy to access vulnerability data, including handling aliases and leverages the cvss plugin's functions to expose CVSS data in the OSV records.