### PR TITLE
Release binaries for all runner platforms

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,8 +30,6 @@ builds:
       - arm64
       - arm
     ignore:
-      - goos: windows
-        goarch: arm64
       # 32-bit arm is built for linux only: darwin dropped it and there is no
       # windows/arm target worth shipping.
       - goos: windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,11 +28,16 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
     ignore:
       - goos: windows
         goarch: arm64
+      # 32-bit arm is built for linux only: darwin dropped it and there is no
+      # windows/arm target worth shipping.
+      - goos: windows
+        goarch: arm
       - goos: darwin
-        goarch: amd64
+        goarch: arm
     flags:
       - -trimpath
 

--- a/pkg/verifier/context.go
+++ b/pkg/verifier/context.go
@@ -121,7 +121,9 @@ func convertToInt64(value any) (int64, error) {
 	case int32:
 		return int64(v), nil
 	case uint:
-		if v > math.MaxInt64 {
+		// uint is platform sized, so widen before comparing: on 32-bit builds
+		// the untyped MaxInt64 constant does not fit in a uint.
+		if uint64(v) > math.MaxInt64 {
 			return 0, fmt.Errorf("uint value %d overflows int64", v)
 		}
 		return int64(v), nil


### PR DESCRIPTION
This PR expands the ampel binaries we build (from 4 to 7) to cover all the GitHub action runner platforms in addition to arm32 to run AMPEL on smaller devices.