### PR TITLE
Add summary output driver

### DIFF
--- a/docs/06-eval-results.md
+++ b/docs/06-eval-results.md
@@ -1,0 +1,139 @@
+# Evaluation Results
+
+When AMPEL finishes evaluating a policy, the verdict needs to go somewhere.
+This document explains the result structures the verifier produces internally,
+the output drivers that render them for humans and machines, how results can be
+captured as attestations and how those attestations can be signed.
+
+## The Result Structures
+
+Internally, the verifier mirrors the structure of the policy it evaluates.
+Every layer of a policy produces a matching result type:
+
+- **EvalResult**: The evaluation result of a single tenet. It records the
+  tenet's PASS/FAIL/SOFTFAIL status, the attested statements that were used as
+  evidence, any output values the tenet code computed and the resulting
+  assessment (when it passes) or error (when it fails).
+- **Result**: The result of evaluating one policy. It aggregates the
+  EvalResults of the policy's tenets into a single status, together with the
+  policy identifier, its metadata and the evaluation context values in effect.
+- **ResultGroup**: The result of a [policy group](05-policy-groups.md). It
+  collects the results of the policies in the group's blocks and computes the
+  group status according to the group's assertion mode.
+- **ResultSet**: The result of the whole run. It contains a Result for each
+  policy in the PolicySet, a ResultGroup for each group, the subject under
+  evaluation and the overall status. Even a run with a single policy produces
+  a ResultSet wrapping one Result.
+
+Every level carries one of three status labels: `PASS`, `FAIL` or `SOFTFAIL`.
+Soft failures occur when a failing policy is not enforced (its `enforce` mode
+is off) or when the engine is instructed to tolerate missing runtimes or
+plugins (`--skip-unsupported-runtime`).
+
+## Output Drivers
+
+The verifier renders results through pluggable output drivers, selected with
+the `--format` (`-f`) flag of `ampel verify`:
+
+```bash
+ampel verify binary.exe -p policy.json -a attestation.intoto.json --format=summary
+```
+
+These are the supported drivers:
+
+| Format | Output |
+| --- | --- |
+| `tty` | Colored tables for the terminal (the default). |
+| `html` | The results tables as HTML, ready to embed in web pages or CI job summaries. |
+| `markdown` | The results tables as markdown. |
+| `summary` | A single traffic-light line (🔴🟡🟢) summarizing the run, ideal for compact destinations such as the GitHub Actions step summary. |
+| `attestation` | The results as an unsigned in-toto attestation statement. |
+| `vsa` | The results as a [SLSA Verification Summary Attestation](https://slsa.dev/spec/v1.0/verification_summary). |
+| `svr` | The results as a [Simple Verification Result](https://github.com/in-toto/attestation/blob/main/spec/predicates/svr.md) attestation. |
+
+The available formats are listed in the `ampel verify --help` output, the list
+is generated from the registered drivers so it is always up to date.
+
+## Attesting the Results
+
+Independent of the output rendered above, AMPEL can capture the evaluation
+results as an attestation. This is how a policy verdict becomes evidence:
+downstream tooling (including AMPEL itself) can consume the results
+attestation to gate later stages without re-running the evaluation.
+
+To attest the results of an evaluation, pass `--attest-results`:
+
+```bash
+ampel verify binary.exe -p policy.json -a attestation.intoto.json \
+    --attest-results --results-path=results.intoto.json
+```
+
+The attestation is written to the file specified with `--results-path`
+(`results.intoto.json` by default). The predicate format is controlled with
+`--attest-format`:
+
+- **`ampel`** (default): The full ResultSet described above, using the
+  `https://carabiner.dev/ampel/resultset/v0` predicate type. This is the
+  richest format, it preserves every policy, tenet and message.
+- **`vsa`**: A [SLSA Verification Summary Attestation](https://slsa.dev/spec/v1.0/verification_summary),
+  the standard summary format for policy verdicts in the SLSA ecosystem.
+- **`svr`**: A [Simple Verification Result](https://github.com/in-toto/attestation/blob/main/spec/predicates/svr.md),
+  a minimal in-toto predicate (`https://in-toto.io/attestation/svr/v0.1`)
+  that captures the verdict without the evaluation detail.
+
+## Signing the Results Attestations
+
+A results attestation is only as trustworthy as its signature. Passing
+`--sign` makes AMPEL sign the attestation it writes:
+
+```bash
+ampel verify binary.exe -p policy.json -a attestation.intoto.json \
+    --attest-results --sign
+```
+
+The signing method is selected with `--signing-backend`:
+
+- **`sigstore`** (default): Keyless signing using an OIDC identity. In
+  automation, ambient credentials are picked up automatically (for example,
+  the workflow identity token when running in GitHub Actions); interactively,
+  AMPEL starts the browser-based OIDC flow. Use `--sigstore-instance` to pick
+  the sigstore instance to sign against (`sigstore`, the public good instance,
+  is the default; `github` signs against GitHub's Sigstore deployment). By default the signature is
+  recorded in the Rekor transparency log (disable with
+  `--sigstore-rekor-append=false`).
+- **`key`**: Signing with private keys passed with `--signing-key` (`-K`).
+  AMPEL reads PEM-encoded PKCS#8, PKCS#1 and SEC1 keys as well as OpenPGP
+  keys. If a key is protected by a passphrase, AMPEL reads it from the
+  environment variable named by `--signing-key-passphrase-env`
+  (`SIGNING_KEY_PASSPHRASE` by default).
+- **`spiffe`**: Signing with an identity obtained from a SPIFFE Workload API
+  socket (`--spiffe-socket`), optionally enforcing the expected trust domain
+  with `--spiffe-trust-domain`.
+
+When signing through sigstore or SPIFFE, AMPEL adds an RFC 3161 timestamp from
+a trusted timestamp authority by default (disable with
+`--signing-timestamp=false`).
+
+## Writing a New Output Renderer
+
+Output drivers live in `internal/drivers/`, one package per format. A driver
+implements the render engine's `Driver` interface:
+
+```golang
+type Driver interface {
+	RenderResultSet(w io.Writer, status *papi.ResultSet) error
+	RenderResult(w io.Writer, status *papi.Result) error
+	RenderResultGroup(w io.Writer, status *papi.ResultGroup) error
+}
+```
+
+The three methods render the result structures described at the top of this
+document; each one writes its output to the supplied writer. To make the new
+driver available to `--format`, register it under its format name in
+`LoadDefaultDrivers()` in `internal/render/render.go` (programs embedding the
+engine can also call `render.RegisterDriver()` at runtime). Once registered,
+the driver automatically shows up in the format list of the
+`ampel verify --help` output.
+
+The `summary` driver is a good starting point to study: it is the smallest of
+the built-in drivers and exercises the whole interface.

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -159,7 +159,7 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&o.Format, "format", "f", "tty", "output format",
+		&o.Format, "format", "f", "tty", fmt.Sprintf("output format %v", render.Formats()),
 	)
 
 	cmd.PersistentFlags().StringSliceVarP(

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -305,10 +306,8 @@ func (o *verifyOptions) Validate() error {
 
 	if o.Format == "" {
 		errs = append(errs, errors.New("no output format defined"))
-	} else {
-		if err := render.GetDriverBytType(o.Format); err != nil {
-			errs = append(errs, errors.New("invalid format"))
-		}
+	} else if !slices.Contains(render.Formats(), o.Format) {
+		errs = append(errs, fmt.Errorf("invalid format %q (must be one of %v)", o.Format, render.Formats()))
 	}
 
 	if o.ParallelWorkers <= 0 {

--- a/internal/drivers/summary/driver.go
+++ b/internal/drivers/summary/driver.go
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package summary implements a rendering driver that outputs the
+// evaluation results as a single traffic-light line, suitable for
+// compact destinations such as the GitHub Actions step summary.
+package summary
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+)
+
+// New returns a new summary driver
+func New() *Driver {
+	return &Driver{}
+}
+
+// Driver renders evaluation results as a single line
+type Driver struct{}
+
+func dot(status string) string {
+	switch status {
+	case papi.StatusFAIL:
+		return "🔴"
+	case papi.StatusPASS:
+		return "🟢"
+	default:
+		return "🟡"
+	}
+}
+
+func policyID(r *papi.Result) string {
+	if id := r.GetPolicy().GetId(); id != "" {
+		return id
+	}
+	return "policy"
+}
+
+func groupID(g *papi.ResultGroup) string {
+	if id := g.GetGroup().GetId(); id != "" {
+		return id
+	}
+	return "policy group"
+}
+
+// decidingMessage returns the message from the eval result that decided
+// the policy status: the first tenet whose status matches the policy's,
+// preferring tenets that evaluated evidence over those that errored
+// before evaluating (eg for lack of attestations).
+func decidingMessage(r *papi.Result) string {
+	var deciding *papi.EvalResult
+	for _, er := range r.GetEvalResults() {
+		if er.GetStatus() != r.GetStatus() {
+			continue
+		}
+		if deciding == nil {
+			deciding = er
+		}
+		if len(er.GetStatements()) > 0 {
+			deciding = er
+			break
+		}
+	}
+	if deciding == nil && len(r.GetEvalResults()) > 0 {
+		deciding = r.GetEvalResults()[0]
+	}
+
+	if msg := deciding.GetAssessment().GetMessage(); msg != "" {
+		return msg
+	}
+	if msg := deciding.GetError().GetMessage(); msg != "" {
+		return msg
+	}
+	if msg := r.GetMeta().GetDescription(); msg != "" {
+		return msg
+	}
+	status := r.GetStatus()
+	if status == "" {
+		status = "evaluated"
+	}
+	return "policy " + strings.ToLower(status)
+}
+
+// groupMessage returns the message of the block that decided the group
+// status, drilling into its policy results for a more specific one.
+func groupMessage(g *papi.ResultGroup) string {
+	var deciding *papi.BlockEvalResult
+	for _, ber := range g.GetEvalResults() {
+		if ber.GetStatus() == g.GetStatus() {
+			deciding = ber
+			break
+		}
+	}
+	if deciding == nil && len(g.GetEvalResults()) > 0 {
+		deciding = g.GetEvalResults()[0]
+	}
+
+	if msg := deciding.GetError().GetMessage(); msg != "" {
+		return msg
+	}
+	for _, r := range deciding.GetResults() {
+		if r.GetStatus() == g.GetStatus() {
+			return decidingMessage(r)
+		}
+	}
+	if msg := g.GetMeta().GetDescription(); msg != "" {
+		return msg
+	}
+	status := g.GetStatus()
+	if status == "" {
+		status = "evaluated"
+	}
+	return "policy group " + strings.ToLower(status)
+}
+
+// RenderResult writes the policy result as a single line
+func (d *Driver) RenderResult(w io.Writer, result *papi.Result) error {
+	_, err := fmt.Fprintf(
+		w, "%s %s: %s\n", dot(result.GetStatus()), policyID(result), decidingMessage(result),
+	)
+	return err
+}
+
+// RenderResultGroup writes the group result as a single line
+func (d *Driver) RenderResultGroup(w io.Writer, group *papi.ResultGroup) error {
+	_, err := fmt.Fprintf(
+		w, "%s %s: %s\n", dot(group.GetStatus()), groupID(group), groupMessage(group),
+	)
+	return err
+}
+
+// RenderResultSet writes the whole resultset as a single line. Sets with
+// a single policy or group render as that unit's line; larger sets lead
+// with the first failing (or softfailing) unit and a failure count.
+func (d *Driver) RenderResultSet(w io.Writer, rset *papi.ResultSet) error {
+	results := rset.GetResults()
+	groups := rset.GetGroups()
+	total := len(results) + len(groups)
+
+	if total == 1 {
+		if len(results) == 1 {
+			return d.RenderResult(w, results[0])
+		}
+		return d.RenderResultGroup(w, groups[0])
+	}
+
+	prefix := ""
+	if id := rset.GetPolicySet().GetId(); id != "" {
+		prefix = id + ": "
+	}
+	overall := dot(rset.GetStatus())
+
+	if total == 0 {
+		msg := "no policy results found"
+		if m := rset.GetError().GetMessage(); m != "" {
+			msg = m
+		}
+		_, err := fmt.Fprintf(w, "%s %s%s\n", overall, prefix, msg)
+		return err
+	}
+
+	var failed, soft int
+	var failedID, failedMsg, softID, softMsg string
+	for _, r := range results {
+		switch r.GetStatus() {
+		case papi.StatusPASS:
+		case papi.StatusFAIL:
+			if failed == 0 {
+				failedID, failedMsg = policyID(r), decidingMessage(r)
+			}
+			failed++
+		default:
+			if soft == 0 {
+				softID, softMsg = policyID(r), decidingMessage(r)
+			}
+			soft++
+		}
+	}
+	for _, g := range groups {
+		switch g.GetStatus() {
+		case papi.StatusPASS:
+		case papi.StatusFAIL:
+			if failed == 0 {
+				failedID, failedMsg = groupID(g), groupMessage(g)
+			}
+			failed++
+		default:
+			if soft == 0 {
+				softID, softMsg = groupID(g), groupMessage(g)
+			}
+			soft++
+		}
+	}
+
+	var err error
+	switch {
+	case failed > 0:
+		_, err = fmt.Fprintf(
+			w, "%s %s%s: %s (%d of %d policies failed)\n",
+			overall, prefix, failedID, failedMsg, failed, total,
+		)
+	case soft > 0:
+		_, err = fmt.Fprintf(
+			w, "%s %s%s: %s (%d of %d policies softfailed)\n",
+			overall, prefix, softID, softMsg, soft, total,
+		)
+	default:
+		_, err = fmt.Fprintf(w, "%s %sall %d policies passed\n", overall, prefix, total)
+	}
+	return err
+}

--- a/internal/drivers/summary/driver_test.go
+++ b/internal/drivers/summary/driver_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package summary
+
+import (
+	"bytes"
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func testPolicies(t *testing.T) (pass, fail, soft *papi.Result) {
+	t.Helper()
+	passTenet := &papi.EvalResult{
+		Status:     papi.StatusPASS,
+		Statements: []*papi.StatementRef{{}},
+		Assessment: &papi.Assessment{Message: "build point found"},
+	}
+	// A tenet that never evaluated for lack of attestations
+	starvedTenet := &papi.EvalResult{
+		Status: papi.StatusFAIL,
+		Error:  &papi.Error{Message: "required attestations missing"},
+	}
+	failTenet := &papi.EvalResult{
+		Status:     papi.StatusFAIL,
+		Statements: []*papi.StatementRef{{}},
+		Error:      &papi.Error{Message: "build point mismatch"},
+	}
+
+	pass = &papi.Result{
+		Status: papi.StatusPASS, Policy: &papi.PolicyRef{Id: "pol-pass"},
+		EvalResults: []*papi.EvalResult{starvedTenet, passTenet},
+	}
+	fail = &papi.Result{
+		Status: papi.StatusFAIL, Policy: &papi.PolicyRef{Id: "pol-fail"},
+		EvalResults: []*papi.EvalResult{starvedTenet, failTenet},
+	}
+	soft = &papi.Result{
+		Status: papi.StatusSOFTFAIL, Policy: &papi.PolicyRef{Id: "pol-soft"},
+		EvalResults: []*papi.EvalResult{failTenet},
+	}
+	return pass, fail, soft
+}
+
+func TestRenderResultSet(t *testing.T) {
+	t.Parallel()
+	pass, fail, soft := testPolicies(t)
+	setRef := &papi.PolicyRef{Id: "test-set"}
+
+	for _, tc := range []struct {
+		name   string
+		rset   *papi.ResultSet
+		expect string
+	}{
+		// Single-policy sets render as the policy line, no set prefix.
+		// The passing policy picks the evaluated tenet's assessment over
+		// the starved tenet's error.
+		{
+			"single-pass",
+			&papi.ResultSet{Status: papi.StatusPASS, Results: []*papi.Result{pass}},
+			"🟢 pol-pass: build point found\n",
+		},
+		// The failing policy picks the evaluated failing tenet's error
+		{
+			"single-fail",
+			&papi.ResultSet{Status: papi.StatusFAIL, Results: []*papi.Result{fail}},
+			"🔴 pol-fail: build point mismatch\n",
+		},
+		{
+			"set-pass",
+			&papi.ResultSet{Status: papi.StatusPASS, PolicySet: setRef, Results: []*papi.Result{pass, pass}},
+			"🟢 test-set: all 2 policies passed\n",
+		},
+		{
+			"set-fail",
+			&papi.ResultSet{Status: papi.StatusFAIL, PolicySet: setRef, Results: []*papi.Result{pass, fail, pass}},
+			"🔴 test-set: pol-fail: build point mismatch (1 of 3 policies failed)\n",
+		},
+		{
+			"set-softfail",
+			&papi.ResultSet{Status: papi.StatusSOFTFAIL, PolicySet: setRef, Results: []*papi.Result{pass, soft}},
+			"🟡 test-set: pol-soft: build point mismatch (1 of 2 policies softfailed)\n",
+		},
+		// Hard failures win over softfails in the headline
+		{
+			"set-fail-and-softfail",
+			&papi.ResultSet{Status: papi.StatusFAIL, PolicySet: setRef, Results: []*papi.Result{soft, fail}},
+			"🔴 test-set: pol-fail: build point mismatch (1 of 2 policies failed)\n",
+		},
+		{
+			"empty-set",
+			&papi.ResultSet{Status: papi.StatusPASS, PolicySet: setRef},
+			"🟢 test-set: no policy results found\n",
+		},
+		{
+			"empty-set-with-error",
+			&papi.ResultSet{Status: papi.StatusFAIL, Error: &papi.Error{Message: "evaluation blew up"}},
+			"🔴 evaluation blew up\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var b bytes.Buffer
+			require.NoError(t, New().RenderResultSet(&b, tc.rset))
+			require.Equal(t, tc.expect, b.String())
+		})
+	}
+}
+
+func TestRenderResultGroup(t *testing.T) {
+	t.Parallel()
+	_, fail, _ := testPolicies(t)
+
+	group := &papi.ResultGroup{
+		Status: papi.StatusFAIL,
+		Group:  &papi.PolicyGroupRef{Id: "test-group"},
+		EvalResults: []*papi.BlockEvalResult{
+			{Status: papi.StatusPASS},
+			{Status: papi.StatusFAIL, Results: []*papi.Result{fail}},
+		},
+	}
+	var b bytes.Buffer
+	require.NoError(t, New().RenderResultGroup(&b, group))
+	require.Equal(t, "🔴 test-group: build point mismatch\n", b.String())
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -13,6 +13,7 @@ import (
 	"github.com/carabiner-dev/ampel/internal/drivers/attester"
 	"github.com/carabiner-dev/ampel/internal/drivers/html"
 	"github.com/carabiner-dev/ampel/internal/drivers/markdown"
+	"github.com/carabiner-dev/ampel/internal/drivers/summary"
 	"github.com/carabiner-dev/ampel/internal/drivers/svr"
 	"github.com/carabiner-dev/ampel/internal/drivers/tty"
 	"github.com/carabiner-dev/ampel/internal/drivers/vsa"
@@ -30,6 +31,7 @@ func LoadDefaultDrivers() {
 	drivers["attestation"] = attester.New()
 	drivers["html"] = html.New()
 	drivers["markdown"] = markdown.New()
+	drivers["summary"] = summary.New()
 	drivers["tty"] = tty.New()
 	drivers["svr"] = svr.New()
 	drivers["vsa"] = vsa.New()

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -6,6 +6,8 @@ package render
 import (
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 	"sync"
 
 	papi "github.com/carabiner-dev/policy/api/v1"
@@ -36,6 +38,14 @@ func LoadDefaultDrivers() {
 	drivers["svr"] = svr.New()
 	drivers["vsa"] = vsa.New()
 	drMtx.Unlock()
+}
+
+// Formats returns the names of the registered rendering drivers
+func Formats() []string {
+	LoadDefaultDrivers()
+	drMtx.Lock()
+	defer drMtx.Unlock()
+	return slices.Sorted(maps.Keys(drivers))
 }
 
 func GetDriverBytType(t string) Driver {


### PR DESCRIPTION
This commit adds a new output driver that only prints a shorter summary of the evaluation results. While the user can't know from the human output the details of the eval, this is intended to be used when the results are captured in an attestation.

Sample output:

```
  🔴 test-set: pol-b: pol-b exploded (1 of 3 policies failed)
  🟢 test-set: all 3 policies passed
  🟢 slsa-build-point: Expected build point found: git+ssh://github.com/carabiner-dev/vexflow
  🔴 slsa-build-point: Build point mismatch
```