### PR TITLE
Expose attestation signers to CEL environment

### DIFF
--- a/docs/03-ampel-policy-guide.md
+++ b/docs/03-ampel-policy-guide.md
@@ -559,3 +559,65 @@ To specify a key (unstable), use the following string format:
 ```
 key:::TYPE:::KEY_ID:::KEY_DATA
 ```
+
+### Accessing Verification Data in Policies
+
+Once AMPEL has verified an attestation, its verification data is exposed to CEL
+tenets through the `predicate.verification` object. The following fields are
+available:
+
+| Field | Description |
+| --- | --- |
+| `verification.verified` | Boolean, `true` when the attestation signature was cryptographically verified. |
+| `verification.identities` | The subset of signer identities that **matched a pinned allowlist** (the identities defined in the policy/`PolicySet` or passed via `--signer`). It is **empty when no allowlist was supplied**. |
+| `verification.signers` | The **actual verified signer identities** of the attestation. |
+
+Both `verification.identities` and `verification.signers` are lists whose
+elements share the same shape (`.id`, and one of `.sigstore`, `.key` or `.ref`,
+matching the identity kind).
+
+#### `verification.signers`
+
+`verification.signers` is **populated by AMPEL** from the signer identities it
+actually verified on the attestation. Unlike `verification.identities`, it is
+populated **even when no allowlist is configured**, so a policy can read who
+really signed the evidence regardless of whether signer identities were pinned:
+
+```cel
+// At least one signer used a sigstore (keyless) identity:
+predicate.verification.signers.exists(s, has(s.sigstore))
+
+// The attestation was signed by someone in a given domain:
+predicate.verification.signers.exists(s, has(s.sigstore) && s.sigstore.identity.endsWith("@example.com"))
+```
+
+AMPEL's CEL environment enables
+[optional types](https://github.com/google/cel-spec/wiki/proposal-246), so the
+`has()` guards can also be written with the optional selection syntax, where
+selecting an absent field yields an empty optional instead of an error:
+
+```cel
+// Same checks using optional types:
+predicate.verification.signers.exists(s, s.?sigstore.hasValue())
+predicate.verification.signers.exists(s, s.?sigstore.?identity.orValue("").endsWith("@example.com"))
+```
+
+> [!IMPORTANT]
+> `verification.signers` is **distinct from `verification.identities`**.
+> `identities` is the subset that matched a pinned allowlist (and is empty
+> without one), while `signers` is always the full set of actual verified
+> signers. `verification.signers` is an **AMPEL-provided view**: it is *not*
+> part of the `carabiner-dev/signer` Verification proto.
+
+#### `matchesId`
+
+The `verification` object also exposes a `matchesId` member function that
+matches an [identity slug](#identity-slugs) against the verification's identity
+set:
+
+```cel
+predicate.verification.matchesId("sigstore::https://accounts.google.com::joe@example.com")
+```
+
+With `verification.signers` now available, policies can additionally inspect the
+real signers directly using the `.exists`/`.all` comprehensions shown above.

--- a/pkg/evaluator/cel/verification.go
+++ b/pkg/evaluator/cel/verification.go
@@ -16,21 +16,28 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// extractVerificationData converts the verification data from a predicate into
-// a map[string]any suitable for structpb serialization into the CEL environment.
-func extractVerificationData(pred attestation.Predicate) map[string]any {
-	v, ok := pred.GetVerification().(*sapi.Verification)
-	if !ok || v == nil {
-		return nil
-	}
+// SignersProvider is implemented by predicate wrappers that can expose the
+// actual verified signer identities observed on an attestation. This is the
+// full set of signers AMPEL verified, as distinct from verification.identities
+// (the subset that matched a pinned allowlist, which is empty when none was
+// supplied). AMPEL's per-policy predicate wrapper (verifier.matchedPredicate)
+// implements this; when a predicate does, its signers are surfaced to policies
+// as verification.signers.
+//
+// Note: signers is an AMPEL-provided view. It is NOT part of the
+// carabiner-dev/signer Verification proto.
+type SignersProvider interface {
+	// Signers returns the actual verified signer identities of the attestation.
+	Signers() []*sapi.Identity
+}
 
-	sig := v.GetSignature()
-	if sig == nil {
-		return nil
-	}
-
-	identities := make([]any, 0, len(sig.GetIdentities()))
-	for _, id := range sig.GetIdentities() {
+// identitiesToAny converts a slice of signer identities into the CEL-friendly
+// []any representation. It is shared by verification.identities and
+// verification.signers so both fields expose the same element shape
+// (.id / .sigstore / .key / .ref).
+func identitiesToAny(ids []*sapi.Identity) []any {
+	out := make([]any, 0, len(ids))
+	for _, id := range ids {
 		idMap := map[string]any{
 			"id": id.GetId(),
 		}
@@ -53,13 +60,37 @@ func extractVerificationData(pred attestation.Predicate) map[string]any {
 				"id": r.GetId(),
 			}
 		}
-		identities = append(identities, idMap)
+		out = append(out, idMap)
+	}
+	return out
+}
+
+// extractVerificationData converts the verification data from a predicate into
+// a map[string]any suitable for structpb serialization into the CEL environment.
+func extractVerificationData(pred attestation.Predicate) map[string]any {
+	v, ok := pred.GetVerification().(*sapi.Verification)
+	if !ok || v == nil {
+		return nil
 	}
 
-	return map[string]any{
-		"verified":   sig.GetVerified(),
-		"identities": identities,
+	sig := v.GetSignature()
+	if sig == nil {
+		return nil
 	}
+
+	data := map[string]any{
+		"verified":   sig.GetVerified(),
+		"identities": identitiesToAny(sig.GetIdentities()),
+		// signers is populated by AMPEL from the actual verified signer
+		// identities (see SignersProvider). Unlike identities (the matched
+		// allowlist subset), it is populated even when no allowlist was
+		// supplied. It is an AMPEL-provided view, NOT part of the signer proto.
+		"signers": []any{},
+	}
+	if sp, ok := pred.(SignersProvider); ok {
+		data["signers"] = identitiesToAny(sp.Signers())
+	}
+	return data
 }
 
 // --- VerificationVal: custom CEL value with matchesId support ---
@@ -68,8 +99,15 @@ func extractVerificationData(pred attestation.Predicate) map[string]any {
 var VerificationType = cel.ObjectType("verification", traits.ReceiverType, traits.IndexerType)
 
 // VerificationVal wraps signer verification data as a CEL value. It exposes
-// field access (.verified, .identities) via an embedded structpb CEL map and
-// provides a matchesId member function for identity matching.
+// field access (.verified, .identities, .signers) via an embedded structpb CEL
+// map and provides a matchesId member function for identity matching.
+//
+// .identities is the subset of signers that matched a pinned allowlist (empty
+// when no allowlist was supplied). .signers is the full set of actual verified
+// signers AMPEL observed, populated regardless of any allowlist. matchesId
+// still matches against the verification's identity set; with .signers now
+// available, a policy can also inspect the real signers directly, e.g.
+// verification.signers.exists(s, has(s.sigstore)).
 type VerificationVal struct {
 	verification *sapi.Verification
 	celMap       ref.Val
@@ -77,13 +115,14 @@ type VerificationVal struct {
 
 // NewVerificationVal creates a VerificationVal from a predicate. If the
 // predicate is nil or has no verification, a default (unverified, no
-// identities) value is returned.
+// identities, no signers) value is returned.
 func NewVerificationVal(pred attestation.Predicate) *VerificationVal {
 	vv := &VerificationVal{}
 
 	vdata := map[string]any{
 		"verified":   false,
 		"identities": []any{},
+		"signers":    []any{},
 	}
 
 	if pred != nil {
@@ -186,7 +225,10 @@ func (p *PredicateVal) Get(index ref.Val) ref.Val {
 // --- matchesId function implementation ---
 
 // matchIdImpl parses a slug string into an Identity and checks it against
-// the verification data.
+// the verification data. matchesId matches against the verification's identity
+// set (the matched allowlist subset). With verification.signers now exposing
+// the actual verified signers, a policy can additionally inspect the real
+// signers directly (e.g. verification.signers.exists(s, has(s.sigstore))).
 var matchIdImpl = func(lhs ref.Val, rhs ref.Val) ref.Val {
 	vv, ok := lhs.(*VerificationVal)
 	if !ok {

--- a/pkg/evaluator/cel/verification_test.go
+++ b/pkg/evaluator/cel/verification_test.go
@@ -34,8 +34,11 @@ var _ attestation.Predicate = (*mockPredicate)(nil)
 func newTestEnv(t *testing.T) *cel.Env {
 	t.Helper()
 	vco := verificationCompileOptions()
-	opts := make([]cel.EnvOption, 0, 1+len(vco))
-	opts = append(opts, cel.Variable("predicate", cel.AnyType))
+	opts := make([]cel.EnvOption, 0, 2+len(vco))
+	// Optional types mirror the production environment (see the envOpts in
+	// implementation.go) so tests can pin the optional syntax
+	// (s.?field.orValue(...)) policies rely on.
+	opts = append(opts, cel.Variable("predicate", cel.AnyType), cel.OptionalTypes())
 	opts = append(opts, vco...)
 	env, err := cel.NewEnv(opts...)
 	require.NoError(t, err)
@@ -279,6 +282,12 @@ func TestPredicateVerificationSigners(t *testing.T) {
 		require.True(t, evalBool(t, env, `size(predicate.verification.signers) == 1`, vars))
 		require.True(t, evalBool(t, env, `predicate.verification.signers[0].sigstore.identity == "alice@example.com"`, vars))
 		require.True(t, evalBool(t, env, `predicate.verification.signers.exists(s, has(s.sigstore))`, vars))
+
+		// The optional-types syntax must work on signer elements: presence
+		// checks, safe chained selection and safe traversal of absent fields.
+		require.True(t, evalBool(t, env, `predicate.verification.signers.exists(s, s.?sigstore.hasValue())`, vars))
+		require.True(t, evalBool(t, env, `predicate.verification.signers.exists(s, s.?sigstore.?identity.orValue("") == "alice@example.com")`, vars))
+		require.True(t, evalBool(t, env, `predicate.verification.signers.all(s, s.?key.?id.orValue("none") == "none")`, vars))
 	})
 
 	// With an allowlist: identities is the matched subset (signerA only) while

--- a/pkg/evaluator/cel/verification_test.go
+++ b/pkg/evaluator/cel/verification_test.go
@@ -225,6 +225,109 @@ func TestPredicateVerificationFieldAccess(t *testing.T) {
 	})
 }
 
+// mockPredicateSigners extends mockPredicate with the actual verified signer
+// identities, mirroring verifier.matchedPredicate. It satisfies SignersProvider
+// so verification.signers is populated from Signers() rather than from the
+// verification's (matched-subset) identities.
+type mockPredicateSigners struct {
+	mockPredicate
+	signers []*sapi.Identity
+}
+
+func (m *mockPredicateSigners) Signers() []*sapi.Identity { return m.signers }
+
+var (
+	_ attestation.Predicate = (*mockPredicateSigners)(nil)
+	_ SignersProvider       = (*mockPredicateSigners)(nil)
+)
+
+func TestPredicateVerificationSigners(t *testing.T) {
+	t.Parallel()
+	env := newTestEnv(t)
+
+	signerA := &sapi.Identity{
+		Sigstore: &sapi.IdentitySigstore{
+			Issuer:   "https://accounts.google.com",
+			Identity: "alice@example.com",
+		},
+	}
+	signerB := &sapi.Identity{
+		Sigstore: &sapi.IdentitySigstore{
+			Issuer:   "https://accounts.google.com",
+			Identity: "bob@example.com",
+		},
+	}
+
+	// No allowlist: the verification's identities subset is empty while signers
+	// carries the actual signer AMPEL verified.
+	t.Run("no-allowlist", func(t *testing.T) {
+		t.Parallel()
+		pred := &mockPredicateSigners{
+			mockPredicate: mockPredicate{
+				verification: &sapi.Verification{
+					Signature: &sapi.SignatureVerification{
+						Verified:   true,
+						Identities: nil, // no allowlist supplied → empty subset
+					},
+				},
+			},
+			signers: []*sapi.Identity{signerA},
+		}
+		vars := testPredicateVars(pred)
+
+		require.True(t, evalBool(t, env, `size(predicate.verification.identities) == 0`, vars))
+		require.True(t, evalBool(t, env, `size(predicate.verification.signers) == 1`, vars))
+		require.True(t, evalBool(t, env, `predicate.verification.signers[0].sigstore.identity == "alice@example.com"`, vars))
+		require.True(t, evalBool(t, env, `predicate.verification.signers.exists(s, has(s.sigstore))`, vars))
+	})
+
+	// With an allowlist: identities is the matched subset (signerA only) while
+	// signers remains the full actual set (signerA and signerB).
+	t.Run("with-allowlist", func(t *testing.T) {
+		t.Parallel()
+		pred := &mockPredicateSigners{
+			mockPredicate: mockPredicate{
+				verification: &sapi.Verification{
+					Signature: &sapi.SignatureVerification{
+						Verified:   true,
+						Identities: []*sapi.Identity{signerA}, // matched subset
+					},
+				},
+			},
+			signers: []*sapi.Identity{signerA, signerB}, // full actual set
+		}
+		vars := testPredicateVars(pred)
+
+		require.True(t, evalBool(t, env, `size(predicate.verification.identities) == 1`, vars))
+		require.True(t, evalBool(t, env, `predicate.verification.identities[0].sigstore.identity == "alice@example.com"`, vars))
+		require.True(t, evalBool(t, env, `size(predicate.verification.signers) == 2`, vars))
+		require.True(t, evalBool(t, env, `predicate.verification.signers.exists(s, s.sigstore.identity == "bob@example.com")`, vars))
+	})
+
+	// A predicate that does not implement SignersProvider exposes an empty
+	// signers list (never absent), so policies can safely reference it.
+	t.Run("no-signers-provider", func(t *testing.T) {
+		t.Parallel()
+		pred := &mockPredicate{
+			verification: &sapi.Verification{
+				Signature: &sapi.SignatureVerification{
+					Verified:   true,
+					Identities: []*sapi.Identity{signerA},
+				},
+			},
+		}
+		vars := testPredicateVars(pred)
+		require.True(t, evalBool(t, env, `size(predicate.verification.signers) == 0`, vars))
+	})
+
+	// A nil predicate yields the default value with an empty signers list.
+	t.Run("nil-predicate", func(t *testing.T) {
+		t.Parallel()
+		vars := testPredicateVars(nil)
+		require.True(t, evalBool(t, env, `size(predicate.verification.signers) == 0`, vars))
+	})
+}
+
 func TestPredicateDataAccess(t *testing.T) {
 	t.Parallel()
 	env := newTestEnv(t)

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -30,6 +30,7 @@ import (
 
 	acontext "github.com/carabiner-dev/ampel/pkg/context"
 	"github.com/carabiner-dev/ampel/pkg/evaluator"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/cel"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/evalcontext"
 	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
@@ -667,9 +668,27 @@ func (di *defaultIplementation) FilterAttestations(opts *VerificationOptions, su
 					Identities: matchedIds,
 				},
 			},
+			// Carry the attestation's actual verified signers, independent of
+			// the matched allowlist subset above. These are populated even when
+			// no allowlist is configured and are surfaced to policies as
+			// verification.signers.
+			signers: envelopeSigners(env),
 		})
 	}
 	return preds, nil
+}
+
+// envelopeSigners returns the actual verified signer identities recorded on an
+// envelope's verification, tolerating a nil/absent verification by returning
+// nil. Unlike the matched allowlist subset carried on matchedPredicate's
+// verification, these are the real signers AMPEL observed regardless of whether
+// an allowlist was pinned.
+func envelopeSigners(env attestation.Envelope) []*sapi.Identity {
+	v, ok := env.GetVerification().(*sapi.Verification)
+	if !ok || v == nil {
+		return nil
+	}
+	return v.GetSignature().GetIdentities()
 }
 
 // matchedPredicate wraps a shared attestation.Predicate to carry the identities
@@ -678,9 +697,18 @@ func (di *defaultIplementation) FilterAttestations(opts *VerificationOptions, su
 // the verification accessors so the evaluator sees the per-policy matched
 // identities while leaving the shared predicate (and the signer identity cached
 // on its envelope) untouched. See FilterAttestations and issue #298.
+//
+// It additionally carries the attestation's actual verified signers so policies
+// can read who really signed (via verification.signers in CEL) regardless of
+// whether an allowlist was pinned. This satisfies cel.SignersProvider.
 type matchedPredicate struct {
 	attestation.Predicate
 	verification attestation.Verification
+	// signers holds the actual verified signer identities observed on the
+	// attestation envelope. It is distinct from the matched allowlist subset
+	// carried on verification (which is empty when no allowlist was supplied)
+	// and is surfaced to the evaluator as verification.signers.
+	signers []*sapi.Identity
 }
 
 func (mp *matchedPredicate) GetVerification() attestation.Verification {
@@ -690,6 +718,18 @@ func (mp *matchedPredicate) GetVerification() attestation.Verification {
 func (mp *matchedPredicate) SetVerification(v attestation.Verification) {
 	mp.verification = v
 }
+
+// Signers returns the actual verified signer identities of the attestation.
+// The CEL verification adapter reads these (via cel.SignersProvider) to
+// populate verification.signers. It is an AMPEL-provided view and is NOT part
+// of the carabiner-dev/signer Verification proto.
+func (mp *matchedPredicate) Signers() []*sapi.Identity {
+	return mp.signers
+}
+
+// Compile-time assertion that matchedPredicate satisfies the CEL adapter's
+// SignersProvider contract, keeping the FilterAttestations → CEL plumbing intact.
+var _ cel.SignersProvider = (*matchedPredicate)(nil)
 
 // evaluateChain evaluates an evidence chain and returns the resulting subject
 func (di *defaultIplementation) evaluateChain(

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -511,11 +511,26 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 		}
 	}
 
-	// If there are no identities defined, return here with all envelopes
-	// accepted (no identity constraint to enforce). A nil ids slice signals
-	// to FilterAttestations that no identity filtering should be applied.
+	// If there are no identities defined, accept all envelopes (no identity
+	// constraint to enforce). A nil ids slice signals to FilterAttestations
+	// that no identity filtering should be applied. Signatures are still
+	// verified so each envelope's verification records the actual signer
+	// identities, which FilterAttestations surfaces to policies as
+	// verification.signers; failures are tolerated as there is no identity
+	// constraint to enforce. Like the verify-and-match step below, the
+	// verification is serialized under the per-run evidence lock because the
+	// envelopes are shared across the policies of a PolicySet.
 	if len(allIds) == 0 {
-		logrus.Debug("No identities defined in policy. Not checking.")
+		logrus.Debug("No identities defined in policy. Not filtering on signer identity.")
+		if mu := sharedEvidenceLock(ctx); mu != nil {
+			mu.Lock()
+			defer mu.Unlock()
+		}
+		for i, e := range envelopes {
+			if err := e.Verify(opts.Keys); err != nil {
+				logrus.Debugf("attestation %d (type %s): signature verification error: %v", i, e.GetStatement().GetType(), err)
+			}
+		}
 		return true, nil, nil, nil
 	}
 

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -639,6 +639,85 @@ func TestFilterAttestationsSkipsNonAdmitted(t *testing.T) {
 	require.Len(t, preds, 2, "only admitted envelopes should produce predicates")
 }
 
+// TestFilterAttestationsCarriesSigners verifies that FilterAttestations records
+// the attestation's actual verified signers on the matchedPredicate (surfaced
+// to policies as verification.signers) independently of the matched allowlist
+// subset carried on the verification (verification.identities).
+func TestFilterAttestationsCarriesSigners(t *testing.T) {
+	t.Parallel()
+
+	signerA := &sapi.Identity{Sigstore: &sapi.IdentitySigstore{Issuer: "https://example.com", Identity: "alice@example.com"}}
+	signerB := &sapi.Identity{Sigstore: &sapi.IdentitySigstore{Issuer: "https://example.com", Identity: "bob@example.com"}}
+
+	di := defaultIplementation{}
+
+	newEnv := func() attestation.Envelope {
+		return &fakeEnvelope{
+			pred: &fakePredicate{},
+			ver: &sapi.Verification{Signature: &sapi.SignatureVerification{
+				Verified:   true,
+				Identities: []*sapi.Identity{signerA, signerB},
+			}},
+		}
+	}
+
+	// No allowlist (CheckIdentities returns nil ids): identities subset is empty
+	// but signers carries the full actual signer set.
+	t.Run("no-allowlist", func(t *testing.T) {
+		t.Parallel()
+		preds, err := di.FilterAttestations(&VerificationOptions{}, nil, []attestation.Envelope{newEnv()}, nil)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+
+		mp, ok := preds[0].(*matchedPredicate)
+		require.True(t, ok)
+
+		v, ok := mp.GetVerification().(*sapi.Verification)
+		require.True(t, ok)
+		require.Empty(t, v.GetSignature().GetIdentities(), "matched identities must be empty without an allowlist")
+
+		require.Len(t, mp.Signers(), 2, "signers must carry the full actual signer set")
+		require.Same(t, signerA, mp.Signers()[0])
+		require.Same(t, signerB, mp.Signers()[1])
+	})
+
+	// With an allowlist that matched only signerA: identities is the matched
+	// subset while signers remains the full actual set.
+	t.Run("with-allowlist", func(t *testing.T) {
+		t.Parallel()
+		preds, err := di.FilterAttestations(
+			&VerificationOptions{}, nil, []attestation.Envelope{newEnv()},
+			[][]*sapi.Identity{{signerA}},
+		)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+
+		mp, ok := preds[0].(*matchedPredicate)
+		require.True(t, ok)
+
+		v, ok := mp.GetVerification().(*sapi.Verification)
+		require.True(t, ok)
+		require.Len(t, v.GetSignature().GetIdentities(), 1, "identities must be the matched subset")
+		require.Same(t, signerA, v.GetSignature().GetIdentities()[0])
+
+		require.Len(t, mp.Signers(), 2, "signers must remain the full actual set")
+	})
+
+	// A nil/absent envelope verification is tolerated: signers is empty.
+	t.Run("nil-verification", func(t *testing.T) {
+		t.Parallel()
+		preds, err := di.FilterAttestations(
+			&VerificationOptions{}, nil,
+			[]attestation.Envelope{&fakeEnvelope{pred: &fakePredicate{}}}, nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, preds, 1)
+		mp, ok := preds[0].(*matchedPredicate)
+		require.True(t, ok)
+		require.Empty(t, mp.Signers())
+	})
+}
+
 // TestProcessChainedSubjectsPropagatesFailFlag verifies that ProcessChainedSubjects
 // propagates policyFail=true when evaluateChain returns both an error and fail=true.
 // This covers the bug where the fail flag was discarded (hardcoded false) on error.

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -295,6 +295,10 @@ var _ attestation.Predicate = &fakePredicate{}
 type fakeEnvelope struct {
 	ver  attestation.Verification
 	pred attestation.Predicate
+	// verOnVerify, when set, is recorded as the envelope's verification by
+	// Verify, mimicking real envelopes that cache their verification result
+	// when their signatures are checked.
+	verOnVerify attestation.Verification
 }
 
 func (fe *fakeEnvelope) GetStatement() attestation.Statement {
@@ -304,7 +308,12 @@ func (fe *fakeEnvelope) GetPredicate() attestation.Predicate       { return fe.p
 func (fe *fakeEnvelope) GetSignatures() []attestation.Signature    { return nil }
 func (fe *fakeEnvelope) GetCertificate() attestation.Certificate   { return nil }
 func (fe *fakeEnvelope) GetVerification() attestation.Verification { return fe.ver }
-func (fe *fakeEnvelope) Verify(...any) error                       { return nil }
+func (fe *fakeEnvelope) Verify(...any) error {
+	if fe.verOnVerify != nil {
+		fe.ver = fe.verOnVerify
+	}
+	return nil
+}
 
 var _ attestation.Envelope = &fakeEnvelope{}
 
@@ -716,6 +725,38 @@ func TestFilterAttestationsCarriesSigners(t *testing.T) {
 		require.True(t, ok)
 		require.Empty(t, mp.Signers())
 	})
+}
+
+// TestCheckIdentitiesNoAllowlistVerifies verifies that CheckIdentities still
+// verifies the envelope signatures when no identity allowlist is defined, so
+// the actual signers get recorded on the envelope verification and surface to
+// policies as verification.signers (via FilterAttestations).
+func TestCheckIdentitiesNoAllowlistVerifies(t *testing.T) {
+	t.Parallel()
+
+	signer := &sapi.Identity{Sigstore: &sapi.IdentitySigstore{Issuer: "https://example.com", Identity: "alice@example.com"}}
+	env := &fakeEnvelope{
+		pred: &fakePredicate{},
+		verOnVerify: &sapi.Verification{Signature: &sapi.SignatureVerification{
+			Verified:   true,
+			Identities: []*sapi.Identity{signer},
+		}},
+	}
+
+	di := defaultIplementation{}
+	pass, ids, idErrors, err := di.CheckIdentities(context.Background(), &VerificationOptions{}, nil, []attestation.Envelope{env})
+	require.NoError(t, err)
+	require.Empty(t, idErrors)
+	require.True(t, pass)
+	require.Nil(t, ids, "a nil ids slice must signal that no identity filtering applies")
+
+	preds, err := di.FilterAttestations(&VerificationOptions{}, nil, []attestation.Envelope{env}, ids)
+	require.NoError(t, err)
+	require.Len(t, preds, 1)
+	mp, ok := preds[0].(*matchedPredicate)
+	require.True(t, ok)
+	require.Len(t, mp.Signers(), 1, "signers must carry the identities recorded during verification")
+	require.Same(t, signer, mp.Signers()[0])
 }
 
 // TestProcessChainedSubjectsPropagatesFailFlag verifies that ProcessChainedSubjects


### PR DESCRIPTION
This commit exposes all the attestation signers  (not just the recognized identities) on the CEL environment. 

We now introduce a new `signers` list in the verification object that captures the observed signers of the attestations. Note that this is different from `verification.identities` which has the expected identities from the verifier invocation.

