### PR TITLE
Reject malformed context value definitions

### DIFF
--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -591,8 +591,11 @@ func (opts *verifyOptions) Run() error {
 func (opts *verifyOptions) buildContextProviders() (err error) {
 	// Pass the -x flags as a new StringMapList list provider
 	if len(opts.ContextStringVals) > 0 {
-		l := acontext.StringMapList(opts.ContextStringVals)
-		opts.WithContextProvider(&l)
+		l, err := acontext.NewStringMapList(opts.ContextStringVals)
+		if err != nil {
+			return err
+		}
+		opts.WithContextProvider(l)
 	}
 
 	// Read the evaluation context data from JSON:

--- a/pkg/context/stringmap.go
+++ b/pkg/context/stringmap.go
@@ -3,7 +3,11 @@
 
 package context
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // StringMapList returns context data from a list of strings where each
 // line has the value preceded by a colon and the value. For example:
@@ -17,6 +21,31 @@ import "strings"
 // This provider was created to support context strings passed in the CLI
 // to the ampel verifier.
 type StringMapList []string
+
+// ErrInvalidContextValue is returned when a context value definition is
+// not a key:value pair.
+var ErrInvalidContextValue = errors.New("invalid context value definition")
+
+// NewStringMapList validates a list of key:value context definitions
+// and returns them as a provider. A definition without a colon, with an
+// empty key, or with an equals sign or spaces in the key (almost always
+// a key=value mixup) never matches a lookup, so it is rejected here
+// instead of surfacing later as a missing required context value.
+func NewStringMapList(vals []string) (*StringMapList, error) {
+	for _, s := range vals {
+		key, _, ok := strings.Cut(s, ":")
+		switch {
+		case !ok:
+			return nil, fmt.Errorf("%w %q: expected key:value", ErrInvalidContextValue, s)
+		case key == "":
+			return nil, fmt.Errorf("%w %q: empty key", ErrInvalidContextValue, s)
+		case strings.ContainsAny(key, "= \t"):
+			return nil, fmt.Errorf("%w %q: %q is not a plain key (did you write key=value?)", ErrInvalidContextValue, s, key)
+		}
+	}
+	l := StringMapList(vals)
+	return &l, nil
+}
 
 func (sml *StringMapList) GetContextValue(key string) (any, error) {
 	if sml == nil {

--- a/pkg/context/stringmap_test.go
+++ b/pkg/context/stringmap_test.go
@@ -47,3 +47,36 @@ func TestStringMapGetValue(t *testing.T) {
 		})
 	}
 }
+
+func TestNewStringMapList(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		vals    []string
+		mustErr bool
+	}{
+		{name: "key-value", vals: []string{"builderId:https://github.com/org/repo/.github/workflows/release.yaml"}},
+		{name: "value-with-colons", vals: []string{"buildPoint:git+ssh://github.com/org/repo@refs/heads/main"}},
+		{name: "empty-value", vals: []string{"since:"}},
+		{name: "dotted-key", vals: []string{"policy.v2:on"}},
+		{name: "several", vals: []string{"a:1", "b:2"}},
+		{name: "empty-list", vals: nil},
+		{name: "equals-instead-of-colon", vals: []string{"builderId=https://github.com/org/repo"}, mustErr: true},
+		{name: "no-colon", vals: []string{"builderId"}, mustErr: true},
+		{name: "empty-key", vals: []string{":value"}, mustErr: true},
+		{name: "space-in-key", vals: []string{"builder id:x"}, mustErr: true},
+		{name: "one-bad-among-good", vals: []string{"a:1", "b=2"}, mustErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			l, err := NewStringMapList(tt.vals)
+			if tt.mustErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidContextValue)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, l)
+		})
+	}
+}


### PR DESCRIPTION
A -x definition written as key=value never matches a context lookup: values are found by key-colon prefix, so the policy only fails later with a confusing "required but not set" error, and when the value is a URL, the colon it carries makes the definition look superficially valid.

Now we validate definitions when the provider is built: no colon, an empty key, or an equals sign or spaces in the key are rejected up front, naming the definition and the likely mixup.