### PR TITLE
Add SkipUnsupportedRuntime option to soft-fail unmet runtimes

### DIFF
--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -211,6 +211,10 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().BoolVar(
+		&o.SkipUnsupportedRuntime, "skip-unsupported-runtime", verifier.DefaultVerificationOptions.SkipUnsupportedRuntime, "soft-fail policies when the runtime or plugins are unavailable",
+	)
+
+	cmd.PersistentFlags().BoolVar(
 		&o.Sign, "sign", false, "sign the results attestation",
 	)
 	o.SignerSet.AddFlags(cmd)
@@ -220,7 +224,7 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	groupFlags(cmd, grpEvidence, "key", "attestation", "collector", "signer")
 	groupFlags(cmd, grpContext, "context", "context-json", "context-yaml", "context-env")
 	groupFlags(cmd, grpResults, "attest-results", "attest-format", "results-path", "format", "publish")
-	groupFlags(cmd, grpVerification, "exit-code", "workers", "allow-empty-set-chain")
+	groupFlags(cmd, grpVerification, "exit-code", "workers", "allow-empty-set-chain", "skip-unsupported-runtime")
 	groupFlags(cmd, grpSigning, "sign")
 	// Sweep every flag the SignerSet just registered into the
 	// Signing section. Doing it post-hoc keeps the signer library's

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -38,10 +38,21 @@ func (f *Factory) Get(opts *options.EvaluatorOptions, c class.Class) (Evaluator,
 	if err != nil {
 		return nil, err
 	}
+
+	// When the policy's declared runtime asks for an engine version or plugins
+	// this binary cannot satisfy, we route its tenets to a stub evaluator. By
+	// default the stub fails them; when the caller opts in via
+	// SkipUnsupportedRuntime it soft-fails (skips) them instead.
+	mismatchStatus := papi.StatusFAIL
+	if opts.SkipUnsupportedRuntime {
+		mismatchStatus = papi.StatusSOFTFAIL
+	}
+
 	if !class.SupportsVersion(c.Version(), e.SupportedVersion()) {
 		return &versionMismatchEvaluator{
 			errMsg:    fmt.Sprintf("version %s is not supported by this engine (supports %s@%s)", c.String(), c.Name(), e.SupportedVersion()),
 			supported: e.SupportedVersion(),
+			status:    mismatchStatus,
 		}, nil
 	}
 	if pp, ok := e.(PluginAware); ok {
@@ -49,6 +60,7 @@ func (f *Factory) Get(opts *options.EvaluatorOptions, c class.Class) (Evaluator,
 			return &versionMismatchEvaluator{ //nolint:nilerr
 				errMsg:    err.Error(),
 				supported: e.SupportedVersion(),
+				status:    mismatchStatus,
 			}, nil
 		}
 	}
@@ -96,16 +108,25 @@ type Evaluator interface {
 
 // versionMismatchEvaluator is returned by the factory when the policy spec
 // requests a runtime or plugin version the engine binary does not support.
-// Every tenet routed to it produces a FAIL with a clear message; no code is executed.
+// Every tenet routed to it produces a result with status (FAIL by default, or
+// SOFTFAIL when the caller opted to skip unsupported runtimes) and a clear
+// message; no policy code is executed.
 type versionMismatchEvaluator struct {
 	errMsg    string
 	supported string
+	// status is the EvalResult status emitted for every tenet routed here.
+	// Empty is treated as FAIL.
+	status string
 }
 
 func (v *versionMismatchEvaluator) ExecTenet(_ context.Context, _ *options.EvaluatorOptions, tenet *papi.Tenet, _ []attestation.Predicate) (*papi.EvalResult, error) {
+	status := v.status
+	if status == "" {
+		status = papi.StatusFAIL
+	}
 	return &papi.EvalResult{
 		Id:     tenet.GetId(),
-		Status: papi.StatusFAIL,
+		Status: status,
 		Date:   timestamppb.Now(),
 		Error:  &papi.Error{Message: v.err().Error()},
 	}, nil

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -152,3 +152,42 @@ func TestFactoryVersionMismatch(t *testing.T) {
 		require.False(t, ok, "satisfied plugin with transformer requirement should return a real evaluator")
 	})
 }
+
+func TestFactorySkipUnsupportedRuntime(t *testing.T) {
+	t.Parallel()
+	f := &Factory{}
+
+	skipOpts := options.Default
+	skipOpts.SkipUnsupportedRuntime = true
+
+	// Each case declares a runtime this engine cannot satisfy. With the skip
+	// option on, the stub soft-fails the tenet; with it off (options.Default),
+	// the stub fails it.
+	for _, tc := range []struct {
+		name  string
+		class string
+	}{
+		{"unsupported engine version", "cel@v99"},
+		{"missing plugin", "cel@v0?plugin:nosuchplugin=v0"},
+		{"plugin version too new", "cel@v0?plugin:semver=v99"},
+	} {
+		t.Run(tc.name+" soft-fails when skipping", func(t *testing.T) {
+			t.Parallel()
+			e, err := f.Get(&skipOpts, class.MustParseClass(tc.class))
+			require.NoError(t, err)
+			result, err := e.ExecTenet(context.Background(), &skipOpts, &papi.Tenet{Id: "t"}, nil)
+			require.NoError(t, err)
+			require.Equal(t, papi.StatusSOFTFAIL, result.GetStatus(), "skip option should soft-fail unsupported runtime")
+			require.NotEmpty(t, result.GetError().GetMessage(), "the skipped result should still explain why")
+		})
+
+		t.Run(tc.name+" fails by default", func(t *testing.T) {
+			t.Parallel()
+			e, err := f.Get(&options.Default, class.MustParseClass(tc.class))
+			require.NoError(t, err)
+			result, err := e.ExecTenet(context.Background(), &options.Default, &papi.Tenet{Id: "t"}, nil)
+			require.NoError(t, err)
+			require.Equal(t, papi.StatusFAIL, result.GetStatus(), "default behavior should fail unsupported runtime")
+		})
+	}
+}

--- a/pkg/evaluator/options/options.go
+++ b/pkg/evaluator/options/options.go
@@ -8,6 +8,14 @@ package options
 type EvaluatorOptions struct {
 	LoadDefaultPlugins bool
 	ParallelWorkers    int8
+
+	// SkipUnsupportedRuntime makes the evaluator factory soft-fail (skip) tenets
+	// whose policy declares a runtime engine version or plugins that this binary
+	// does not provide, instead of failing them. This lets a policy set combine
+	// policies that rely on newer engine features with older engines that skip
+	// them rather than reporting a hard failure. The default (false) preserves
+	// the failing behavior.
+	SkipUnsupportedRuntime bool
 }
 
 var Default = EvaluatorOptions{

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -414,8 +414,7 @@ func (di *defaultIplementation) BuildEvaluators(opts *VerificationOptions, p *pa
 		if _, ok := evaluators[cl]; ok {
 			continue
 		}
-		// TODO(puerco): Options here should come from the verifier options
-		e, err := factory.Get(&options.EvaluatorOptions{}, rt)
+		e, err := factory.Get(&opts.EvaluatorOptions, rt)
 		if err != nil {
 			return nil, fmt.Errorf("building %q runtime: %w", t.Runtime, err)
 		}


### PR DESCRIPTION
This commit adds a new option (and flag) to configure the verifier to soft-fail policies when a policy requires more modern runtimes or plugins/transformers.