### PR TITLE
Fix two bugs in subject writting

### DIFF
--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -180,6 +180,7 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results, o attes
 	switch r := results.(type) {
 	case *papi.Result:
 		rs := &papi.ResultSet{
+			Subject:   r.Subject,
 			Results:   []*papi.Result{r},
 			DateStart: r.DateStart,
 			DateEnd:   r.DateEnd,
@@ -192,6 +193,7 @@ func (a *ResultsAttester) attestAmpel(w io.Writer, results papi.Results, o attes
 		return a.writeResultSet(w, r, o)
 	case *papi.ResultGroup:
 		rs := &papi.ResultSet{
+			Subject:   r.Subject,
 			Groups:    []*papi.ResultGroup{r},
 			DateStart: r.DateStart,
 			DateEnd:   r.DateEnd,
@@ -229,43 +231,21 @@ func writeStatementJSON(w io.Writer, stmt *intoto.Statement, pretty bool) error 
 }
 
 // writeResultSet builds an in-toto statement carrying a
-// predicates.ResultSet and writes it via a.writeStatement. Subjects
-// are drawn from each Result's first Chain entry when present, with
-// per-digest deduplication so a ResultSet covering many results
-// against the same subject doesn't repeat it.
+// predicates.ResultSet and writes it via a.writeStatement. The statement
+// is about the subject the set was evaluated against, not about the
+// subjects recorded in its results: chained evaluations look at other
+// artifacts along the way, but the verdict is still about the original
+// subject.
 func (a *ResultsAttester) writeResultSet(w io.Writer, resultset *papi.ResultSet, o attestOptions) error {
 	if resultset == nil {
 		return errors.New("unable to attest results, set is nil")
 	}
-
-	stmt := intoto.NewStatement()
-
-	// TODO(puerco): This should probably be a method of the results set
-	seen := []string{}
-	for _, result := range resultset.Results {
-		subject := result.Subject
-		if len(result.Chain) > 0 {
-			subject = result.Chain[0].Source
-		}
-
-		// If we already saw it, skip.
-		if slices.Contains(seen, stringifyDigests(subject)) {
-			continue
-		}
-		seen = append(seen, stringifyDigests(subject))
-
-		haveMatching := false
-		for _, s := range stmt.Subject {
-			if attestation.SubjectsMatch(s, subject) {
-				haveMatching = true
-				break
-			}
-		}
-		if !haveMatching {
-			stmt.AddSubject(subject)
-		}
+	if len(resultset.GetSubject().GetDigest()) == 0 {
+		return errors.New("unable to attest results, the set has no subject with digests")
 	}
 
+	stmt := intoto.NewStatement()
+	stmt.AddSubject(resultset.GetSubject())
 	stmt.PredicateType = predicates.PredicateTypeResultSet
 	stmt.Predicate = &predicates.ResultSet{Parsed: resultset}
 

--- a/pkg/attest/attest_test.go
+++ b/pkg/attest/attest_test.go
@@ -145,9 +145,13 @@ func TestAttestTo_PrettyPrint(t *testing.T) {
 	}
 }
 
-func TestAttestAmpel_SubjectDedup(t *testing.T) {
-	// Two results sharing the same digest should yield one subject.
-	rs := newResultSet(t, "deadbeef", "deadbeef")
+// attestSubjects runs the ampel attester on rs and returns the subjects
+// of the resulting statement.
+func attestSubjects(t *testing.T, rs *papi.ResultSet) []struct {
+	Name   string            `json:"name,omitempty"`
+	Digest map[string]string `json:"digest,omitempty"`
+} {
+	t.Helper()
 	var buf bytes.Buffer
 	if err := New().AttestTo(&buf, rs); err != nil {
 		t.Fatalf("AttestTo: %v", err)
@@ -156,8 +160,72 @@ func TestAttestAmpel_SubjectDedup(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
 		t.Fatalf("unmarshaling output: %v", err)
 	}
-	if got := len(stmt.Subject); got != 1 {
-		t.Errorf("subject count = %d, want 1 (dedup); subjects: %+v", got, stmt.Subject)
+	return stmt.Subject
+}
+
+func TestAttestAmpel_SetSubject(t *testing.T) {
+	// The statement is about the evaluated subject, once, no matter how
+	// many results the set holds.
+	rs := newResultSet(t, "deadbeef", "deadbeef")
+	subjects := attestSubjects(t, rs)
+	if len(subjects) != 1 || subjects[0].Digest["sha256"] != "deadbeef" {
+		t.Errorf("subjects = %+v, want one with digest deadbeef", subjects)
+	}
+
+	// Results and groups about other artifacts, chained or not, do not
+	// add subjects.
+	rs.Results = append(rs.Results, &papi.Result{Subject: newSubject("cafecafe")})
+	rs.Groups = []*papi.ResultGroup{
+		{Subject: newSubject("deadbeef"), Chain: []*papi.ChainedSubject{{Source: newSubject("cafecafe")}}},
+	}
+	subjects = attestSubjects(t, rs)
+	if len(subjects) != 1 || subjects[0].Digest["sha256"] != "deadbeef" {
+		t.Errorf("subjects = %+v, want only deadbeef", subjects)
+	}
+
+	// A set made only of groups, as group-based policy sets produce,
+	// still carries the evaluated subject.
+	rs.Results = nil
+	subjects = attestSubjects(t, rs)
+	if len(subjects) != 1 || subjects[0].Digest["sha256"] != "deadbeef" {
+		t.Errorf("subjects = %+v, want only deadbeef", subjects)
+	}
+}
+
+func TestAttestAmpel_NoSubject(t *testing.T) {
+	// A set without an evaluated subject cannot be attested
+	rs := newResultSet(t)
+	rs.Results = []*papi.Result{{Subject: newSubject("deadbeef")}}
+	if err := New().AttestTo(&bytes.Buffer{}, rs); err == nil {
+		t.Error("expected an error attesting a set without subject")
+	}
+
+	rs.Subject = &gointoto.ResourceDescriptor{Name: "no-digest"}
+	if err := New().AttestTo(&bytes.Buffer{}, rs); err == nil {
+		t.Error("expected an error attesting a subject without digests")
+	}
+}
+
+func TestAttestAmpel_WrappedInputs(t *testing.T) {
+	// Single results and groups are wrapped into a set that takes their
+	// subject.
+	for name, results := range map[string]papi.Results{
+		"result": &papi.Result{Subject: newSubject("deadbeef"), Status: papi.StatusPASS},
+		"group":  &papi.ResultGroup{Subject: newSubject("deadbeef"), Status: papi.StatusPASS},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := New().AttestTo(&buf, results); err != nil {
+				t.Fatalf("AttestTo: %v", err)
+			}
+			var stmt statementShape
+			if err := json.Unmarshal(buf.Bytes(), &stmt); err != nil {
+				t.Fatalf("unmarshaling output: %v", err)
+			}
+			if len(stmt.Subject) != 1 || stmt.Subject[0].Digest["sha256"] != "deadbeef" {
+				t.Errorf("subjects = %+v, want one with digest deadbeef", stmt.Subject)
+			}
+		})
 	}
 }
 

--- a/pkg/verifier/subject_test.go
+++ b/pkg/verifier/subject_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/carabiner-dev/attestation"
+	"github.com/carabiner-dev/collector"
+	papi "github.com/carabiner-dev/policy/api/v1"
+	gointoto "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/carabiner-dev/ampel/pkg/evaluator"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/class"
+	"github.com/carabiner-dev/ampel/pkg/evaluator/options"
+)
+
+// chainRewritingImpl wraps the default implementation and makes every
+// chain resolve to another subject, as a policy chaining to a different
+// artifact would.
+type chainRewritingImpl struct {
+	AmpelVerifier
+	effective *gointoto.ResourceDescriptor
+}
+
+func (c *chainRewritingImpl) chain(original attestation.Subject) []*papi.ChainedSubject {
+	return []*papi.ChainedSubject{{
+		Source: &gointoto.ResourceDescriptor{
+			Name: original.GetName(), Uri: original.GetUri(), Digest: original.GetDigest(),
+		},
+		Destination: c.effective,
+	}}
+}
+
+func (c *chainRewritingImpl) ProcessChainedSubjects(
+	_ context.Context, _ *VerificationOptions, _ map[class.Class]evaluator.Evaluator, _ *collector.Agent,
+	_ papi.ChainProvider, _ map[string]any, subject attestation.Subject, _ []attestation.Envelope,
+) (attestation.Subject, []*papi.ChainedSubject, bool, error) {
+	return c.effective, c.chain(subject), false, nil
+}
+
+func (c *chainRewritingImpl) ProcessPolicySetChainedSubjects(
+	_ context.Context, _ *VerificationOptions, _ map[class.Class]evaluator.Evaluator, _ *collector.Agent,
+	_ *papi.PolicySet, _ map[string]any, subject attestation.Subject, _ []attestation.Envelope,
+) ([]attestation.Subject, []*papi.ChainedSubject, bool, error) {
+	return []attestation.Subject{c.effective}, c.chain(subject), false, nil
+}
+
+// TestResultsRecordOriginalSubject guards against results recording the
+// effective subject a chain resolved to instead of the subject under
+// evaluation. The attestations of the results are about the original
+// subject, so all three result types must carry it.
+func TestResultsRecordOriginalSubject(t *testing.T) {
+	t.Parallel()
+
+	original := &gointoto.ResourceDescriptor{
+		Name:   "original",
+		Digest: map[string]string{"sha256": "0000000000000000000000000000000000000000000000000000000000000001"},
+	}
+	effective := &gointoto.ResourceDescriptor{
+		Name:   "effective",
+		Digest: map[string]string{"sha256": "0000000000000000000000000000000000000000000000000000000000000002"},
+	}
+
+	policy := &papi.Policy{
+		Id:     "pass",
+		Meta:   &papi.Meta{},
+		Tenets: []*papi.Tenet{{Id: "t1", Code: "true"}},
+	}
+	group := &papi.PolicyGroup{
+		Id:   "group",
+		Meta: &papi.PolicyGroupMeta{},
+		Blocks: []*papi.PolicyBlock{
+			{Id: "block-1", Meta: &papi.PolicyBlockMeta{}, Policies: []*papi.Policy{policy}},
+		},
+	}
+	set := &papi.PolicySet{
+		Id:       "set",
+		Meta:     &papi.PolicySetMeta{},
+		Policies: []*papi.Policy{policy},
+		Groups:   []*papi.PolicyGroup{group},
+	}
+
+	newAmpel := func(t *testing.T) (*Ampel, *VerificationOptions) {
+		t.Helper()
+		ampel, err := New()
+		require.NoError(t, err)
+		ampel.impl = &chainRewritingImpl{AmpelVerifier: ampel.impl, effective: effective}
+		return ampel, &VerificationOptions{
+			EvaluatorOptions:    options.Default,
+			DefaultEvaluator:    DefaultVerificationOptions.DefaultEvaluator,
+			AllowEmptySetChains: true,
+		}
+	}
+
+	requireOriginal := func(t *testing.T, what string, subject *gointoto.ResourceDescriptor) {
+		t.Helper()
+		require.Equal(t, original.GetDigest(), subject.GetDigest(), "%s records the effective subject instead of the original", what)
+	}
+
+	t.Run("policy", func(t *testing.T) {
+		t.Parallel()
+		ampel, opts := newAmpel(t)
+		res, err := ampel.VerifySubjectWithPolicy(context.Background(), opts, policy, original)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.GetChain(), "the chain must have run for the test to be meaningful")
+		requireOriginal(t, "result", res.GetSubject())
+	})
+
+	t.Run("group", func(t *testing.T) {
+		t.Parallel()
+		ampel, opts := newAmpel(t)
+		res, err := ampel.VerifySubjectWithPolicyGroup(context.Background(), opts, group, original)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.GetChain(), "the chain must have run for the test to be meaningful")
+		requireOriginal(t, "result group", res.GetSubject())
+	})
+
+	t.Run("set", func(t *testing.T) {
+		t.Parallel()
+		ampel, opts := newAmpel(t)
+		res, err := ampel.VerifySubjectWithPolicySet(context.Background(), opts, set, original)
+		require.NoError(t, err)
+		require.NotEmpty(t, res.GetResults())
+		require.NotEmpty(t, res.GetGroups())
+		requireOriginal(t, "result set", res.GetSubject())
+	})
+}

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -111,7 +111,7 @@ func (ampel *Ampel) verify(
 	switch v := policy.(type) {
 	case *papi.Policy:
 		if len(opts.Policies) > 0 && !slices.Contains(opts.Policies, v.Id) {
-			return &papi.ResultSet{}, nil
+			return &papi.ResultSet{Subject: subjectDescriptor(subject)}, nil
 		}
 		res, err := ampel.VerifySubjectWithPolicy(ctx, opts, v, subject)
 		if err != nil {
@@ -131,7 +131,7 @@ func (ampel *Ampel) verify(
 		}
 		return rs, nil
 	case []*papi.PolicySet:
-		rs := &papi.ResultSet{}
+		rs := &papi.ResultSet{Subject: subjectDescriptor(subject)}
 		for j, ps := range v {
 			for i, p := range ps.Policies {
 				if len(opts.Policies) > 0 && !slices.Contains(opts.Policies, p.Id) {
@@ -147,6 +147,16 @@ func (ampel *Ampel) verify(
 		return rs, nil
 	default:
 		return nil, fmt.Errorf("did not get a policy or policy set")
+	}
+}
+
+// subjectDescriptor returns the resource descriptor recording subject as
+// the subject under evaluation in a result set.
+func subjectDescriptor(subject attestation.Subject) *gointoto.ResourceDescriptor {
+	return &gointoto.ResourceDescriptor{
+		Name:   subject.GetName(),
+		Uri:    subject.GetUri(),
+		Digest: subject.GetDigest(),
 	}
 }
 
@@ -176,11 +186,7 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 		},
 		Meta:      policySet.GetMeta(),
 		DateStart: timestamppb.Now(),
-		Subject: &gointoto.ResourceDescriptor{
-			Name:   subject.GetName(),
-			Uri:    subject.GetUri(),
-			Digest: subject.GetDigest(),
-		},
+		Subject:   subjectDescriptor(subject),
 	}
 
 	// Check if the policy is viable before

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -383,14 +383,18 @@ func (ampel *Ampel) VerifySubjectWithPolicySet(
 
 // VerifySubjectWithPolicy verifies a subject against a single policy
 func (ampel *Ampel) VerifySubjectWithPolicy(
-	ctx context.Context, opts *VerificationOptions, policy *papi.Policy, subject attestation.Subject,
+	ctx context.Context, opts *VerificationOptions, policy *papi.Policy, originalSubject attestation.Subject,
 ) (*papi.Result, error) {
+	// The subject may be replaced by the chain and the transformers below
+	// but the result always records the original subject under evaluation.
+	subject := originalSubject
+
 	// Check if the policy is viable before
 	if err := ampel.impl.CheckPolicy(ctx, opts, policy); err != nil {
 		// If the policy failed validation, don't err. Fail the policy
 		perr := PolicyError{}
 		if errors.As(err, &perr) {
-			return failPolicyWithError(policy, nil, subject, perr), nil
+			return failPolicyWithError(policy, nil, originalSubject, perr), nil
 		}
 		// ..else something broke
 		return nil, fmt.Errorf("checking policy: %w", err)
@@ -434,7 +438,7 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 		// If policyFail is true, then we don't return an error but rather
 		// a policy fail result based on the error
 		if policyFail {
-			return failPolicyWithError(policy, chain, subject, err), nil
+			return failPolicyWithError(policy, chain, originalSubject, err), nil
 		}
 		return nil, fmt.Errorf("processing chained subject: %w", err)
 	}
@@ -481,7 +485,7 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 		if reason != nil {
 			perr.Guidance = reason.Error()
 		}
-		return failPolicyWithError(policy, chain, subject, perr), nil
+		return failPolicyWithError(policy, chain, originalSubject, perr), nil
 	}
 
 	// Filter attestations to those applicable to the subject
@@ -508,6 +512,7 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 	}
 
 	result.Chain = chain
+	result.Subject = subjectDescriptor(originalSubject)
 
 	// Assert the status from the evaluation results
 	if err := ampel.impl.AssertResult(policy, result); err != nil {
@@ -520,8 +525,12 @@ func (ampel *Ampel) VerifySubjectWithPolicy(
 
 // VerifySubjectWithPolicyGroup evaluates a policy group and its blocks
 func (ampel *Ampel) VerifySubjectWithPolicyGroup(
-	ctx context.Context, oOpts *VerificationOptions, group *papi.PolicyGroup, subject attestation.Subject,
+	ctx context.Context, oOpts *VerificationOptions, group *papi.PolicyGroup, originalSubject attestation.Subject,
 ) (*papi.ResultGroup, error) {
+	// The subject may be replaced by the chain below but the result always
+	// records the original subject under evaluation.
+	subject := originalSubject
+
 	// DeepCopy the options as we will mutate them after parsing the initial
 	// attestations set.
 	opts := *oOpts
@@ -536,6 +545,7 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 
 	// Resuktset to return
 	res := &papi.ResultGroup{
+		Subject:   subjectDescriptor(originalSubject),
 		Status:    papi.StatusPASS,
 		DateStart: timestamppb.Now(),
 		DateEnd:   timestamppb.Now(),
@@ -559,7 +569,7 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 		// If the policygroup failed validation, don't err. Fail the evaluation
 		perr := PolicyError{}
 		if errors.As(err, &perr) {
-			return failPolicyGroupWithError(group, nil, subject, err), nil
+			return failPolicyGroupWithError(group, nil, originalSubject, err), nil
 		}
 		// else something broke
 		return nil, fmt.Errorf("checking policy: %w", err)
@@ -604,17 +614,12 @@ func (ampel *Ampel) VerifySubjectWithPolicyGroup(
 		// If policyFail is true, then we don't return an error but rather
 		// a policy fail result based on the error
 		if policyFail {
-			return failPolicyGroupWithError(group, chain, subject, err), nil
+			return failPolicyGroupWithError(group, chain, originalSubject, err), nil
 		}
 		return nil, fmt.Errorf("processing chained subject: %w", err)
 	}
 
-	res.Subject = &gointoto.ResourceDescriptor{
-		Name:   subject.GetName(),
-		Uri:    subject.GetUri(),
-		Digest: subject.GetDigest(),
-	}
-
+	res.Chain = chain
 	evalContext.ChainedSubjects = chain
 
 	// Rebuild the go context as we are now shipping the chained subjects.


### PR DESCRIPTION
This PR fixes a critical bug where results attestations from policy groups were missing their subject. It also fixes another bug where chained subjects would cause the effective subject to be attested 