### PR TITLE
Add owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cpanato
+  - deobieta
+  - puerco
+reviewers:
+  - cpanato
+  - deobieta
+  - puerco


### PR DESCRIPTION
This pull request adds an `OWNERS` file to the repository, specifying the approvers and reviewers for the project. This helps clarify code ownership and streamlines the review process. 

* [`OWNERS`](diffhunk://#diff-c393dd2b18a8a597d895940893e574d6895122c4bf3ce6e2a78dbd9ca0cdd66fR1-R10): Added a new file listing `cpanato`, `deobieta`, and `puerco` as both approvers and reviewers for the repository.