### PR TITLE
Reject unverified attestations regardless of signing method

### DIFF
--- a/docs/02-ampel-attestations.md
+++ b/docs/02-ampel-attestations.md
@@ -111,12 +111,32 @@ As mentioned, attestations can be wrapped in signed envelopes. But it is importa
 to differentiate between the signature providing authenticity and inegrity guarantees
 and the _signing identity_.
 
-When loading a signed attestation, AMPEL will verify an attestation's signature
-automatically. If the signature fails, the attestation will be rejected.
+When loading an attestation, AMPEL verifies its signature automatically and
+admits it as evidence only when the signature verified against the material it
+holds: the sigstore trust roots for bundles, the configured public keys
+(`--key` and any keys pinned in the policy identities) for DSSE envelopes. This
+signature gate does not depend on the policy or on how the attestation was
+signed. A bare statement carries no signature, and an envelope signed with a
+key the verifier does not hold cannot be checked; both are simply _unverified_
+and are dropped from the evidence set. When every attestation supplied for a
+subject is unverified, the policy fails with an explicit "no verified
+attestations" error rather than reporting the evidence as missing.
+
+There is one deliberate exception. The `ampel verify` CLI admits unverified
+attestations passed with `--attestation` / `-a`, on the grounds that handing a
+file to the verifier is an explicit choice. Attestations found by collectors are
+never admitted unverified, and the exception ends as soon as the policy (or
+`--signer`) pins signer identities: from then on unverified attestations are
+skipped and only signed evidence from an accepted identity counts. Admitted
+unverified attestations reach policies with `verification.verified` set to
+false so a policy can still tell them apart. Library callers get the same
+behavior through the `AdmitUnverified` verification option.
 
 But when it comes to the signing identity, AMPEL does not do any assumptions. It is
 up to the policy to define who can sign attestations. _Who_ in this context refers
-to a key or sigstore identity, or a mix of both.
+to a key or sigstore identity, or a mix of both. Identities pinned in a policy
+always win over `--signer`: a signed policy cannot be loosened from the command
+line, and an operator who needs more signers extends the policy instead.
 
 ## Producing Result Attestations
 

