### PR TITLE
Improve PolicyBlock success messages

### DIFF
--- a/internal/drivers/gotable/gotable.go
+++ b/internal/drivers/gotable/gotable.go
@@ -18,6 +18,52 @@ import (
 
 const headerSubject = "Subject"
 
+// assertModeOR mirrors the verifier's assert mode label. A block in OR
+// mode passes as soon as one of its policies does.
+const assertModeOR = "OR"
+
+// blockAssessments returns the assessment messages of the policies that
+// carried a block to PASS, in evaluation order and dedup'd.
+//
+// Under the default AND assert mode every policy in the block has to
+// pass, so all of their messages are reported. Under OR a single passing
+// policy decides the block, so only that policy's messages are reported:
+// the rest either failed or never got to run under lazy evaluation.
+func blockAssessments(block *papi.BlockEvalResult) []string {
+	orMode := block.GetMeta().GetAssertMode() == assertModeOR
+	msgs := []string{}
+	seen := map[string]struct{}{}
+	for _, res := range block.GetResults() {
+		if res.GetStatus() != papi.StatusPASS {
+			continue
+		}
+		added := false
+		for _, er := range res.GetEvalResults() {
+			if er.GetStatus() != papi.StatusPASS {
+				continue
+			}
+			msg := er.GetAssessment().GetMessage()
+			if msg == "" {
+				continue
+			}
+			if _, ok := seen[msg]; ok {
+				// Still the deciding policy under OR, just nothing new to say.
+				added = true
+				continue
+			}
+			seen[msg] = struct{}{}
+			msgs = append(msgs, msg)
+			added = true
+		}
+		// Keep looking if the deciding policy had nothing to report, so an
+		// OR block does not end up with an empty cell.
+		if orMode && added {
+			break
+		}
+	}
+	return msgs
+}
+
 type TableBuilder struct {
 	Decorator TableDecorator
 }
@@ -165,15 +211,11 @@ func (tb *TableBuilder) ResultSetTable(set *papi.ResultSet) (table.Writer, error
 					}
 					prefix = "[" + strings.Join(labels, ", ") + "] "
 				}