--- a/e2e/signature_admission_test.go
+++ b/e2e/signature_admission_test.go
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package e2e
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carabiner-dev/policy"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	"github.com/carabiner-dev/signer"
+	"github.com/carabiner-dev/signer/key"
+	soptions "github.com/carabiner-dev/signer/options"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/carabiner-dev/ampel/pkg/verifier"
+)
+
+// The admission matrix. Evidence is admitted only when its signature verified
+// (bundles against the sigstore roots, DSSE envelopes against the keys the
+// verifier holds); bare statements and envelopes signed with unknown keys are
+// unverified. AdmitUnverified admits unverified evidence passed explicitly,
+// and never applies once the policy pins signer identities. The outcome must
+// be the same whichever way the attestation was signed. Sigstore verification
+// of the genuine bundle hits the trust root over TUF (network).
+
+const (
+	dssePredicateType   = "https://example.com/ampel/admission/v1"
+	bundlePredicateType = "https://slsa.dev/provenance/v0.2"
+	// Digest of the DSSE / bare fixture subject.
+	dsseSubjectDigest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	// Digest of the subject in testdata/github-actions-bundle.json.
+	bundleSubjectDigest = "76176ffa33808b54602c7c35de5c6e9a4deb96066dba6533f50ac234f4f1f4c6b3527515dc17c06fbe2860030f410eee69ea20079bd3a2c6f3dcf3b329b10751"
+
+	unverifiedFailure = "no verified attestations available to evaluate the policy"
+	identityFailure   = "attestation identity validation failed"
+)
+
+// keyPair is an ECDSA P-256 key in the PEM forms the signer library reads.
+type keyPair struct {
+	privPEM, pubPEM []byte
+}
+
+func newKeyPair(t *testing.T) keyPair {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	pub, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+	return keyPair{
+		privPEM: pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}),
+		pubPEM:  pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pub}),
+	}
+}
+
+func (kp keyPair) provider(t *testing.T) key.PublicKeyProvider {
+	t.Helper()
+	p, err := key.NewParser().ParsePublicKeyProvider(kp.pubPEM)
+	require.NoError(t, err)
+	return p
+}
+
+// tamperPayload rewrites a JSON file, appending a byte to the base64 payload
+// found under the given key path so the signature no longer covers it.
+func tamperPayload(t *testing.T, in, out string, path ...string) {
+	t.Helper()
+	data, err := os.ReadFile(in)
+	require.NoError(t, err)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc))
+	node := doc
+	for _, k := range path[:len(path)-1] {
+		next, ok := node[k].(map[string]any)
+		require.True(t, ok, "missing %q in %s", k, in)
+		node = next
+	}
+	last := path[len(path)-1]
+	payload, ok := node[last].(string)
+	require.True(t, ok)
+	raw, err := base64.StdEncoding.DecodeString(payload)
+	require.NoError(t, err)
+	node[last] = base64.StdEncoding.EncodeToString(append(raw, ' '))
+	tampered, err := json.Marshal(doc)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(out, tampered, 0o600))
+}
+
+// fixtures writes the evidence files: a bare statement, the same statement
+// signed as a DSSE envelope with signingKey, a tampered copy of it, and a
+// tampered copy of the genuine GitHub Actions bundle.
+type fixtures struct {
+	bare, dsse, dsseTampered, bundle, bundleTampered string
+}
+
+func makeFixtures(t *testing.T, signingKey keyPair) fixtures {
+	t.Helper()
+	dir := t.TempDir()
+
+	pred, err := structpb.NewStruct(map[string]any{"a": 1})
+	require.NoError(t, err)
+	stmt := &gointoto.Statement{
+		Type:          "https://in-toto.io/Statement/v1",
+		Subject:       []*gointoto.ResourceDescriptor{{Name: "artifact", Digest: map[string]string{"sha256": dsseSubjectDigest}}},
+		PredicateType: dssePredicateType,
+		Predicate:     pred,
+	}
+	stmtJSON, err := protojson.Marshal(stmt)
+	require.NoError(t, err)
+
+	f := fixtures{
+		bare:           filepath.Join(dir, "bare.json"),
+		dsse:           filepath.Join(dir, "dsse.json"),
+		dsseTampered:   filepath.Join(dir, "dsse-tampered.json"),
+		bundle:         "testdata/github-actions-bundle.json",
+		bundleTampered: filepath.Join(dir, "bundle-tampered.json"),
+	}
+	require.NoError(t, os.WriteFile(f.bare, stmtJSON, 0o600))
+
+	priv, err := key.NewParser().ParsePrivateKeyProvider(signingKey.privPEM)
+	require.NoError(t, err)
+	env, err := signer.NewSigner().SignStatementToDSSE(stmtJSON, soptions.WithKey(priv))
+	require.NoError(t, err)
+	envJSON, err := protojson.Marshal(env)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(f.dsse, envJSON, 0o600))
+
+	tamperPayload(t, f.dsse, f.dsseTampered, "payload")
+	tamperPayload(t, f.bundle, f.bundleTampered, "dsseEnvelope", "payload")
+	return f
+}
+
+// compilePolicy builds a policy requiring one predicate of the given type,
+// optionally pinning signer identities (a JSON array fragment).
+func compilePolicy(t *testing.T, predicateType, identities string) any {
+	t.Helper()
+	ids := ""
+	if identities != "" {
+		ids = fmt.Sprintf(`"identities": %s,`, identities)
+	}
+	src := fmt.Sprintf(`{
+		"id": "admission",
+		%s
+		"tenets": [{
+			"id": "t",
+			"code": "size(predicates) > 0",
+			"predicates": {"types": [%q]}
+		}]
+	}`, ids, predicateType)
+	set, pcy, _, err := policy.NewCompiler().Compile([]byte(src))
+	require.NoError(t, err)
+	if set != nil {
+		return set
+	}
+	require.NotNil(t, pcy)
+	return pcy
+}
+
+func keyIdentity(t *testing.T, kp keyPair) string {
+	t.Helper()
+	data, err := json.Marshal(string(kp.pubPEM))
+	require.NoError(t, err)
+	return fmt.Sprintf(`[{"key": {"data": %s}}]`, data)
+}
+
+func sigstoreIdentity(repo string) string {
+	return fmt.Sprintf(`[{"sigstore": {
+		"issuerMatch": {"exact": "https://token.actions.githubusercontent.com"},
+		"sourceRepositoryUriMatch": {"exact": %q}
+	}}]`, repo)
+}
+
+func failureMessages(t *testing.T, res papi.Results) []string {
+	t.Helper()
+	var results []*papi.Result
+	switch r := res.(type) {
+	case *papi.Result:
+		results = []*papi.Result{r}
+	case *papi.ResultSet:
+		results = r.GetResults()
+	default:
+		t.Fatalf("unexpected results type %T", res)
+	}
+	var msgs []string
+	for _, r := range results {
+		for _, er := range r.GetEvalResults() {
+			if er.GetError() != nil {
+				msgs = append(msgs, er.GetError().GetMessage())
+			}
+		}
+	}
+	return msgs
+}
+
+func TestSignatureAdmissionMatrix(t *testing.T) {
+	right, wrong := newKeyPair(t), newKeyPair(t)
+	fx := makeFixtures(t, right)
+
+	dsseSubject := &gointoto.ResourceDescriptor{Digest: map[string]string{"sha256": dsseSubjectDigest}}
+	bundleSubject := &gointoto.ResourceDescriptor{Digest: map[string]string{"sha512": bundleSubjectDigest}}
+
+	for _, tc := range []struct {
+		name       string
+		evidence   string
+		subject    *gointoto.ResourceDescriptor
+		policyType string
+		identities string // policy identities JSON fragment, "" for none
+		keys       []key.PublicKeyProvider
+		admit      bool // AdmitUnverified (the CLI's -a opt-in)
+		status     string
+		failure    string // expected failure message when status is FAIL
+	}{
+		// --- sigstore bundle -------------------------------------------------
+		{"bundle/genuine", fx.bundle, bundleSubject, bundlePredicateType, "", nil, false, papi.StatusPASS, ""},
+		{"bundle/tampered", fx.bundleTampered, bundleSubject, bundlePredicateType, "", nil, false, papi.StatusFAIL, unverifiedFailure},
+		{"bundle/tampered/opt-in", fx.bundleTampered, bundleSubject, bundlePredicateType, "", nil, true, papi.StatusPASS, ""},
+		{"bundle/genuine/identity-match", fx.bundle, bundleSubject, bundlePredicateType, sigstoreIdentity("https://github.com/sigstore/sigstore-js"), nil, false, papi.StatusPASS, ""},
+		{"bundle/genuine/identity-mismatch", fx.bundle, bundleSubject, bundlePredicateType, sigstoreIdentity("https://github.com/evil/repo"), nil, false, papi.StatusFAIL, identityFailure},
+		{"bundle/tampered/identity/opt-in", fx.bundleTampered, bundleSubject, bundlePredicateType, sigstoreIdentity("https://github.com/sigstore/sigstore-js"), nil, true, papi.StatusFAIL, identityFailure},
+
+		// --- key-signed DSSE envelope ---------------------------------------
+		{"dsse/right-key", fx.dsse, dsseSubject, dssePredicateType, "", []key.PublicKeyProvider{right.provider(t)}, false, papi.StatusPASS, ""},
+		{"dsse/wrong-key", fx.dsse, dsseSubject, dssePredicateType, "", []key.PublicKeyProvider{wrong.provider(t)}, false, papi.StatusFAIL, unverifiedFailure},
+		{"dsse/no-key", fx.dsse, dsseSubject, dssePredicateType, "", nil, false, papi.StatusFAIL, unverifiedFailure},
+		{"dsse/no-key/opt-in", fx.dsse, dsseSubject, dssePredicateType, "", nil, true, papi.StatusPASS, ""},
+		{"dsse/tampered/right-key", fx.dsseTampered, dsseSubject, dssePredicateType, "", []key.PublicKeyProvider{right.provider(t)}, false, papi.StatusFAIL, unverifiedFailure},
+		{"dsse/policy-key-match", fx.dsse, dsseSubject, dssePredicateType, keyIdentity(t, right), nil, false, papi.StatusPASS, ""},
+		{"dsse/policy-key-mismatch", fx.dsse, dsseSubject, dssePredicateType, keyIdentity(t, wrong), nil, false, papi.StatusFAIL, identityFailure},
+		{"dsse/policy-key-mismatch/opt-in", fx.dsse, dsseSubject, dssePredicateType, keyIdentity(t, wrong), nil, true, papi.StatusFAIL, identityFailure},
+		{"dsse/tampered/policy-key/opt-in", fx.dsseTampered, dsseSubject, dssePredicateType, keyIdentity(t, right), nil, true, papi.StatusFAIL, identityFailure},
+
+		// --- bare (unsigned) statement --------------------------------------
+		{"bare", fx.bare, dsseSubject, dssePredicateType, "", nil, false, papi.StatusFAIL, unverifiedFailure},
+		{"bare/opt-in", fx.bare, dsseSubject, dssePredicateType, "", nil, true, papi.StatusPASS, ""},
+		{"bare/identity/opt-in", fx.bare, dsseSubject, dssePredicateType, keyIdentity(t, right), nil, true, papi.StatusFAIL, identityFailure},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ampel, err := verifier.New()
+			require.NoError(t, err)
+			opts := verifier.NewVerificationOptions()
+			opts.EnforceExpiration = false
+			opts.AttestationFiles = []string{tc.evidence}
+			opts.Keys = tc.keys
+			opts.AdmitUnverified = tc.admit
+
+			res, err := ampel.Verify(t.Context(), &opts, compilePolicy(t, tc.policyType, tc.identities), tc.subject)
+			require.NoError(t, err)
+			require.Equal(t, tc.status, res.GetStatus(), "failures: %v", failureMessages(t, res))
+			if tc.failure != "" {
+				require.Contains(t, failureMessages(t, res), tc.failure)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cel.dev/cel-go v0.32.0
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/carabiner-dev/attestation v0.2.1
-	github.com/carabiner-dev/collector v0.3.15
+	github.com/carabiner-dev/collector v0.3.16
 	github.com/carabiner-dev/command v0.3.2
 	github.com/carabiner-dev/hasher v0.2.4
 	github.com/carabiner-dev/osv v0.1.2
@@ -17,7 +17,7 @@ require (
 	github.com/in-toto/attestation v1.2.0
 	github.com/jedib0t/go-pretty/v6 v6.8.3
 	github.com/mitchellh/go-wordwrap v1.0.1
-	github.com/openvex/go-vex v0.2.8
+	github.com/openvex/go-vex v0.2.9
 	github.com/package-url/packageurl-go v0.1.7
 	github.com/pandatix/go-cvss v0.6.4
 	github.com/protobom/cel v0.1.3
@@ -54,7 +54,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.1 // indirect
 	github.com/go-git/go-git/v5 v5.19.2 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.5 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.26.0 // indirect
@@ -85,7 +85,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/secure-systems-lab/go-securesystemslib v0.11.0 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.11.1 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
 	github.com/sigstore/protobuf-specs v0.5.2 // indirect
@@ -152,7 +152,7 @@ require (
 	github.com/carabiner-dev/deadrop v0.0.0-20260228173914-d95e9ea2877d // indirect
 	github.com/carabiner-dev/sbomfs v0.2.0 // indirect
 	github.com/carabiner-dev/spdx3 v0.1.0 // indirect
-	github.com/carabiner-dev/stash v0.0.0-20260907173633-c7ccf2e6d134 // indirect
+	github.com/carabiner-dev/stash v0.0.0-20260908191435-d6225e020426 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chainguard-dev/clog v1.8.1 // indirect
@@ -230,7 +230,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tink-crypto/tink-go-awskms/v3 v3.0.0 // indirect
 	github.com/tink-crypto/tink-go-gcpkms/v2 v2.4.0 // indirect
-	github.com/tink-crypto/tink-go/v2 v2.7.0 // indirect
+	github.com/tink-crypto/tink-go/v2 v2.8.0 // indirect
 	github.com/ulikunitz/xz v0.5.16 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.70.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/c2sp/wycheproof v0.0.0-20260105152342-fca0d3ba9f12 h1:C34LW7dhWgjAaAO
 github.com/c2sp/wycheproof v0.0.0-20260105152342-fca0d3ba9f12/go.mod h1:U1QjrC6KepOmtVmJn3QsKOTd9HliGr/da5afPEhLRnk=
 github.com/carabiner-dev/attestation v0.2.1 h1:VhjV5YlO9TsW50Sr/Zd54bdbZhhDAqgxC3kB9z1I+3Q=
 github.com/carabiner-dev/attestation v0.2.1/go.mod h1:O84vF84RZG3pJO/6BYrPs718bZviHF5DKajP1HsrDpw=
-github.com/carabiner-dev/collector v0.3.15 h1:NWKvuE5cc6MoMwJQCqftiPNQ47XxyNpF3JDlR0DyvRc=
-github.com/carabiner-dev/collector v0.3.15/go.mod h1:cDoNb+Ck8CjRvqpCkMguJikSYHqs5zsFpwjw3m1s3js=
+github.com/carabiner-dev/collector v0.3.16 h1:Tatp4tK/xWDluFwDqGfPPcYd9crCWm/0Ma+XlDAZ2Xs=
+github.com/carabiner-dev/collector v0.3.16/go.mod h1:G6neTqtRFOEjjOayE02bDWpLkcFB/gmbkfFteSliPcE=
 github.com/carabiner-dev/command v0.3.2 h1:lkmgr+Sj9OaPxKk2AHlitR76Mg+hqys6BK7071taywY=
 github.com/carabiner-dev/command v0.3.2/go.mod h1:ABHTlUZbUUq7LF1Xmlx01ZY8xMCv4eqleuVEO/LIifU=
 github.com/carabiner-dev/deadrop v0.0.0-20260228173914-d95e9ea2877d h1:Gl8o56PI73PE6YcDzUd49iJJBdp/ye/METanFm8gG64=
@@ -136,8 +136,8 @@ github.com/carabiner-dev/signer v0.6.2 h1:Tww40YP4RKjLSKdgT5nXVRiqd3Czjvkwd2WRDE
 github.com/carabiner-dev/signer v0.6.2/go.mod h1:xIeR0GMK3Hp9gYsd7dGO9W8EwjftWBk3/+flEle6o0Y=
 github.com/carabiner-dev/spdx3 v0.1.0 h1:Q6nMLXV0BhtqDQuwRDOaJDZR670TK4jdOvZqvTW/ctY=
 github.com/carabiner-dev/spdx3 v0.1.0/go.mod h1:d/t010TrZvYZBeYGpvHeId6QpRvGLlqK7cy0E81npPA=
-github.com/carabiner-dev/stash v0.0.0-20260907173633-c7ccf2e6d134 h1:FqgcmCJo/X1ePDcfg0RnpQRQAUxBNh9A0Tj0ZA6nBho=
-github.com/carabiner-dev/stash v0.0.0-20260907173633-c7ccf2e6d134/go.mod h1:zt3Ci22BBpzvoi9FyIvwMEnKmliDof3d7NWJTDwd6p0=
+github.com/carabiner-dev/stash v0.0.0-20260908191435-d6225e020426 h1:OpWSJwPUe5cwDLRS52AIG5UlvEjnA3NClq+nQO74HZI=
+github.com/carabiner-dev/stash v0.0.0-20260908191435-d6225e020426/go.mod h1:a3y+CMfB8JcwycV3dMGJ9sskLpamxzLFEW1cMJoaTc8=
 github.com/carabiner-dev/termtable v1.1.0 h1:b/7IqM52Wqwi9njjnAEIDddUYyX23msFkQVihkwarDs=
 github.com/carabiner-dev/termtable v1.1.0/go.mod h1:f2kBeZo0N9vQEMhfDfxv+DdXXy7eb9Wvu9u1sSyvR2A=
 github.com/carabiner-dev/vcslocator v0.5.0 h1:UpqilJXRJBgwzQHk0MsD03w+8/0GcyC1HbXxX0wZKcU=
@@ -226,8 +226,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMj
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
 github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
-github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
-github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.5 h1:RjgjO2LOtWOJKUC5wpwY9LR3B3vwVAz6JS2YHfYU6eA=
+github.com/go-jose/go-jose/v4 v4.1.5/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -456,8 +456,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openvex/go-vex v0.2.8 h1:m/iH6+0fc7QXwfx7vJ0UeT8Z1oN1zVcyHjcVK+UO11Y=
-github.com/openvex/go-vex v0.2.8/go.mod h1:V09jOICYN/3VS4oU2hthSN8wGI6UAv3FvvYbpYS1xCE=
+github.com/openvex/go-vex v0.2.9 h1:InBYPjk5FQtDjnSQ12RUyQcnMlDO5QAg4QK848LIFm8=
+github.com/openvex/go-vex v0.2.9/go.mod h1:K7NfMaPzwZHZjg5xBvDzl4Wul4ojoNN4ICR5s4xbNHw=
 github.com/ossf/osv-schema/bindings/go v0.0.0-20260730052020-9509daabeece h1:PSGyVVj2mqBaGj9sa/8yv/XNni3JCPZC4xAVdnwww2M=
 github.com/ossf/osv-schema/bindings/go v0.0.0-20260730052020-9509daabeece/go.mod h1:IrUa4QzZUi03J3WXDzZYXVawYipHownNfqqZrqeGXfg=
 github.com/package-url/packageurl-go v0.1.7 h1:iFWg6tzAjLA6F/qX3M5nZaiMHJgc+p2zxVyr/fY+sZY=
@@ -497,8 +497,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sassoftware/relic/v8 v8.2.0 h1:9/L4S4I6an/JsPNhmcTpqfiOIsLb/iJaePZD1xR+ulE=
 github.com/sassoftware/relic/v8 v8.2.0/go.mod h1:pZy7hLT9WCOKPonV8G/fplvtBLOZd6/kWtKqeHR6nKc=
-github.com/secure-systems-lab/go-securesystemslib v0.11.0 h1:iuCR9kcMFD4QurdKrGvPLoKZLv9YvwPYVr0473BdtFs=
-github.com/secure-systems-lab/go-securesystemslib v0.11.0/go.mod h1:+PMOTjUGwHj2vcZ+TFKlb1tXRbrdWE1LYDT5i9JC80Q=
+github.com/secure-systems-lab/go-securesystemslib v0.11.1 h1:ayahDPjfSIqKegyt5YVGEvQ7SAi72GHXTy+b2YjUd5w=
+github.com/secure-systems-lab/go-securesystemslib v0.11.1/go.mod h1:UyOjhoZLi76ir63u1ptubEevVe6dlNPmNxwgVvKqFFY=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh5dkI=
@@ -565,8 +565,8 @@ github.com/tink-crypto/tink-go-gcpkms/v2 v2.4.0 h1:xpI5pnEQ0erFCS3JmcEl7Blluo8Zi
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.4.0/go.mod h1:wDDAhjfd1t4TjeJCSsmFK7CARPUs/ITi16ZZ8kmAaFQ=
 github.com/tink-crypto/tink-go-hcvault/v2 v2.5.0 h1:eXuNqgrcYelxU1MVikOJDP3wTS5lvihM4ntoAbAMfvs=
 github.com/tink-crypto/tink-go-hcvault/v2 v2.5.0/go.mod h1:3RhcxAqek6xUlRFmJifvU4CYLZN60KMQdIKqpZAZJG0=
-github.com/tink-crypto/tink-go/v2 v2.7.0 h1:k7QnUXJ1cRDpvoy/5l1FimZqMAArRff8vjUqzi5N04o=
-github.com/tink-crypto/tink-go/v2 v2.7.0/go.mod h1:cWNpQ/yAT/QHzAV0kBGMOSJzzYTKofDZdJaUqOPPWCI=
+github.com/tink-crypto/tink-go/v2 v2.8.0 h1:1zODq1bZDqOQdNPjhvwGYLDw9On7mDWPnQf+4xXlpAc=
+github.com/tink-crypto/tink-go/v2 v2.8.0/go.mod h1:aNXZeyxjQU9iqAeARRNmbESXUW6Mao1HRCCTY8B1TFM=
 github.com/transparency-dev/formats v0.1.1 h1:4bVHJc+KdBgpA1OJD1yjI+g0i5Z1graCppTMH8lWKJI=
 github.com/transparency-dev/formats v0.1.1/go.mod h1:qtZ8goRuJ8FTBG9c9+Bj0rn2rUG7eG/AUTkr+Aw3jFw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -128,7 +128,7 @@ func (o *verifyOptions) AddFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().StringSliceVarP(
-		&o.AttestationFiles, "attestation", "a", o.AttestationFiles, "additional attestations to read",
+		&o.AttestationFiles, "attestation", "a", o.AttestationFiles, "additional attestations to read (admitted unsigned)",
 	)
 
 	cmd.PersistentFlags().BoolVar(
@@ -336,6 +336,12 @@ func addVerify(parentCmd *cobra.Command) {
 		VerificationOptions: verifier.NewVerificationOptions(),
 		SignerSet:           signerOpts.DefaultSignerSet(),
 	}
+	// Attestations passed with --attestation are evidence the user chose to
+	// hand the verifier, so they are admitted even when unsigned or signed
+	// with a key we do not hold (unless the policy pins signer identities).
+	//
+	// Evidence fetched by collectors never gets this treatment.
+	opts.AdmitUnverified = true
 	evalCmd := &cobra.Command{
 		Short: "check artifacts against a policy",
 		Long: fmt.Sprintf(`

--- a/pkg/verifier/admission_test.go
+++ b/pkg/verifier/admission_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"testing"
+
+	"github.com/carabiner-dev/policy"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	sapi "github.com/carabiner-dev/signer/api/v1"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// failureMessages collects the error messages of every failed evaluation in
+// a result set, so tests can tell which gate stopped the evidence.
+func failureMessages(t *testing.T, res papi.Results) []string {
+	t.Helper()
+	var results []*papi.Result
+	switch r := res.(type) {
+	case *papi.Result:
+		results = []*papi.Result{r}
+	case *papi.ResultSet:
+		results = r.GetResults()
+	default:
+		t.Fatalf("unexpected results type %T", res)
+	}
+	var msgs []string
+	for _, r := range results {
+		for _, er := range r.GetEvalResults() {
+			if er.GetError() != nil {
+				msgs = append(msgs, er.GetError().GetMessage())
+			}
+		}
+	}
+	return msgs
+}
+
+// TestVerifyUnverifiedEvidence runs an unsigned (bare) statement through the
+// full Verify path. Without an opt-in the evidence is rejected at the
+// signature gate and the policy fails with ErrUnverifiedAttestations rather
+// than a misleading "missing attestations". With AdmitUnverified, evidence
+// passed through AttestationFiles is admitted, but never once the policy or
+// the options pin signer identities.
+func TestVerifyUnverifiedEvidence(t *testing.T) {
+	t.Parallel()
+
+	set, pcy, _, err := policy.NewCompiler().Compile([]byte(`{
+		"id": "has-example",
+		"tenets": [{
+			"id": "t",
+			"code": "size(predicates) > 0",
+			"predicates": {"types": ["https://example.com/"]}
+		}]
+	}`))
+	require.NoError(t, err)
+	var target any = pcy
+	if set != nil {
+		target = set
+	}
+	require.NotNil(t, target)
+
+	// Subject of testdata/link1.json, an unsigned in-toto statement.
+	subject := &gointoto.ResourceDescriptor{
+		Digest: map[string]string{"sha1": "856314ba21181a746186c24f1647d06e45048964"},
+	}
+
+	verify := func(t *testing.T, mutate func(*VerificationOptions)) papi.Results {
+		t.Helper()
+		ampel, err := New()
+		require.NoError(t, err)
+		opts := NewVerificationOptions()
+		opts.EnforceExpiration = false
+		opts.AttestationFiles = []string{"testdata/link1.json"}
+		if mutate != nil {
+			mutate(&opts)
+		}
+		res, err := ampel.Verify(t.Context(), &opts, target, subject)
+		require.NoError(t, err)
+		return res
+	}
+
+	t.Run("rejected-by-default", func(t *testing.T) {
+		t.Parallel()
+		res := verify(t, nil)
+		require.Equal(t, papi.StatusFAIL, res.GetStatus())
+		require.Contains(t, failureMessages(t, res), ErrUnverifiedAttestations.Error())
+	})
+
+	t.Run("admitted-when-opted-in", func(t *testing.T) {
+		t.Parallel()
+		res := verify(t, func(o *VerificationOptions) { o.AdmitUnverified = true })
+		require.Equal(t, papi.StatusPASS, res.GetStatus())
+	})
+
+	t.Run("never-admitted-under-identity-constraint", func(t *testing.T) {
+		t.Parallel()
+		signer := &sapi.Identity{Sigstore: &sapi.IdentitySigstore{Issuer: "https://example.com", Identity: "alice@example.com"}}
+		res := verify(t, func(o *VerificationOptions) {
+			o.AdmitUnverified = true
+			o.IdentityStrings = []string{signer.Spec()}
+		})
+		require.Equal(t, papi.StatusFAIL, res.GetStatus())
+		require.Contains(t, failureMessages(t, res), "attestation identity validation failed")
+	})
+}

--- a/pkg/verifier/ampel.go
+++ b/pkg/verifier/ampel.go
@@ -19,6 +19,11 @@ import (
 
 var ErrMissingAttestations = errors.New("required attestations missing to verify subject")
 
+// ErrUnverifiedAttestations is returned (wrapped) when evidence was supplied
+// but none of it could be admitted because no signature verified: the
+// attestations are unsigned, or signed with keys the verifier does not hold.
+var ErrUnverifiedAttestations = errors.New("no verified attestations available to evaluate the policy")
+
 type AmpelStatusChecker interface {
 	GatherResults(context.Context, *StatusOptions, attestation.Subject) ([]attestation.Envelope, error)
 	ParseAttestedResults(context.Context, *StatusOptions, []attestation.Envelope) ([]attestation.Predicate, error)

--- a/pkg/verifier/implementation.go
+++ b/pkg/verifier/implementation.go
@@ -53,9 +53,9 @@ type AmpelVerifier interface {
 	Transform(*VerificationOptions, map[transformer.Class]transformer.Transformer, *papi.Policy, attestation.Subject, []attestation.Predicate) (attestation.Subject, []attestation.Predicate, error)
 
 	// CheckIdentities verifies that attestations are signed by the policy identities
-	CheckIdentities(context.Context, *VerificationOptions, []*sapi.Identity, []attestation.Envelope) (bool, [][]*sapi.Identity, []error, error)
+	CheckIdentities(context.Context, *VerificationOptions, []*sapi.Identity, []attestation.Envelope) (bool, []admission, []error, error)
 
-	FilterAttestations(*VerificationOptions, attestation.Subject, []attestation.Envelope, [][]*sapi.Identity) ([]attestation.Predicate, error)
+	FilterAttestations(*VerificationOptions, attestation.Subject, []attestation.Envelope, []admission) ([]attestation.Predicate, error)
 	AssertResult(*papi.Policy, *papi.Result) error
 
 	// VerifySubject runs the verification process.
@@ -476,12 +476,40 @@ func (di *defaultIplementation) Transform(
 	return subject, prepredicates, nil
 }
 
-// CheckIdentities verifies attestation signatures and filters the envelope
-// list to only those signed by a recognized identity. Envelopes that cannot
-// be verified or whose signer does not match any of the policy/context
-// identities are silently discarded — they are simply not candidates for
-// evaluation. The function only fails when no envelopes survive the filter.
-func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *VerificationOptions, policyIdentities []*sapi.Identity, envelopes []attestation.Envelope) (bool, [][]*sapi.Identity, []error, error) {
+// admission records the outcome of CheckIdentities for one envelope: whether
+// it may be used as evidence, whether its signature verified, and, when an
+// identity constraint applies, the allowed identities its signer matched.
+type admission struct {
+	admitted   bool
+	verified   bool
+	identities []*sapi.Identity
+}
+
+// CheckIdentities verifies attestation signatures and decides which envelopes
+// are admitted as evidence. Admission is a two stage gate whose outcome does
+// not depend on how an attestation was signed:
+//
+//  1. Signature: an envelope is admitted only when its signature verified
+//     against the available material (the sigstore trust roots for bundles,
+//     the configured public keys for DSSE envelopes). Bare statements and
+//     envelopes signed with keys the verifier does not hold are unverified,
+//     not errors.
+//     The one exception is opts.AdmitUnverified, which admits unverified envelopes
+//     the caller passed explicitly when no identity constraint applies (see
+//     withExplicitEvidence). Evidence fetched by the collector is never admitted
+//     unverified.
+//
+//  2. Identity: when the policy (or the options, if the policy defines none)
+//     pins signer identities, a verified envelope is admitted only if its
+//     signer matches one of them.
+//
+// Envelopes that fail either gate are dropped from the evidence set. The
+// returned slice carries one admission per envelope. The boolean is false when
+// nothing was admitted although evidence was supplied (or an identity
+// constraint applies), and the error list then explains why nothing was admitted:
+// an identity mismatch, or ErrUnverifiedAttestations when every envelope was
+// unverified.
+func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *VerificationOptions, policyIdentities []*sapi.Identity, envelopes []attestation.Envelope) (bool, []admission, []error, error) {
 	// allIds are the allowed ids (from the policy + any from options)
 	allIds := []*sapi.Identity{}
 
@@ -511,32 +539,14 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 		}
 	}
 
-	// If there are no identities defined, accept all envelopes (no identity
-	// constraint to enforce). A nil ids slice signals to FilterAttestations
-	// that no identity filtering should be applied. Signatures are still
-	// verified so each envelope's verification records the actual signer
-	// identities, which FilterAttestations surfaces to policies as
-	// verification.signers; failures are tolerated as there is no identity
-	// constraint to enforce. Like the verify-and-match step below, the
-	// verification is serialized under the per-run evidence lock because the
-	// envelopes are shared across the policies of a PolicySet.
-	if len(allIds) == 0 {
+	constrained := len(allIds) > 0
+	if constrained {
+		logrus.Debug("Will look for signed attestations from:")
+		for _, i := range allIds {
+			logrus.Debugf("  > %s", i.Principal())
+		}
+	} else {
 		logrus.Debug("No identities defined in policy. Not filtering on signer identity.")
-		if mu := sharedEvidenceLock(ctx); mu != nil {
-			mu.Lock()
-			defer mu.Unlock()
-		}
-		for i, e := range envelopes {
-			if err := e.Verify(opts.Keys); err != nil {
-				logrus.Debugf("attestation %d (type %s): signature verification error: %v", i, e.GetStatement().GetType(), err)
-			}
-		}
-		return true, nil, nil, nil
-	}
-
-	logrus.Debug("Will look for signed attestations from:")
-	for _, i := range allIds {
-		logrus.Debugf("  > %s", i.Principal())
 	}
 
 	// The keys to use are the ones in the options...
@@ -553,85 +563,110 @@ func (di *defaultIplementation) CheckIdentities(ctx context.Context, opts *Verif
 		}
 	}
 
-	// Verify signatures and collect only envelopes with a matching identity.
-	// The envelopes are shared across the concurrently-evaluated policies of a
+	// Verify signatures and decide the admission of each envelope. The
+	// envelopes are shared across the concurrently-evaluated policies of a
 	// PolicySet, and their verification is cached/recomputed on the shared
 	// predicate, so serialize the verify-and-match step under the per-run lock
 	// published on the context (nil outside a concurrent fan-out).
-	validSigners := make([][]*sapi.Identity, len(envelopes))
+	admissions := make([]admission, len(envelopes))
+
 	// observedSigners collects the actual signer identities seen on the
 	// verified attestations. It is used to build a "wanted / got" diagnostic
 	// when no attestation matches an accepted identity.
 	var observedSigners []*sapi.Identity
+	admitted, unverified := 0, 0
 	if mu := sharedEvidenceLock(ctx); mu != nil {
 		mu.Lock()
 		defer mu.Unlock()
 	}
 	for i, e := range envelopes {
+		ptype := e.GetStatement().GetPredicateType()
 		if err := e.Verify(keys); err != nil {
-			logrus.Debugf("attestation %d (type %s): signature verification error, skipping: %v", i, e.GetStatement().GetType(), err)
+			logrus.Debugf("attestation %d (type %s): signature verification error, skipping: %v", i, ptype, err)
+			unverified++
 			continue
 		}
 
-		if e.GetVerification() == nil || !e.GetVerification().GetVerified() {
-			logrus.Debugf("attestation %d (type %s): not verified, skipping", i, e.GetStatement().GetType())
-			continue
-		}
-
-		if v, ok := e.GetVerification().(*sapi.Verification); ok {
-			if sig := v.GetSignature(); sig != nil {
-				observedSigners = append(observedSigners, sig.GetIdentities()...)
+		// Signature gate. Verify records the outcome on the envelope. It does
+		// not fail on a bad or unverifiable signature.
+		v := e.GetVerification()
+		if v == nil || !v.GetVerified() {
+			unverified++
+			if !constrained && opts.AdmitUnverified && isExplicitEvidence(ctx, e) {
+				logrus.Warnf("attestation %d (type %s) is unsigned or its signature could not be verified; admitting it because it was passed explicitly", i, ptype)
+				admissions[i] = admission{admitted: true}
+				admitted++
+				continue
 			}
+			logrus.Debugf("attestation %d (type %s): not verified, skipping", i, ptype)
+			continue
+		}
+		observedSigners = append(observedSigners, envelopeSigners(e)...)
+
+		if !constrained {
+			admissions[i] = admission{admitted: true, verified: true}
+			admitted++
+			continue
 		}
 
+		// Identity gate.
+		var matched []*sapi.Identity
 		for _, id := range allIds {
-			if e.GetVerification().MatchesIdentity(id) {
-				validSigners[i] = append(validSigners[i], id)
+			if v.MatchesIdentity(id) {
+				matched = append(matched, id)
 			}
 		}
-
-		if len(validSigners[i]) == 0 {
-			logrus.Debugf("attestation %d (type %s): no matching signer identity, skipping", i, e.GetStatement().GetType())
+		if len(matched) == 0 {
+			logrus.Debugf("attestation %d (type %s): no matching signer identity, skipping", i, ptype)
+			continue
 		}
+		admissions[i] = admission{admitted: true, verified: true, identities: matched}
+		admitted++
 	}
 
-	// Check if at least one envelope matched a recognized identity.
-	matched := false
-	for _, ids := range validSigners {
-		if len(ids) > 0 {
-			matched = true
-			break
-		}
+	if admitted > 0 {
+		return true, admissions, nil, nil
 	}
-
-	if !matched {
-		return false, validSigners, []error{
-			identityMismatchError(allIds, observedSigners),
+	if constrained {
+		return false, admissions, []error{
+			identityMismatchError(allIds, observedSigners, unverified),
 		}, nil
 	}
-
-	return true, validSigners, nil, nil
+	if len(envelopes) == 0 {
+		return true, admissions, nil, nil
+	}
+	return false, admissions, []error{
+		fmt.Errorf("%w: %d attestation(s) were unsigned or signed with keys the verifier does not hold", ErrUnverifiedAttestations, unverified),
+	}, nil
 }
 
 // identityMismatchError builds a human-readable "wanted / got" diagnostic for a
 // signer-identity check that admitted no attestations. The wanted identities are
-// rendered in their rich (matcher-aware) form; the observed signers as pure
-// principals.
-func identityMismatchError(wanted, got []*sapi.Identity) error {
+// rendered in their rich (matcher-aware) form while the observed signers are
+// recorded as pure principals. "unverified" counts the attestations skipped
+// because their signature did not verify, so an operator can tell a missing key
+// apart from a wrong signer.
+func identityMismatchError(wanted, got []*sapi.Identity, unverified int) error {
+	var err error
 	if len(got) == 0 {
-		return fmt.Errorf(
+		err = fmt.Errorf(
 			"no attestation carried a verified signer identity (wanted one of: %s)",
 			renderIdentities(wanted, (*sapi.Identity).Spec),
 		)
+	} else {
+		err = fmt.Errorf(
+			"attestation signer does not match an accepted identity (wanted one of: %s; got: %s)",
+			renderIdentities(wanted, (*sapi.Identity).Spec),
+			renderIdentities(got, (*sapi.Identity).Principal),
+		)
 	}
-	return fmt.Errorf(
-		"attestation signer does not match an accepted identity (wanted one of: %s; got: %s)",
-		renderIdentities(wanted, (*sapi.Identity).Spec),
-		renderIdentities(got, (*sapi.Identity).Principal),
-	)
+	if unverified > 0 {
+		err = fmt.Errorf("%w; %d attestation(s) were skipped because they are unsigned or their signature could not be verified", err, unverified)
+	}
+	return err
 }
 
-// renderIdentities renders a list of identities to a comma-separated string
+// renderIdentities renders a list of identities to a comma separated string
 // using the provided rendering function, de-duplicating and dropping empties.
 func renderIdentities(ids []*sapi.Identity, render func(*sapi.Identity) string) string {
 	seen := make(map[string]struct{}, len(ids))
@@ -653,34 +688,30 @@ func renderIdentities(ids []*sapi.Identity, render func(*sapi.Identity) string) 
 	return strings.Join(parts, ", ")
 }
 
-// FilterAttestations filters the attestations read to only those required by the
-// policy. This function also restamps the ingested predicates with the identities
-// verified against the policy when ingesting the attestations. Envelopes whose
-// identity list is empty (not admitted by CheckIdentities) are excluded.
+// FilterAttestations turns the envelopes admitted by CheckIdentities into the
+// predicates a policy evaluates, stamping each with the verification outcome
+// CheckIdentities recorded: whether the signature verified and the allowed
+// identities the signer matched. Envelopes that were not admitted are excluded.
 //
-// The matched identities are exposed to the evaluator through a per-policy
+// The verification data is exposed to the evaluator through a per-policy
 // matchedPredicate wrapper rather than by mutating the shared predicate.
-//
-// TODO(puerco): Implement filtering before 1.0
-func (di *defaultIplementation) FilterAttestations(opts *VerificationOptions, subject attestation.Subject, envs []attestation.Envelope, ids [][]*sapi.Identity) ([]attestation.Predicate, error) {
+func (di *defaultIplementation) FilterAttestations(opts *VerificationOptions, subject attestation.Subject, envs []attestation.Envelope, admissions []admission) ([]attestation.Predicate, error) {
+	if len(admissions) != len(envs) {
+		return nil, fmt.Errorf("admission list does not match the envelope list (%d admissions for %d envelopes)", len(admissions), len(envs))
+	}
 	preds := make([]attestation.Predicate, 0, len(envs))
 	for i, env := range envs {
 		// Skip envelopes that were not admitted by CheckIdentities.
-		if len(ids) > 0 && len(ids[i]) == 0 {
+		if !admissions[i].admitted {
 			continue
 		}
-		pred := env.GetStatement().GetPredicate()
-		var matchedIds []*sapi.Identity
-		if ids != nil {
-			matchedIds = ids[i]
-		}
 		preds = append(preds, &matchedPredicate{
-			Predicate: pred,
+			Predicate: env.GetStatement().GetPredicate(),
 			verification: &sapi.Verification{
 				Signature: &sapi.SignatureVerification{
 					Date:       timestamppb.Now(),
-					Verified:   true,
-					Identities: matchedIds,
+					Verified:   admissions[i].verified,
+					Identities: admissions[i].identities,
 				},
 			},
 			// Carry the attestation's actual verified signers, independent of
@@ -813,7 +844,7 @@ func (di *defaultIplementation) evaluateChain(
 		}
 		var pass bool
 		var err error
-		var ids [][]*sapi.Identity
+		var ids []admission
 
 		// Check the attestation identities for now, we fallback to the identities
 		// defined in the policy if the link does not have its own. Probably this
@@ -893,7 +924,7 @@ func (di *defaultIplementation) evaluateChain(
 		// Add to link history
 		var goodIds []*sapi.Identity
 		if len(ids) > 0 {
-			goodIds = ids[0]
+			goodIds = ids[0].identities
 		}
 		chain = append(chain, &papi.ChainedSubject{
 			Source:      newResourceDescriptorFromSubject(subject),

--- a/pkg/verifier/implementation_test.go
+++ b/pkg/verifier/implementation_test.go
@@ -457,49 +457,50 @@ func TestCheckIdentities(t *testing.T) {
 		envelopes        []attestation.Envelope
 		mustErr          bool
 		mustAllow        bool
-		expectNilIds     bool // when true, ids slice must be nil (no filtering)
+		admitted         int  // number of envelopes expected to be admitted
+		explicit         bool // publish the envelopes as explicit evidence on the context
 	}{
 		{"no-allowedIdentities-defined", DefaultVerificationOptions, []*sapi.Identity{}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}}},
 			},
-		}, false, true, true},
+		}, false, true, 1, false},
 		{"no-matching-identities-opts", VerificationOptions{IdentityStrings: []string{idSigstore.Spec()}}, []*sapi.Identity{}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstoreOther}}},
 			},
-		}, false, false, false},
+		}, false, false, 0, false},
 		{"no-matching-identities-policy", VerificationOptions{IdentityStrings: []string{}}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstoreOther}}},
 			},
-		}, false, false, false},
+		}, false, false, 0, false},
 		{"ids-in-opts", VerificationOptions{IdentityStrings: []string{idSigstore.Spec()}}, []*sapi.Identity{}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}}},
 			},
-		}, false, true, false},
+		}, false, true, 1, false},
 		{"ids-in-policy", VerificationOptions{IdentityStrings: []string{}}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{
 					Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}},
 				},
 			},
-		}, false, true, false},
+		}, false, true, 1, false},
 		{"ids-in-policy-over-opts-pass", VerificationOptions{IdentityStrings: []string{idSigstoreOther.Spec()}}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{
 					Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}},
 				},
 			},
-		}, false, true, false},
+		}, false, true, 1, false},
 		{"ids-in-policy-over-opts-fail", VerificationOptions{IdentityStrings: []string{idSigstore.Spec()}}, []*sapi.Identity{idSigstoreOther}, []attestation.Envelope{
 			&fakeEnvelope{
 				ver: &sapi.Verification{
 					Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}},
 				},
 			},
-		}, false, false, false},
+		}, false, false, 0, false},
 		// Mixed envelopes: one matches, others don't — should pass and
 		// silently discard non-matching envelopes.
 		{"mixed-envelopes-one-matches", VerificationOptions{}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
@@ -512,17 +513,51 @@ func TestCheckIdentities(t *testing.T) {
 			&fakeEnvelope{
 				ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}},
 			},
-		}, false, true, false},
+		}, false, true, 1, false},
 		// All envelopes unverified — should fail.
 		{"all-unverified", VerificationOptions{}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
 			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
 			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
-		}, false, false, false},
+		}, false, false, 0, false},
+		// No identity constraint: the signature gate still applies. Unverified
+		// and unsigned (nil verification) envelopes are rejected, and when
+		// nothing survives the check fails with ErrUnverifiedAttestations.
+		{"no-constraint-unverified-rejected", VerificationOptions{}, nil, []attestation.Envelope{
+			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
+		}, false, false, 0, false},
+		{"no-constraint-unsigned-rejected", VerificationOptions{}, nil, []attestation.Envelope{
+			&fakeEnvelope{},
+		}, false, false, 0, false},
+		{"no-constraint-mixed-keeps-verified", VerificationOptions{}, nil, []attestation.Envelope{
+			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: true, Identities: []*sapi.Identity{idSigstore}}}},
+			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
+			&fakeEnvelope{},
+		}, false, true, 1, false},
+		{"no-constraint-no-evidence", VerificationOptions{}, nil, []attestation.Envelope{}, false, true, 0, false},
+		// AdmitUnverified only covers evidence passed explicitly...
+		{"admit-unverified-not-explicit", VerificationOptions{AdmitUnverified: true}, nil, []attestation.Envelope{
+			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
+		}, false, false, 0, false},
+		{"admit-unverified-explicit", VerificationOptions{AdmitUnverified: true}, nil, []attestation.Envelope{
+			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
+			&fakeEnvelope{},
+		}, false, true, 2, true},
+		// ... and never applies once signer identities are pinned.
+		{"admit-unverified-explicit-with-policy-ids", VerificationOptions{AdmitUnverified: true}, []*sapi.Identity{idSigstore}, []attestation.Envelope{
+			&fakeEnvelope{ver: &sapi.Verification{Signature: &sapi.SignatureVerification{Verified: false}}},
+		}, false, false, 0, true},
+		{"admit-unverified-explicit-with-opts-ids", VerificationOptions{AdmitUnverified: true, IdentityStrings: []string{idSigstore.Spec()}}, nil, []attestation.Envelope{
+			&fakeEnvelope{},
+		}, false, false, 0, true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			allow, ids, _, err := di.CheckIdentities(
-				t.Context(), &tt.opts, tt.policyIdentities, tt.envelopes,
+			ctx := t.Context()
+			if tt.explicit {
+				ctx = withExplicitEvidence(ctx, tt.envelopes)
+			}
+			allow, admissions, idErrors, err := di.CheckIdentities(
+				ctx, &tt.opts, tt.policyIdentities, tt.envelopes,
 			)
 
 			if tt.mustErr {
@@ -531,8 +566,19 @@ func TestCheckIdentities(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.mustAllow, allow)
-			if tt.expectNilIds {
-				require.Nil(t, ids, "ids must be nil when no identities are defined")
+			require.Len(t, admissions, len(tt.envelopes), "one admission per envelope")
+			admitted := 0
+			for i, a := range admissions {
+				if !a.admitted {
+					continue
+				}
+				admitted++
+				v := tt.envelopes[i].GetVerification()
+				require.Equal(t, v != nil && v.GetVerified(), a.verified, "admission must carry the real verification outcome")
+			}
+			require.Equal(t, tt.admitted, admitted)
+			if !allow {
+				require.NotEmpty(t, idErrors, "a rejected evidence set must explain why")
 			}
 		})
 	}
@@ -578,16 +624,18 @@ func TestCheckIdentitiesMixedSigners(t *testing.T) {
 	require.True(t, allow, "should allow when at least one envelope matches")
 	require.Nil(t, errs)
 
-	// Matching envelope gets identity; others get empty slices.
+	// Matching envelope is admitted with its identity; the others are not.
 	require.Len(t, ids, 3)
-	require.Len(t, ids[0], 1, "envelope 0 should have a matched identity")
-	require.Empty(t, ids[1], "envelope 1 should have no matched identity")
-	require.Empty(t, ids[2], "envelope 2 should have no matched identity")
+	require.True(t, ids[0].admitted, "envelope 0 should be admitted")
+	require.Len(t, ids[0].identities, 1, "envelope 0 should have a matched identity")
+	require.False(t, ids[1].admitted, "envelope 1 (wrong identity) must not be admitted")
+	require.False(t, ids[2].admitted, "envelope 2 (unverified) must not be admitted")
 }
 
-// TestFilterAttestationsNilIds verifies that when no identities are defined
-// (CheckIdentities returns nil ids), all envelopes pass through without panic.
-func TestFilterAttestationsNilIds(t *testing.T) {
+// TestFilterAttestationsAdmissions verifies that FilterAttestations follows the
+// admission list: every admitted envelope produces a predicate, and a list that
+// does not line up with the envelopes is refused rather than guessed at.
+func TestFilterAttestationsAdmissions(t *testing.T) {
 	t.Parallel()
 
 	di := defaultIplementation{}
@@ -597,10 +645,16 @@ func TestFilterAttestationsNilIds(t *testing.T) {
 		&fakeEnvelope{pred: &fakePredicate{}},
 	}
 	preds, err := di.FilterAttestations(
-		&VerificationOptions{}, nil, envs, nil,
+		&VerificationOptions{}, nil, envs, []admission{{admitted: true}, {admitted: true}, {admitted: true}},
 	)
 	require.NoError(t, err)
-	require.Len(t, preds, 3, "all envelopes must pass through when ids is nil")
+	require.Len(t, preds, 3, "all admitted envelopes must pass through")
+
+	_, err = di.FilterAttestations(&VerificationOptions{}, nil, envs, nil)
+	require.Error(t, err, "a missing admission list must not admit anything")
+
+	_, err = di.FilterAttestations(&VerificationOptions{}, nil, envs, []admission{{admitted: true}})
+	require.Error(t, err, "a short admission list must be refused")
 }
 
 func TestFilterAttestationsSkipsNonAdmitted(t *testing.T) {
@@ -637,11 +691,11 @@ func TestFilterAttestationsSkipsNonAdmitted(t *testing.T) {
 				},
 			},
 		},
-		// Only envelope 0 and 2 have matched identities.
-		[][]*sapi.Identity{
-			{idMatch},
+		// Only envelope 0 and 2 were admitted.
+		[]admission{
+			{admitted: true, verified: true, identities: []*sapi.Identity{idMatch}},
 			{},
-			{idMatch},
+			{admitted: true, verified: true, identities: []*sapi.Identity{idMatch}},
 		},
 	)
 	require.NoError(t, err)
@@ -674,7 +728,7 @@ func TestFilterAttestationsCarriesSigners(t *testing.T) {
 	// but signers carries the full actual signer set.
 	t.Run("no-allowlist", func(t *testing.T) {
 		t.Parallel()
-		preds, err := di.FilterAttestations(&VerificationOptions{}, nil, []attestation.Envelope{newEnv()}, nil)
+		preds, err := di.FilterAttestations(&VerificationOptions{}, nil, []attestation.Envelope{newEnv()}, []admission{{admitted: true, verified: true}})
 		require.NoError(t, err)
 		require.Len(t, preds, 1)
 
@@ -696,7 +750,7 @@ func TestFilterAttestationsCarriesSigners(t *testing.T) {
 		t.Parallel()
 		preds, err := di.FilterAttestations(
 			&VerificationOptions{}, nil, []attestation.Envelope{newEnv()},
-			[][]*sapi.Identity{{signerA}},
+			[]admission{{admitted: true, verified: true, identities: []*sapi.Identity{signerA}}},
 		)
 		require.NoError(t, err)
 		require.Len(t, preds, 1)
@@ -712,18 +766,20 @@ func TestFilterAttestationsCarriesSigners(t *testing.T) {
 		require.Len(t, mp.Signers(), 2, "signers must remain the full actual set")
 	})
 
-	// A nil/absent envelope verification is tolerated: signers is empty.
+	// An admitted envelope without verification (explicit unverified evidence)
+	// reaches the policy honestly marked as not verified, with no signers.
 	t.Run("nil-verification", func(t *testing.T) {
 		t.Parallel()
 		preds, err := di.FilterAttestations(
 			&VerificationOptions{}, nil,
-			[]attestation.Envelope{&fakeEnvelope{pred: &fakePredicate{}}}, nil,
+			[]attestation.Envelope{&fakeEnvelope{pred: &fakePredicate{}}}, []admission{{admitted: true}},
 		)
 		require.NoError(t, err)
 		require.Len(t, preds, 1)
 		mp, ok := preds[0].(*matchedPredicate)
 		require.True(t, ok)
 		require.Empty(t, mp.Signers())
+		require.False(t, mp.GetVerification().GetVerified(), "unverified evidence must not be stamped as verified")
 	})
 }
 
@@ -748,13 +804,17 @@ func TestCheckIdentitiesNoAllowlistVerifies(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, idErrors)
 	require.True(t, pass)
-	require.Nil(t, ids, "a nil ids slice must signal that no identity filtering applies")
+	require.Len(t, ids, 1)
+	require.True(t, ids[0].admitted)
+	require.True(t, ids[0].verified)
+	require.Empty(t, ids[0].identities, "no allowlist means no matched identities")
 
 	preds, err := di.FilterAttestations(&VerificationOptions{}, nil, []attestation.Envelope{env}, ids)
 	require.NoError(t, err)
 	require.Len(t, preds, 1)
 	mp, ok := preds[0].(*matchedPredicate)
 	require.True(t, ok)
+	require.True(t, mp.GetVerification().GetVerified(), "verified evidence must be stamped as verified")
 	require.Len(t, mp.Signers(), 1, "signers must carry the identities recorded during verification")
 	require.Same(t, signer, mp.Signers()[0])
 }
@@ -982,7 +1042,7 @@ func TestIdentityMismatchError(t *testing.T) {
 
 	t.Run("no-signer-observed", func(t *testing.T) {
 		t.Parallel()
-		err := identityMismatchError(wanted, nil)
+		err := identityMismatchError(wanted, nil, 0)
 		require.Contains(t, err.Error(), "no attestation carried a verified signer identity")
 		require.Contains(t, err.Error(), "sigstore::https://issuer::expected")
 	})
@@ -990,7 +1050,7 @@ func TestIdentityMismatchError(t *testing.T) {
 	t.Run("mismatch", func(t *testing.T) {
 		t.Parallel()
 		got := []*sapi.Identity{{Sigstore: &sapi.IdentitySigstore{Issuer: "https://issuer", Identity: "actual"}}}
-		err := identityMismatchError(wanted, got)
+		err := identityMismatchError(wanted, got, 0)
 		require.Contains(t, err.Error(), "does not match an accepted identity")
 		require.Contains(t, err.Error(), "wanted one of: sigstore::https://issuer::expected")
 		require.Contains(t, err.Error(), "got: sigstore::https://issuer::actual")

--- a/pkg/verifier/options.go
+++ b/pkg/verifier/options.go
@@ -101,6 +101,17 @@ type VerificationOptions struct {
 	// distinctly from policy violations or signature failures (for example,
 	// to drive a wait+retry loop while attestations land).
 	ErrOnMissingAttestations bool
+
+	// AdmitUnverified admits attestations that were passed explicitly to the
+	// verifier (through Attestations or AttestationFiles) even when they are
+	// unsigned or their signature could not be verified, provided the policy
+	// pins no signer identities. It exists for callers that hand the verifier
+	// evidence on purpose, such as the ampel CLI's --attestation flag, and
+	// never applies to attestations fetched by collectors. Admitted
+	// unverified attestations reach policies with verification.verified set
+	// to false. When the policy (or IdentityStrings) pins signer identities,
+	// unverified attestations are always skipped.
+	AdmitUnverified bool
 }
 
 // Validate checks the options set

--- a/pkg/verifier/shared_envelope_test.go
+++ b/pkg/verifier/shared_envelope_test.go
@@ -124,7 +124,7 @@ func TestFilterAttestationsDoesNotMutateSharedEnvelope(t *testing.T) {
 
 	env := newSharedFakeEnvelope(concreteSigner())
 	envs := []attestation.Envelope{env}
-	ids := [][]*sapi.Identity{{policyIdentity()}}
+	ids := []admission{{admitted: true, verified: true, identities: []*sapi.Identity{policyIdentity()}}}
 
 	// Establish the signer-identity verification as Verify() would.
 	require.NoError(t, env.Verify())

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -60,6 +60,31 @@ func sharedEvidenceLock(ctx context.Context) *sync.Mutex {
 	return mu
 }
 
+// explicitEvidenceKey is the context key under which the verifier publishes
+// the set of envelopes the caller passed explicitly (opts.Attestations and
+// opts.AttestationFiles), as opposed to evidence fetched by the collector. Only
+// these are eligible for the AdmitUnverified opt-in in CheckIdentities.
+type explicitEvidenceKey struct{}
+
+// withExplicitEvidence records the explicitly supplied envelopes on the context.
+func withExplicitEvidence(ctx context.Context, envs []attestation.Envelope) context.Context {
+	set := make(map[attestation.Envelope]struct{}, len(envs))
+	for _, e := range envs {
+		set[e] = struct{}{}
+	}
+	return context.WithValue(ctx, explicitEvidenceKey{}, set)
+}
+
+// isExplicitEvidence reports whether env was passed explicitly to the verifier.
+func isExplicitEvidence(ctx context.Context, env attestation.Envelope) bool {
+	set, ok := ctx.Value(explicitEvidenceKey{}).(map[attestation.Envelope]struct{})
+	if !ok {
+		return false
+	}
+	_, ok = set[env]
+	return ok
+}
+
 // Verify checks a subject against a policy using the available evidence. The
 // policy argument may be a single policy, a policy group or a policy set; the
 // results are published once per call, regardless of the material kind.
@@ -192,6 +217,7 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 	if err != nil {
 		return nil, fmt.Errorf("parsing single attestations: %w", err)
 	}
+	ctx = withExplicitEvidence(ctx, atts)
 
 	// Mutate the options set to avoid reparsing the paths
 	opts.AttestationFiles = []string{}
@@ -375,6 +401,7 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 	if err != nil {
 		return nil, fmt.Errorf("parsing single attestations: %w", err)
 	}
+	ctx = withExplicitEvidence(ctx, atts)
 
 	// Publish the subject on the evalcontext so context-value expressions and
 	// the evaluator runtimes can reach it via ctx.
@@ -440,10 +467,15 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 	}
 
 	if !allow {
-		return failPolicyWithError(policy, chain, subject, PolicyError{
-			error:    errors.New("attestation identity validation failed"),
-			Guidance: errors.Join(idErrors...).Error(),
-		}), nil
+		reason := errors.Join(idErrors...)
+		perr := PolicyError{error: errors.New("attestation identity validation failed")}
+		if errors.Is(reason, ErrUnverifiedAttestations) {
+			perr.error = ErrUnverifiedAttestations
+		}
+		if reason != nil {
+			perr.Guidance = reason.Error()
+		}
+		return failPolicyWithError(policy, chain, subject, perr), nil
 	}
 
 	// Filter attestations to those applicable to the subject
@@ -538,6 +570,7 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 	if err != nil {
 		return nil, fmt.Errorf("parsing single attestations: %w", err)
 	}
+	ctx = withExplicitEvidence(ctx, atts)
 
 	// Load the policyset eval ctx definition into the go contect
 	ctx, evalContext := ampel.loadElementEvalContextDef(ctx, group)


### PR DESCRIPTION
This PR adds a unified model to handle signing, verification and identity regardless of the method used to sign attestations.

The combination matrix when handling signature presence, signature verification, expected identities, key presence across 3 methods of signing was becoming complex and required a unified way to express and check when ingesting envelopes.

This PR adds that abstraction to the verifier library and wires it all the way to the CLI. The library now allows callers to evaluate an error to know if an envelope is not verified.