-				for _, res := range block.GetResults() {
-					for _, er := range res.GetEvalResults() {
-						if msg := er.GetAssessment().GetMessage(); msg != "" {
-							line := prefix + msg
-							if _, ok := seen[line]; !ok {
-								seen[line] = struct{}{}
-								msgs = append(msgs, line)
-							}
-						}
+				for _, msg := range blockAssessments(block) {
+					line := prefix + msg
+					if _, ok := seen[line]; !ok {
+						seen[line] = struct{}{}
+						msgs = append(msgs, line)
 					}
 				}
 			}
@@ -257,7 +299,12 @@ func (tb *TableBuilder) ResultGroupTable(grp *papi.ResultGroup) (table.Writer, e
 
 		var message string
 		if r.GetStatus() == papi.StatusPASS {
-			message = fmt.Sprintf("(%d policies)", len(r.Results))
+			message = strings.Join(blockAssessments(r), "\n")
+			// Fall back to the policy count when the passing policies
+			// define no assessment messages.
+			if message == "" {
+				message = fmt.Sprintf("(%d policies)", len(r.Results))
+			}
 		} else {
 			message = r.GetError().GetMessage()
 			if r.GetError().GetGuidance() != "" {

--- a/internal/drivers/gotable/gotable_test.go
+++ b/internal/drivers/gotable/gotable_test.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package gotable
+
+import (
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// pass builds a passing policy result carrying one assessment per message.
+func pass(msgs ...string) *papi.Result {
+	res := &papi.Result{Status: papi.StatusPASS}
+	for _, m := range msgs {
+		res.EvalResults = append(res.EvalResults, &papi.EvalResult{
+			Status:     papi.StatusPASS,
+			Assessment: &papi.Assessment{Message: m},
+		})
+	}
+	return res
+}
+
+// fail builds a failing policy result carrying one error per message.
+func fail(msgs ...string) *papi.Result {
+	res := &papi.Result{Status: papi.StatusFAIL}
+	for _, m := range msgs {
+		res.EvalResults = append(res.EvalResults, &papi.EvalResult{
+			Status: papi.StatusFAIL,
+			Error:  &papi.Error{Message: m},
+		})
+	}
+	return res
+}
+
+func TestBlockAssessments(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		assertMode string
+		results    []*papi.Result
+		expected   []string
+	}{
+		{
+			name:     "single policy",
+			results:  []*papi.Result{pass("SBOM is signed")},
+			expected: []string{"SBOM is signed"},
+		},
+		{
+			// Default (AND) mode: every policy had to pass, so report all.
+			name:       "and mode reports every policy",
+			assertMode: "",
+			results:    []*papi.Result{pass("has author"), pass("has timestamp")},
+			expected:   []string{"has author", "has timestamp"},
+		},
+		{
+			name:       "explicit and mode reports every policy",
+			assertMode: "AND",
+			results:    []*papi.Result{pass("has author"), pass("has timestamp")},
+			expected:   []string{"has author", "has timestamp"},
+		},
+		{
+			// OR mode: only the policy that carried the block is reported.
+			name:       "or mode reports only the deciding policy",
+			assertMode: "OR",
+			results:    []*papi.Result{fail("no purl"), pass("has CPE")},
+			expected:   []string{"has CPE"},
+		},
+		{
+			name:       "or mode stops at the first passing policy",
+			assertMode: "OR",
+			results:    []*papi.Result{pass("has purl"), pass("has CPE")},
+			expected:   []string{"has purl"},
+		},
+		{
+			// A silent deciding policy must not blank the cell when a later
+			// passing policy has something to report.
+			name:       "or mode skips a passing policy with no message",
+			assertMode: "OR",
+			results:    []*papi.Result{pass(), pass("has CPE")},
+			expected:   []string{"has CPE"},
+		},
+		{
+			name:       "failed policies are ignored",
+			assertMode: "AND",
+			results:    []*papi.Result{pass("has author"), fail("no license")},
+			expected:   []string{"has author"},
+		},
+		{
+			name:     "duplicate messages are collapsed",
+			results:  []*papi.Result{pass("has author"), pass("has author")},
+			expected: []string{"has author"},
+		},
+		{
+			name:     "no assessment messages",
+			results:  []*papi.Result{pass()},
+			expected: []string{},
+		},
+		{
+			name:     "no results",
+			results:  []*papi.Result{},
+			expected: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			block := &papi.BlockEvalResult{
+				Status:  papi.StatusPASS,
+				Meta:    &papi.PolicyBlockMeta{AssertMode: tc.assertMode},
+				Results: tc.results,
+			}
+			require.Equal(t, tc.expected, blockAssessments(block))
+		})
+	}
+}
+
+// A policy in OR assert mode passes with some of its tenets failing. Only
+// the tenets that actually passed carry an assessment worth showing.
+func TestBlockAssessmentsSkipsFailedTenets(t *testing.T) {
+	t.Parallel()
+	block := &papi.BlockEvalResult{
+		Status: papi.StatusPASS,
+		Meta:   &papi.PolicyBlockMeta{},
+		Results: []*papi.Result{
+			{
+				Status: papi.StatusPASS,
+				EvalResults: []*papi.EvalResult{
+					{Status: papi.StatusFAIL, Error: &papi.Error{Message: "no purl"}},
+					{Status: papi.StatusPASS, Assessment: &papi.Assessment{Message: "has CPE"}},
+				},
+			},
+		},
+	}
+	require.Equal(t, []string{"has CPE"}, blockAssessments(block))
+}

--- a/internal/drivers/tty/table.go
+++ b/internal/drivers/tty/table.go
@@ -18,6 +18,10 @@ import (
 // fractional seconds.
 const dateFormat = "2006-01-02 15:04:05 -0700 MST"
 
+// assertModeOR mirrors the verifier's assert mode label. A block in OR
+// mode passes as soon as one of its policies does.
+const assertModeOR = "OR"
+
 // localDate renders t in the user's local zone at second resolution.
 func localDate(t time.Time) string {
 	return t.Local().Format(dateFormat)
@@ -225,7 +229,12 @@ func (d *Driver) resultGroupTable(grp *papi.ResultGroup) *termtable.Table {
 
 		var message string
 		if r.GetStatus() == papi.StatusPASS {
-			message = fmt.Sprintf("(%d policies)", len(r.Results))
+			message = strings.Join(blockAssessments(r), "\n")
+			// Fall back to the policy count when the passing policies
+			// define no assessment messages.
+			if message == "" {
+				message = fmt.Sprintf("(%d policies)", len(r.Results))
+			}
 		} else {
 			message = r.GetError().GetMessage()
 			if r.GetError().GetGuidance() != "" {
@@ -311,6 +320,48 @@ func collectAssessments(d *Driver, r *papi.Result) string {
 	return strings.TrimSuffix(b.String(), "\n")
 }
 
+// blockAssessments returns the assessment messages of the policies that
+// carried a block to PASS, in evaluation order and dedup'd.
+//
+// Under the default AND assert mode every policy in the block has to
+// pass, so all of their messages are reported. Under OR a single passing
+// policy decides the block, so only that policy's messages are reported:
+// the rest either failed or never got to run under lazy evaluation.
+func blockAssessments(block *papi.BlockEvalResult) []string {
+	orMode := block.GetMeta().GetAssertMode() == assertModeOR
+	msgs := []string{}
+	seen := map[string]struct{}{}
+	for _, res := range block.GetResults() {
+		if res.GetStatus() != papi.StatusPASS {
+			continue
+		}
+		added := false
+		for _, er := range res.GetEvalResults() {
+			if er.GetStatus() != papi.StatusPASS {
+				continue
+			}
+			msg := er.GetAssessment().GetMessage()
+			if msg == "" {
+				continue
+			}
+			if _, ok := seen[msg]; ok {
+				// Still the deciding policy under OR, just nothing new to say.
+				added = true
+				continue
+			}
+			seen[msg] = struct{}{}
+			msgs = append(msgs, msg)
+			added = true
+		}
+		// Keep looking if the deciding policy had nothing to report, so an
+		// OR block does not end up with an empty cell.
+		if orMode && added {
+			break
+		}
+	}
+	return msgs
+}
+
 // groupSummary builds the Details-column text for a result-group row
 // inside a ResultSet — pass messages on success, dedup'd error
 // messages on failure.
@@ -328,15 +379,11 @@ func groupSummary(d *Driver, grp *papi.ResultGroup) string {
 				}
 				prefix = "[" + strings.Join(labels, ", ") + "] "
 			}
-			for _, res := range block.GetResults() {
-				for _, er := range res.GetEvalResults() {
-					if msg := er.GetAssessment().GetMessage(); msg != "" {
-						line := prefix + msg
-						if _, ok := seen[line]; !ok {
-							seen[line] = struct{}{}
-							msgs = append(msgs, line)
-						}
-					}
+			for _, msg := range blockAssessments(block) {
+				line := prefix + msg
+				if _, ok := seen[line]; !ok {
+					seen[line] = struct{}{}
+					msgs = append(msgs, line)
 				}
 			}
 		}

--- a/internal/drivers/tty/table_test.go
+++ b/internal/drivers/tty/table_test.go
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package tty
+
+import (
+	"testing"
+
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// pass builds a passing policy result carrying one assessment per message.
+func pass(msgs ...string) *papi.Result {
+	res := &papi.Result{Status: papi.StatusPASS}
+	for _, m := range msgs {
+		res.EvalResults = append(res.EvalResults, &papi.EvalResult{
+			Status:     papi.StatusPASS,
+			Assessment: &papi.Assessment{Message: m},
+		})
+	}
+	return res
+}
+
+// fail builds a failing policy result carrying one error per message.
+func fail(msgs ...string) *papi.Result {
+	res := &papi.Result{Status: papi.StatusFAIL}
+	for _, m := range msgs {
+		res.EvalResults = append(res.EvalResults, &papi.EvalResult{
+			Status: papi.StatusFAIL,
+			Error:  &papi.Error{Message: m},
+		})
+	}
+	return res
+}
+
+func TestBlockAssessments(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		assertMode string
+		results    []*papi.Result
+		expected   []string
+	}{
+		{
+			name:     "single policy",
+			results:  []*papi.Result{pass("SBOM is signed")},
+			expected: []string{"SBOM is signed"},
+		},
+		{
+			// Default (AND) mode: every policy had to pass, so report all.
+			name:       "and mode reports every policy",
+			assertMode: "",
+			results:    []*papi.Result{pass("has author"), pass("has timestamp")},
+			expected:   []string{"has author", "has timestamp"},
+		},
+		{
+			name:       "explicit and mode reports every policy",
+			assertMode: "AND",
+			results:    []*papi.Result{pass("has author"), pass("has timestamp")},
+			expected:   []string{"has author", "has timestamp"},
+		},
+		{
+			// OR mode: only the policy that carried the block is reported.
+			name:       "or mode reports only the deciding policy",
+			assertMode: "OR",
+			results:    []*papi.Result{fail("no purl"), pass("has CPE")},
+			expected:   []string{"has CPE"},
+		},
+		{
+			name:       "or mode stops at the first passing policy",
+			assertMode: "OR",
+			results:    []*papi.Result{pass("has purl"), pass("has CPE")},
+			expected:   []string{"has purl"},
+		},
+		{
+			// A silent deciding policy must not blank the cell when a later
+			// passing policy has something to report.
+			name:       "or mode skips a passing policy with no message",
+			assertMode: "OR",
+			results:    []*papi.Result{pass(), pass("has CPE")},
+			expected:   []string{"has CPE"},
+		},
+		{
+			name:       "failed policies are ignored",
+			assertMode: "AND",
+			results:    []*papi.Result{pass("has author"), fail("no license")},
+			expected:   []string{"has author"},
+		},
+		{
+			name:     "duplicate messages are collapsed",
+			results:  []*papi.Result{pass("has author"), pass("has author")},
+			expected: []string{"has author"},
+		},
+		{
+			name:     "no assessment messages",
+			results:  []*papi.Result{pass()},
+			expected: []string{},
+		},
+		{
+			name:     "no results",
+			results:  []*papi.Result{},
+			expected: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			block := &papi.BlockEvalResult{
+				Status:  papi.StatusPASS,
+				Meta:    &papi.PolicyBlockMeta{AssertMode: tc.assertMode},
+				Results: tc.results,
+			}
+			require.Equal(t, tc.expected, blockAssessments(block))
+		})
+	}
+}
+
+// A policy in OR assert mode passes with some of its tenets failing. Only
+// the tenets that actually passed carry an assessment worth showing.
+func TestBlockAssessmentsSkipsFailedTenets(t *testing.T) {
+	t.Parallel()
+	block := &papi.BlockEvalResult{
+		Status: papi.StatusPASS,
+		Meta:   &papi.PolicyBlockMeta{},
+		Results: []*papi.Result{
+			{
+				Status: papi.StatusPASS,
+				EvalResults: []*papi.EvalResult{
+					{Status: papi.StatusFAIL, Error: &papi.Error{Message: "no purl"}},
+					{Status: papi.StatusPASS, Assessment: &papi.Assessment{Message: "has CPE"}},
+				},
+			},
+		},
+	}
+	require.Equal(t, []string{"has CPE"}, blockAssessments(block))
+}

--- a/internal/render/README.md
+++ b/internal/render/README.md
@@ -1,0 +1,18 @@
+# Results Render Drivers
+
+This directory contains drivers for the results renderer. More drivers can be
+added by implementing the `render.Driver` interface and registering them in
+the reader drivers array.
+
+Currently AMPEL supports the following drivers:
+
+* `attester`: Generates an AMPEL ResultSet attestation.
+* `tty`: The driver that displays results in the terminal screen.
+* `html`: Renders evaluation results as HTML.
+* `markdown`: Outputs the evaluation results in markdown.
+* `vsa`: Renders the results set in a Verification Summary attestation.
+
+The tty, html and markdown drivers share code through the `TableBuilder`
+interface. The results output is handled by a central logic core that builds
+a main table and delegates to a decorator to handle the all the
+format-specific nuances.


### PR DESCRIPTION
This pull request introduces a new utility function, `blockAssessments`, to standardize how assessment messages are collected and displayed for passing policy blocks across both the `gotable` (HTML/Markdown) and `tty` (terminal) render drivers. The function ensures consistent handling of AND/OR assert modes, deduplication, and message selection, and is accompanied by comprehensive unit tests. The changes simplify and unify the rendering logic, improve test coverage, and add developer documentation.

**Assessment Message Handling Improvements:**

* Added the `blockAssessments` function to both `gotable.go` and `table.go`, which collects and deduplicates assessment messages from passing policies, correctly handling both AND and OR assert modes. In OR mode, only the deciding policy's messages are shown; in AND mode, all passing policies' messages are reported. [[1]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2R21-R66) [[2]](diffhunk://#diff-285f5d96ed8ab5345df875bea2a9f43ce20329029c815bcd6bcbd8fd42bf7358R323-R364)
* Updated the result rendering logic in both `gotable` and `tty` drivers to use `blockAssessments`, ensuring consistent and correct display of assessment messages in tables. [[1]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2L168-L179) [[2]](diffhunk://#diff-2c28195ef165113679471d7577b4b6379dae7ec4c33316541904b62b0e7502c2R302-R307) [[3]](diffhunk://#diff-285f5d96ed8ab5345df875bea2a9f43ce20329029c815bcd6bcbd8fd42bf7358R232-R237) [[4]](diffhunk://#diff-285f5d96ed8ab5345df875bea2a9f43ce20329029c815bcd6bcbd8fd42bf7358L331-L342)

**Testing Enhancements:**

* Added comprehensive unit tests for `blockAssessments` in both `gotable_test.go` and `table_test.go`, covering various scenarios including AND/OR modes, message deduplication, and handling of silent or failing policies. [[1]](diffhunk://#diff-ddada631d2829c34fe538a40b3b0bfbf901db90ce6137f340ee822d78b5e1eceR1-R136) [[2]](diffhunk://#diff-8204fa77303b3a4a24ccf4bec63584efeb48e16da1642b54c9b41fc0c39f55e9R1-R136)

**Documentation:**

* Added a new README file to the `internal/render` directory, documenting the available result render drivers and their usage.